### PR TITLE
evm: switch node precompiles to a full-Context provider

### DIFF
--- a/crates/arb-reth-derive/Cargo.toml
+++ b/crates/arb-reth-derive/Cargo.toml
@@ -17,7 +17,7 @@ alloy-primitives = "1"
 alloy-rlp = { workspace = true }
 # brotli is re-exported from arb_revm (which vendors it) so both crates share one brotli
 # source and avoid a lockfile collision. BUSL-licensed; see the arb_revm NOTICE.
-arb-revm = { git = "https://github.com/nuntax/arbitrum-revm", rev = "ce0be45c0b94e395b5de83ae0c210f576d8f03a1" }
+arb-revm = { git = "https://github.com/nuntax/arbitrum-revm", rev = "fc912e5146338d54e912ebb404095e49b3582d99" }
 
 [dev-dependencies]
 serde_json = { workspace = true }

--- a/crates/arb-reth-engine/Cargo.toml
+++ b/crates/arb-reth-engine/Cargo.toml
@@ -14,7 +14,7 @@ authors.workspace = true
 [dependencies]
 arbitrum-alloy-consensus = { git = "https://github.com/nuntax/arbitrum-alloy", rev = "f1e74b02952b0716801d4c20ad2e893c7b3992af", default-features = false, features = ["reth"] }
 arb-reth-evm = { path = "../arb-reth-evm" }
-arb-revm = { git = "https://github.com/nuntax/arbitrum-revm", rev = "ce0be45c0b94e395b5de83ae0c210f576d8f03a1" }
+arb-revm = { git = "https://github.com/nuntax/arbitrum-revm", rev = "fc912e5146338d54e912ebb404095e49b3582d99" }
 arbitrum-alloy-sequencer = { git = "https://github.com/nuntax/arbitrum-alloy", rev = "f1e74b02952b0716801d4c20ad2e893c7b3992af", default-features = false, features = ["std"] }
 
 alloy-consensus = { version = "2.0", default-features = false }

--- a/crates/arb-reth-evm/Cargo.toml
+++ b/crates/arb-reth-evm/Cargo.toml
@@ -9,7 +9,7 @@ authors.workspace = true
 # extension points. See docs/arb-reth-roadmap.md.
 
 [dependencies]
-arb-revm = { git = "https://github.com/nuntax/arbitrum-revm", rev = "ce0be45c0b94e395b5de83ae0c210f576d8f03a1", features = ["stylus"] } # pure revm/ArbOS; stylus feature is self-contained (vendors Nitro's wasmer)
+arb-revm = { git = "https://github.com/nuntax/arbitrum-revm", rev = "fc912e5146338d54e912ebb404095e49b3582d99", features = ["stylus"] } # pure revm/ArbOS; stylus feature is self-contained (vendors Nitro's wasmer)
 revm = { workspace = true }
 
 # Arbitrum consensus primitives (ArbTxEnvelope, ArbReceiptEnvelope, ArbHeaderInfo). reth-trait

--- a/crates/arb-reth-evm/src/config.rs
+++ b/crates/arb-reth-evm/src/config.rs
@@ -21,8 +21,8 @@
 //!
 //! reth's [`ConfigureEvm`](reth_evm::ConfigureEvm) requires `EvmFactory<Precompiles = PrecompilesMap,
 //! Tx: TransactionEnvMut>`. Both hold: `ArbTx` impls `TransactionEnvMut` (see `tx.rs`), and
-//! `ArbEvmFactory::Precompiles` is `PrecompilesMap` (ArbOS precompiles re-homed onto alloy-evm's
-//! `DynPrecompile`/`EvmInternals` model via `crate::precompiles::arb_precompiles_map`). The
+//! `ArbEvmFactory::Precompiles` is `PrecompilesMap` (exposed by [`crate::precompiles::ArbPrecompilesMap`],
+//! the actual revm provider, which dispatches ArbOS addresses with the full `ArbContext`). The
 //! [`ConfigureEvm`] impl is at the bottom of this file; per-header logic lives in the inherent
 //! methods below, which the trait methods delegate to.
 

--- a/crates/arb-reth-evm/src/lib.rs
+++ b/crates/arb-reth-evm/src/lib.rs
@@ -25,7 +25,7 @@ pub mod tx;
 pub use tx::ArbTx;
 
 pub mod precompiles;
-pub use precompiles::arb_precompiles_map;
+pub use precompiles::ArbPrecompilesMap;
 
 pub mod block;
 pub use block::{
@@ -60,7 +60,7 @@ use arb_revm::ArbSpecId;
 /// The `arb_revm` EVM type this owns: the ArbOS EVM over [`ArbContext<DB>`] with the Arbitrum
 /// precompile set.
 type ArbRethEvm<DB, I> =
-    arb_revm::ArbEvm<ArbContext<DB>, I, EthInstructions<EthInterpreter, ArbContext<DB>>, PrecompilesMap>;
+    arb_revm::ArbEvm<ArbContext<DB>, I, EthInstructions<EthInterpreter, ArbContext<DB>>, ArbPrecompilesMap>;
 
 /// EVM error surfaced by the Arbitrum bridge. Matches `arb_revm`'s `ArbError`:
 /// `EVMError<DBError, InvalidTransaction>`.
@@ -162,7 +162,7 @@ where
         (
             &self.inner.0.ctx.journaled_state.database,
             &self.inner.0.inspector,
-            &self.inner.0.precompiles,
+            self.inner.0.precompiles.precompiles(),
         )
     }
 
@@ -170,7 +170,7 @@ where
         (
             &mut self.inner.0.ctx.journaled_state.database,
             &mut self.inner.0.inspector,
-            &mut self.inner.0.precompiles,
+            self.inner.0.precompiles.precompiles_mut(),
         )
     }
 }
@@ -215,12 +215,13 @@ impl EvmFactory for ArbEvmFactory {
         evm_env: EvmEnv<ArbSpecId, BlockEnv>,
     ) -> Self::Evm<DB, NoOpInspector> {
         // `create_evm` must return `Evm<DB, NoOpInspector>`, so pass an explicit `NoOpInspector`
-        // rather than the `()` default of `build_arb`. Swap in the `PrecompilesMap` required by
-        // `ConfigureEvm` (ArbOS precompiles re-homed onto `DynPrecompile`s).
+        // rather than the `()` default of `build_arb`. Swap in the ArbOS precompile provider
+        // (dispatches ArbOS addresses with the full `ArbContext`; exposes a `PrecompilesMap` to
+        // satisfy `ConfigureEvm`).
         let spec = evm_env.cfg_env.spec;
         let inner = Self::build_ctx(db, evm_env)
             .build_arb_with_inspector(NoOpInspector {})
-            .with_precompiles(arb_precompiles_map(spec));
+            .with_precompiles(ArbPrecompilesMap::new(spec));
         ArbEvm::new(inner, false)
     }
 
@@ -233,7 +234,7 @@ impl EvmFactory for ArbEvmFactory {
         let spec = evm_env.cfg_env.spec;
         let inner = Self::build_ctx(db, evm_env)
             .build_arb_with_inspector(inspector)
-            .with_precompiles(arb_precompiles_map(spec));
+            .with_precompiles(ArbPrecompilesMap::new(spec));
         ArbEvm::new(inner, true)
     }
 }

--- a/crates/arb-reth-evm/src/precompiles.rs
+++ b/crates/arb-reth-evm/src/precompiles.rs
@@ -1,99 +1,114 @@
-//! Node-path ArbOS precompiles as an alloy-evm [`PrecompilesMap`].
+//! [`ArbPrecompilesMap`]: the node-path ArbOS precompile provider.
 //!
-//! reth v2.0.0's `ConfigureEvm` requires `EvmFactory<…, Precompiles = PrecompilesMap, …>`.
-//! `PrecompilesMap` dispatches each precompile through a [`DynPrecompile`] closure that receives a
-//! [`PrecompileInput`] (carrying an `EvmInternals` state handle), NOT a revm `Context`. We bridge
-//! to `arb_revm`'s precompiles (unchanged, parity-validated) via `ArbPrecompilesEnum::run_dispatch`
-//! over an [`ArbNodeCtx`] (see `arb_revm::arb_journal`). One `DynPrecompile` per ArbOS precompile
-//! address is layered over the spec's eth precompile set.
+//! reth v2.0.0's `ConfigureEvm` hard-requires `EvmFactory<…, Precompiles = PrecompilesMap, …>` so
+//! it can install its precompile cache (`precompiles_mut().map_cacheable_precompiles(…)`). We keep
+//! a [`PrecompilesMap`] to satisfy that bound, but the *actual* revm precompile provider is this
+//! wrapper: it dispatches ArbOS precompile addresses through `arb_revm`'s static
+//! [`ArbPrecompilesEnum::run_dispatch`] with the full `revm::Context` (so precompiles see the real
+//! call depth, tx type, and `ArbChainContext`, matching the in-EVM path exactly), and delegates
+//! every other address to the inner [`PrecompilesMap`] (so reth's eth-precompile cache still
+//! applies). This replaces the earlier `DynPrecompile`/`EvmInternals` bridge, whose context-blind
+//! `PrecompileInput` forced a hardcoded call depth and could not expose `ArbChainContext`.
 
-use alloy_evm::precompiles::{DynPrecompile, PrecompileInput, PrecompilesMap};
+use alloy_evm::Database;
+use alloy_evm::env::BlockEnvironment;
+use alloy_evm::precompiles::PrecompilesMap;
 use arb_revm::ArbSpecId;
-use arb_revm::arb_journal::{ArbCall, ArbNodeCtx};
+use arb_revm::arb_journal::ArbCall;
 use arb_revm::precompiles::{ArbPrecompilesEnum, arb_eth_precompiles};
-use revm::interpreter::{InstructionResult, InterpreterResult};
-use revm::precompile::{PrecompileHalt, PrecompileId, PrecompileOutput, PrecompileResult};
+use revm::context::{Cfg, Context, Journal, Transaction};
+use revm::handler::PrecompileProvider;
+use revm::interpreter::{CallInputs, InterpreterResult};
+use revm::primitives::{Address, AddressSet};
 
-/// Builds the Arbitrum [`PrecompilesMap`] for an ArbOS version: the spec's eth precompile set
-/// (Cancun+P256 below ArbOS 50, Osaka at/after; same selection as the in-EVM path) with the 16
-/// ArbOS precompile addresses layered on top as stateful [`DynPrecompile`]s.
-pub fn arb_precompiles_map(spec: ArbSpecId) -> PrecompilesMap {
-    let mut map = PrecompilesMap::from_static(arb_eth_precompiles(spec));
-    for address in ArbPrecompilesEnum::all_addresses() {
-        let arb = ArbPrecompilesEnum::from_address(&address)
-            .expect("all_addresses yields only known ArbOS precompile addresses");
-        let precompile = DynPrecompile::new_stateful(
-            PrecompileId::Custom(arb_precompile_name(arb).into()),
-            move |input: PrecompileInput<'_>| arb_node_call(arb, input),
-        );
-        // Overwrite/insert at the ArbOS address (converts the map to its dynamic representation).
-        map.apply_precompile(&address, move |_| Some(precompile));
+/// Arbitrum precompile provider for the reth node EVM. See the module docs.
+#[derive(Debug)]
+pub struct ArbPrecompilesMap {
+    /// The spec's eth precompile set. Dispatched for non-ArbOS addresses (so reth's precompile
+    /// cache, installed via `precompiles_mut()`, applies), and handed to reth to satisfy
+    /// `ConfigureEvm`'s `Precompiles = PrecompilesMap` bound.
+    inner: PrecompilesMap,
+    /// Combined warm-address set: eth precompile addresses ∪ ArbOS precompile addresses.
+    warm: AddressSet,
+}
+
+impl ArbPrecompilesMap {
+    /// Builds the provider for an ArbOS version: eth precompile set (Cancun+P256 below ArbOS 50,
+    /// Osaka at/after, the same selection as the in-EVM path) plus the ArbOS addresses in the warm
+    /// set. ArbOS precompiles are dispatched by [`ArbPrecompilesEnum`], not stored in `inner`.
+    pub fn new(spec: ArbSpecId) -> Self {
+        let eth = arb_eth_precompiles(spec);
+        let inner = PrecompilesMap::from_static(eth);
+        let mut warm = AddressSet::default();
+        warm.clone_from(eth.addresses_set());
+        for address in ArbPrecompilesEnum::all_addresses() {
+            warm.insert(address);
+        }
+        Self { inner, warm }
     }
-    map
-}
 
-/// Runs one ArbOS precompile on the node path: rebuild the path-agnostic [`ArbCall`] from the
-/// [`PrecompileInput`], wrap the `EvmInternals` handle in an [`ArbNodeCtx`], and dispatch through
-/// the shared `run_dispatch` (version/method gating + per-call gas live there).
-fn arb_node_call(arb: ArbPrecompilesEnum, input: PrecompileInput<'_>) -> PrecompileResult {
-    let PrecompileInput {
-        data,
-        gas,
-        caller,
-        value,
-        is_static,
-        bytecode_address,
-        target_address,
-        mut internals,
-        reservoir,
-        ..
-    } = input;
-    let call = ArbCall {
-        input: data,
-        gas_limit: gas,
-        caller,
-        value,
-        bytecode_address,
-        acting_address: target_address,
-        is_static,
-    };
-    // `PrecompileInput` carries no EVM call depth; default to top-level. Only `ArbSys.isTopLevelCall`
-    // observes this (a rare path), so this is best-effort on the node path.
-    let mut ctx = ArbNodeCtx::new(&mut internals, 1);
-    to_precompile_result(arb.run_dispatch(&mut ctx, &call), reservoir)
-}
+    /// The inner eth [`PrecompilesMap`] handed to reth (its `Precompiles` associated type).
+    pub const fn precompiles(&self) -> &PrecompilesMap {
+        &self.inner
+    }
 
-/// Convert `arb_revm`'s `InterpreterResult` (the precompile call result) into alloy-evm's
-/// [`PrecompileResult`]. Gas spent maps to `gas_used`; a revert preserves its output bytes; any
-/// halt (out-of-gas etc.) maps to a halted [`PrecompileOutput`] (revm treats it as consuming all
-/// gas, matching the in-EVM CALL semantics).
-fn to_precompile_result(result: InterpreterResult, reservoir: u64) -> PrecompileResult {
-    let gas_used = result.gas.total_gas_spent();
-    match result.result {
-        InstructionResult::Return => Ok(PrecompileOutput::new(gas_used, result.output, reservoir)),
-        InstructionResult::Revert => Ok(PrecompileOutput::revert(gas_used, result.output, reservoir)),
-        _ => Ok(PrecompileOutput::halt(PrecompileHalt::OutOfGas, reservoir)),
+    /// Mutable inner [`PrecompilesMap`], used by reth to install its precompile cache.
+    pub const fn precompiles_mut(&mut self) -> &mut PrecompilesMap {
+        &mut self.inner
     }
 }
 
-/// Stable display name for a precompile's [`PrecompileId`].
-const fn arb_precompile_name(arb: ArbPrecompilesEnum) -> &'static str {
-    match arb {
-        ArbPrecompilesEnum::ArbSys => "ArbSys",
-        ArbPrecompilesEnum::ArbInfo => "ArbInfo",
-        ArbPrecompilesEnum::ArbAddressTable => "ArbAddressTable",
-        ArbPrecompilesEnum::ArbBls => "ArbBLS",
-        ArbPrecompilesEnum::ArbFunctionTable => "ArbFunctionTable",
-        ArbPrecompilesEnum::ArbOwnerPublic => "ArbOwnerPublic",
-        ArbPrecompilesEnum::ArbGasInfo => "ArbGasInfo",
-        ArbPrecompilesEnum::ArbAggregator => "ArbAggregator",
-        ArbPrecompilesEnum::ArbRetryableTx => "ArbRetryableTx",
-        ArbPrecompilesEnum::ArbStatistics => "ArbStatistics",
-        ArbPrecompilesEnum::ArbOwner => "ArbOwner",
-        ArbPrecompilesEnum::ArbWasm => "ArbWasm",
-        ArbPrecompilesEnum::ArbWasmCache => "ArbWasmCache",
-        ArbPrecompilesEnum::ArbNativeTokenManager => "ArbNativeTokenManager",
-        ArbPrecompilesEnum::ArbFilteredTransactionsManager => "ArbFilteredTransactionsManager",
-        ArbPrecompilesEnum::ArbDebug => "ArbDebug",
+// Mirrors alloy-evm's own `PrecompileProvider for PrecompilesMap` impl header (generic over the
+// context type params, journal fixed to revm's `Journal<DB>`), so this provider slots into the
+// same `ArbContext<DB>` the node EVM runs on.
+impl<BlockEnv, TxEnv, CfgEnv, DB, Chain>
+    PrecompileProvider<Context<BlockEnv, TxEnv, CfgEnv, DB, Journal<DB>, Chain>>
+    for ArbPrecompilesMap
+where
+    BlockEnv: BlockEnvironment,
+    TxEnv: Transaction,
+    CfgEnv: Cfg,
+    DB: Database,
+{
+    type Output = InterpreterResult;
+
+    fn set_spec(&mut self, _spec: <CfgEnv as Cfg>::Spec) -> bool {
+        // The spec is baked in at construction (a fresh provider per `create_evm`); mirror
+        // `PrecompilesMap::set_spec`, which is also a no-op.
+        false
+    }
+
+    fn run(
+        &mut self,
+        context: &mut Context<BlockEnv, TxEnv, CfgEnv, DB, Journal<DB>, Chain>,
+        inputs: &CallInputs,
+    ) -> Result<Option<Self::Output>, String> {
+        if let Some(arb) = ArbPrecompilesEnum::from_address(&inputs.bytecode_address) {
+            // Resolve the (possibly shared-buffer) calldata, then dispatch through the shared
+            // `run_dispatch` (gating + per-call gas), same as the in-EVM `ArbPrecompiles::run`.
+            let raw = inputs.input.bytes(context);
+            let call = ArbCall {
+                input: raw.as_ref(),
+                gas_limit: inputs.gas_limit,
+                caller: inputs.caller,
+                value: inputs.call_value(),
+                bytecode_address: inputs.bytecode_address,
+                acting_address: inputs.target_address,
+                is_static: inputs.is_static,
+            };
+            return Ok(Some(arb.run_dispatch(context, &call)));
+        }
+        self.inner.run(context, inputs)
+    }
+
+    fn warm_addresses(&self) -> &AddressSet {
+        &self.warm
+    }
+
+    fn contains(&self, address: &Address) -> bool {
+        ArbPrecompilesEnum::from_address(address).is_some()
+            || <PrecompilesMap as PrecompileProvider<
+                Context<BlockEnv, TxEnv, CfgEnv, DB, Journal<DB>, Chain>,
+            >>::contains(&self.inner, address)
     }
 }

--- a/crates/arb-reth-evm/src/tests.rs
+++ b/crates/arb-reth-evm/src/tests.rs
@@ -122,12 +122,11 @@ fn arb_evm_factory_transact_matches_arb_revm() {
     assert_eq!(evm.chain_id(), CHAIN_ID);
 }
 
-/// End-to-end proof of the node-path precompile bridge: a tx that CALLs `ArbSys.arbOSVersion()`
-/// executes through `PrecompilesMap` → `DynPrecompile` → `run_dispatch`-over-`EvmInternals` and
-/// must match the in-EVM `arb_revm` oracle bit-for-bit in both output and gas. The `arbos_version`
-/// slot is seeded to a known non-default value, proving the `ArbInternals` adapter actually
-/// `sload`s the correct slot (not a coincidental zero) and that gas is preserved through the
-/// `InterpreterResult` → `PrecompileResult` conversion.
+/// End-to-end proof of the node-path precompile provider: a tx that CALLs `ArbSys.arbOSVersion()`
+/// executes through `ArbPrecompilesMap` → `run_dispatch` over the full `ArbContext` and must match
+/// the in-EVM `arb_revm` oracle bit-for-bit in both output and gas. The `arbos_version` slot is
+/// seeded to a known non-default value, proving the provider actually `sload`s the correct slot
+/// (not a coincidental zero) and that gas is preserved.
 #[test]
 fn arbos_precompile_through_precompiles_map_matches_oracle() {
     use arb_revm::ArbosState;
@@ -178,7 +177,7 @@ fn arbos_precompile_through_precompiles_map_matches_oracle() {
     let mut oracle_evm = octx.build_arb();
     let oracle = oracle_evm.transact(call_tx()).expect("oracle precompile call");
 
-    // Bridge: ArbEvmFactory (node PrecompilesMap path).
+    // Bridge: ArbEvmFactory (node ArbPrecompilesMap provider path).
     let evm_env = EvmEnv::new(cfg(), BlockEnv::default());
     let mut bridge_evm = ArbEvmFactory.create_evm(seed_db(), evm_env);
     let bridge = bridge_evm

--- a/crates/arb-reth-genesis/Cargo.toml
+++ b/crates/arb-reth-genesis/Cargo.toml
@@ -9,7 +9,7 @@ authors.workspace = true
 # Nitro's `InitializeArbosInDatabase` (via arb_revm::arbos_init) and verifying the state root.
 
 [dependencies]
-arb-revm = { git = "https://github.com/nuntax/arbitrum-revm", rev = "ce0be45c0b94e395b5de83ae0c210f576d8f03a1" }
+arb-revm = { git = "https://github.com/nuntax/arbitrum-revm", rev = "fc912e5146338d54e912ebb404095e49b3582d99" }
 
 alloy-primitives = { version = "1", default-features = false }
 alloy-trie = { version = "0.9", default-features = false }

--- a/crates/arb-reth-node/Cargo.toml
+++ b/crates/arb-reth-node/Cargo.toml
@@ -14,7 +14,7 @@ authors.workspace = true
 [dependencies]
 arbitrum-alloy-consensus = { git = "https://github.com/nuntax/arbitrum-alloy", rev = "f1e74b02952b0716801d4c20ad2e893c7b3992af", default-features = false, features = ["reth"] }
 arb-reth-evm = { path = "../arb-reth-evm", features = ["rpc"] }
-arb-revm = { git = "https://github.com/nuntax/arbitrum-revm", rev = "ce0be45c0b94e395b5de83ae0c210f576d8f03a1" }
+arb-revm = { git = "https://github.com/nuntax/arbitrum-revm", rev = "fc912e5146338d54e912ebb404095e49b3582d99" }
 
 alloy-primitives = { version = "1", default-features = false }
 alloy-consensus = { version = "2.0", default-features = false }

--- a/crates/arb-reth-node/src/launcher.rs
+++ b/crates/arb-reth-node/src/launcher.rs
@@ -20,17 +20,17 @@ use reth_chain_state::CanonicalInMemoryState;
 use reth_db::{Database, database_metrics::DatabaseMetrics};
 use reth_evm::ConfigureEvm;
 use reth_node_api::{AddOnsContext, FullNodeTypes, NodeAddOns, NodeTypes, NodeTypesWithDBAdapter};
+use reth_node_builder::hooks::NodeHooks;
 use reth_node_builder::{
     AddOns, LaunchContext, LaunchNode, Node, NodeBuilderWithComponents, NodeComponents,
     NodeComponentsBuilder, NodeTypesAdapter, RethFullAdapter,
 };
-use reth_node_builder::hooks::NodeHooks;
 use reth_primitives_traits::SealedHeader;
 use reth_provider::{
-    providers::{BlockchainProvider, NodeTypesForProvider, ProviderNodeTypes},
     BalProvider, BlockNumReader, BlockReader, ChangeSetReader, DatabaseProviderFactory,
     HashedPostStateProvider, ProviderFactory, StateProviderFactory, StateReader,
     StorageChangeSetReader,
+    providers::{BlockchainProvider, NodeTypesForProvider, ProviderNodeTypes},
 };
 use reth_rpc_builder::RpcServerHandle;
 use reth_storage_api::{
@@ -93,35 +93,40 @@ pub struct ArbLauncher {
     pub rpc_addr: Option<SocketAddr>,
 }
 
-impl<N, DB, T, CB>
-    LaunchNode<NodeBuilderWithComponents<T, CB, ()>>
-    for ArbLauncher
+impl<N, DB, T, CB> LaunchNode<NodeBuilderWithComponents<T, CB, ()>> for ArbLauncher
 where
     N: Node<RethFullAdapter<DB, N>>
         + NodeTypesForProvider
-        + NodeTypes<Primitives = ArbPrimitives, Payload = arb_reth_engine::ArbPayloadTypes, ChainSpec: reth_chainspec::EthChainSpec + reth_chainspec::EthereumHardforks + reth_chainspec::Hardforks>,
+        + NodeTypes<
+            Primitives = ArbPrimitives,
+            Payload = arb_reth_engine::ArbPayloadTypes,
+            ChainSpec: reth_chainspec::EthChainSpec
+                           + reth_chainspec::EthereumHardforks
+                           + reth_chainspec::Hardforks,
+        >,
     DB: Database + DatabaseMetrics + Clone + Unpin + 'static,
     T: FullNodeTypes<
-        Types = N,
-        Provider = BlockchainProvider<NodeTypesWithDBAdapter<N, DB>>,
-        DB = DB,
-    >,
+            Types = N,
+            Provider = BlockchainProvider<NodeTypesWithDBAdapter<N, DB>>,
+            DB = DB,
+        >,
     CB: NodeComponentsBuilder<T> + 'static,
-    <CB::Components as NodeComponents<T>>::Evm: ConfigureEvm<Primitives = ArbPrimitives>
-        + Into<arb_reth_evm::ArbEvmConfig>
-        + Clone,
+    <CB::Components as NodeComponents<T>>::Evm:
+        ConfigureEvm<Primitives = ArbPrimitives> + Into<arb_reth_evm::ArbEvmConfig> + Clone,
     CB::Components: NodeComponents<T, Evm = arb_reth_evm::ArbEvmConfig>,
     NodeTypesWithDBAdapter<N, DB>: ProviderNodeTypes<Primitives = ArbPrimitives>,
     // Explicit equality bounds to help the compiler resolve the associated type projections
     // from NodeTypesWithDBAdapter<N, DB>.
-    NodeTypesWithDBAdapter<N, DB>: NodeTypes<ChainSpec = <N as NodeTypes>::ChainSpec, Primitives = ArbPrimitives>,
+    NodeTypesWithDBAdapter<N, DB>:
+        NodeTypes<ChainSpec = <N as NodeTypes>::ChainSpec, Primitives = ArbPrimitives>,
     NodeTypesWithDBAdapter<N, DB>: reth_node_api::NodeTypesWithDB<DB = DB>,
     // Engine-tree (Tier-1) bounds: mirror `EngineApiTreeHandler::spawn_new`'s P-bounds with
     // P = BlockchainProvider<NodeTypesWithDBAdapter<N, DB>> (see engine.rs).
     BlockchainProvider<NodeTypesWithDBAdapter<N, DB>>: DatabaseProviderFactory<DB = DB>
         + BlockReader<Block = ArbBlock, Header = Header>
-        + reth_storage_api::TransactionsProvider<Transaction = arbitrum_alloy_consensus::ArbTxEnvelope>
-        + reth_storage_api::ReceiptProvider<Receipt = ArbReceiptEnvelope>
+        + reth_storage_api::TransactionsProvider<
+            Transaction = arbitrum_alloy_consensus::ArbTxEnvelope,
+        > + reth_storage_api::ReceiptProvider<Receipt = ArbReceiptEnvelope>
         + StateProviderFactory
         + StateReader<Receipt = ArbReceiptEnvelope>
         + HashedPostStateProvider
@@ -157,32 +162,53 @@ impl ArbLauncher {
     where
         N: Node<RethFullAdapter<DB, N>>
             + NodeTypesForProvider
-            + NodeTypes<Primitives = ArbPrimitives, Payload = arb_reth_engine::ArbPayloadTypes, ChainSpec: reth_chainspec::EthChainSpec + reth_chainspec::EthereumHardforks + reth_chainspec::Hardforks>,
+            + NodeTypes<
+                Primitives = ArbPrimitives,
+                Payload = arb_reth_engine::ArbPayloadTypes,
+                ChainSpec: reth_chainspec::EthChainSpec
+                               + reth_chainspec::EthereumHardforks
+                               + reth_chainspec::Hardforks,
+            >,
         DB: Database + DatabaseMetrics + Clone + Unpin + 'static,
         T: FullNodeTypes<
-            Types = N,
-            Provider = BlockchainProvider<NodeTypesWithDBAdapter<N, DB>>,
-            DB = DB,
-        >,
+                Types = N,
+                Provider = BlockchainProvider<NodeTypesWithDBAdapter<N, DB>>,
+                DB = DB,
+            >,
         CB: NodeComponentsBuilder<T> + 'static,
-        <CB::Components as NodeComponents<T>>::Evm: ConfigureEvm<Primitives = ArbPrimitives>
-            + Into<arb_reth_evm::ArbEvmConfig>
-            + Clone,
+        <CB::Components as NodeComponents<T>>::Evm:
+            ConfigureEvm<Primitives = ArbPrimitives> + Into<arb_reth_evm::ArbEvmConfig> + Clone,
         CB::Components: NodeComponents<T, Evm = arb_reth_evm::ArbEvmConfig>,
         NodeTypesWithDBAdapter<N, DB>: ProviderNodeTypes<Primitives = ArbPrimitives>,
-        NodeTypesWithDBAdapter<N, DB>: NodeTypes<ChainSpec = <N as NodeTypes>::ChainSpec, Primitives = ArbPrimitives>,
+        NodeTypesWithDBAdapter<N, DB>:
+            NodeTypes<ChainSpec = <N as NodeTypes>::ChainSpec, Primitives = ArbPrimitives>,
         NodeTypesWithDBAdapter<N, DB>: reth_node_api::NodeTypesWithDB<DB = DB>,
     {
-        let Self { ctx, chain_id, genesis_block, tuning, messages, rpc_addr } = self;
+        let Self {
+            ctx,
+            chain_id,
+            genesis_block,
+            tuning,
+            messages,
+            rpc_addr,
+        } = self;
 
         let NodeBuilderWithComponents {
             adapter: NodeTypesAdapter { database },
             rocksdb_provider,
             components_builder,
-            add_ons: AddOns { hooks, exexs: _, add_ons: _ },
+            add_ons:
+                AddOns {
+                    hooks,
+                    exexs: _,
+                    add_ons: _,
+                },
             config,
         } = target;
-        let NodeHooks { on_component_initialized, .. } = hooks;
+        let NodeHooks {
+            on_component_initialized,
+            ..
+        } = hooks;
 
         // Drive RPC config from the explicit `rpc_addr`: canonical `RpcAddOns` reads addresses from
         // `NodeConfig.rpc`, not an arg. Enable http+ws with the full module fleet; this node is
@@ -228,8 +254,7 @@ impl ArbLauncher {
             };
             if current != Some(reth_db_api::models::StorageSettings::v2()) {
                 let provider_rw = factory.provider_rw()?;
-                provider_rw
-                    .write_storage_settings(reth_db_api::models::StorageSettings::v2())?;
+                provider_rw.write_storage_settings(reth_db_api::models::StorageSettings::v2())?;
                 provider_rw
                     .commit()
                     .map_err(|e| eyre!("persist storage settings v2: {e}"))?;
@@ -254,8 +279,7 @@ impl ArbLauncher {
 
         // Clone the in-memory state from the provider so the tree updates the same instance that
         // BlockchainProvider serves for RPC queries.
-        let canonical: CanonicalInMemoryState<ArbPrimitives> =
-            provider.canonical_in_memory_state();
+        let canonical: CanonicalInMemoryState<ArbPrimitives> = provider.canonical_in_memory_state();
 
         let genesis_tip: SealedHeader<Header> =
             HeaderProvider::sealed_header(&provider, head.number)?
@@ -263,7 +287,7 @@ impl ArbLauncher {
 
         // `arb_evm_config` (hoisted from the RPC block below): also drives the engine tree.
         let arb_evm_config: arb_reth_evm::ArbEvmConfig =
-            ctx.node_adapter().components.evm_config().clone().into();
+            ctx.node_adapter().components.evm_config().clone();
 
         // Stand up reth's engine tree (Tier-1 `InsertExecutedBlock` seam) and drive the
         // sequencer feed through it. Persistence to MDBX is async (tree background service).
@@ -282,49 +306,48 @@ impl ArbLauncher {
         let (exit_tx, exit_rx) = oneshot::channel::<eyre::Result<()>>();
         let mut messages_rx = messages;
 
-        task_executor.spawn_critical_task(
-            "arb-engine-driver",
-            async move {
-                let res: eyre::Result<()> = async {
-                    // Bench accounting: separate time spent WAITING for the next derived feed
-                    // message (L1-fetch-bound) from time spent in advance() (compute/persist-bound).
-                    // Emitted every 1000 blocks at target "arb-reth::bench"; harmless at info off.
-                    let mut bench_recv_us: u128 = 0;
-                    let mut bench_work_us: u128 = 0;
-                    let mut bench_n: u64 = 0;
-                    let mut bench_wall = std::time::Instant::now();
-                    loop {
-                        let __r = std::time::Instant::now();
-                        let Some(msg) = messages_rx.recv().await else { break };
-                        bench_recv_us += __r.elapsed().as_micros();
-                        let __w = std::time::Instant::now();
-                        driver.advance(&msg).await?;
-                        bench_work_us += __w.elapsed().as_micros();
-                        bench_n += 1;
-                        if bench_n.is_multiple_of(1000) {
-                            let wall_ms = bench_wall.elapsed().as_millis().max(1);
-                            tracing::info!(
-                                target: "arb-reth::bench",
-                                blocks = bench_n,
-                                blk_per_s = (1000u128 * 1000 / wall_ms) as u64,
-                                recv_ms = (bench_recv_us / 1000) as u64,
-                                work_ms = (bench_work_us / 1000) as u64,
-                                recv_pct = (100 * bench_recv_us
-                                    / (bench_recv_us + bench_work_us).max(1)) as u64,
-                                "bench: 1000-block window",
-                            );
-                            bench_recv_us = 0;
-                            bench_work_us = 0;
-                            bench_wall = std::time::Instant::now();
-                        }
+        task_executor.spawn_critical_task("arb-engine-driver", async move {
+            let res: eyre::Result<()> = async {
+                // Bench accounting: separate time spent WAITING for the next derived feed
+                // message (L1-fetch-bound) from time spent in advance() (compute/persist-bound).
+                // Emitted every 1000 blocks at target "arb-reth::bench"; harmless at info off.
+                let mut bench_recv_us: u128 = 0;
+                let mut bench_work_us: u128 = 0;
+                let mut bench_n: u64 = 0;
+                let mut bench_wall = std::time::Instant::now();
+                loop {
+                    let __r = std::time::Instant::now();
+                    let Some(msg) = messages_rx.recv().await else {
+                        break;
+                    };
+                    bench_recv_us += __r.elapsed().as_micros();
+                    let __w = std::time::Instant::now();
+                    driver.advance(&msg).await?;
+                    bench_work_us += __w.elapsed().as_micros();
+                    bench_n += 1;
+                    if bench_n.is_multiple_of(1000) {
+                        let wall_ms = bench_wall.elapsed().as_millis().max(1);
+                        tracing::info!(
+                            target: "arb-reth::bench",
+                            blocks = bench_n,
+                            blk_per_s = (1000u128 * 1000 / wall_ms) as u64,
+                            recv_ms = (bench_recv_us / 1000) as u64,
+                            work_ms = (bench_work_us / 1000) as u64,
+                            recv_pct = (100 * bench_recv_us
+                                / (bench_recv_us + bench_work_us).max(1)) as u64,
+                            "bench: 1000-block window",
+                        );
+                        bench_recv_us = 0;
+                        bench_work_us = 0;
+                        bench_wall = std::time::Instant::now();
                     }
-                    driver.shutdown().await;
-                    Ok(())
                 }
-                .await;
-                let _ = exit_tx.send(res); // ignore error if receiver was dropped
-            },
-        );
+                driver.shutdown().await;
+                Ok(())
+            }
+            .await;
+            let _ = exit_tx.send(res); // ignore error if receiver was dropped
+        });
 
         // Serve RPC through reth's canonical `RpcAddOns::launch_add_ons` (full fleet + ws +
         // subscriptions via `NodeConfig.rpc`), not the bespoke server. This node is self-driven
@@ -350,17 +373,21 @@ impl ArbLauncher {
             None
         };
 
-        Ok(ArbNodeHandle { provider, exit_rx, rpc_handle })
+        Ok(ArbNodeHandle {
+            provider,
+            exit_rx,
+            rpc_handle,
+        })
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alloy_primitives::{address, U256};
+    use alloy_primitives::{U256, address};
     use arbitrum_alloy_sequencer::sequencer::feed::BroadcastFeedMessage;
     use reth_chainspec::MAINNET;
-    use reth_node_builder::{NodeBuilder, NodeConfig, LaunchNode};
+    use reth_node_builder::{LaunchNode, NodeBuilder, NodeConfig};
     use reth_provider::{BlockNumReader, HeaderProvider, StateProviderFactory};
     use reth_storage_api::AccountReader;
     use reth_tasks::Runtime;
@@ -371,8 +398,7 @@ mod tests {
     /// and persists blocks 1 & 2 with cumulative balance = 2 x 111_000_000_000_000_000.
     #[tokio::test(flavor = "multi_thread")]
     async fn launcher_boots_and_produces_blocks() {
-        let fixtures_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
-            .join("tests/fixtures");
+        let fixtures_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures");
         let json = std::fs::read_to_string(fixtures_dir.join("deposit_message_only.json"))
             .expect("read fixture");
         let feed_msg: BroadcastFeedMessage =
@@ -395,23 +421,19 @@ mod tests {
         let db = reth_db::test_utils::create_test_rw_db_with_datadir(&datadir);
 
         // Build the ChainPath (data_dir) that LaunchContext needs.
-        let maybe_path = reth_node_core::dirs::MaybePlatformPath::<
-            reth_node_core::dirs::DataDirPath,
-        >::from(datadir.clone());
-        let config = NodeConfig::test().with_chain(MAINNET.clone()).with_datadir_args(
-            reth_node_core::args::DatadirArgs {
+        let maybe_path =
+            reth_node_core::dirs::MaybePlatformPath::<reth_node_core::dirs::DataDirPath>::from(
+                datadir.clone(),
+            );
+        let config = NodeConfig::test()
+            .with_chain(MAINNET.clone())
+            .with_datadir_args(reth_node_core::args::DatadirArgs {
                 datadir: maybe_path.clone(),
                 ..Default::default()
-            },
-        );
-        let data_dir = maybe_path.unwrap_or_chain_default(
-            MAINNET.chain(),
-            config.datadir.clone(),
-        );
+            });
+        let data_dir = maybe_path.unwrap_or_chain_default(MAINNET.chain(), config.datadir.clone());
 
-        let node_builder_with_components = NodeBuilder::new(config)
-            .with_database(db)
-            .node(ArbNode);
+        let node_builder_with_components = NodeBuilder::new(config).with_database(db).node(ArbNode);
 
         let launcher = ArbLauncher {
             ctx: LaunchContext::new(task_executor.clone(), data_dir),
@@ -428,7 +450,10 @@ mod tests {
             .expect("launch must succeed");
 
         let provider = handle.provider.clone();
-        handle.wait_for_node_exit().await.expect("driver task must succeed");
+        handle
+            .wait_for_node_exit()
+            .await
+            .expect("driver task must succeed");
 
         // The launcher opens the DB in storage v2; confirm the flag is persisted.
         {
@@ -442,9 +467,19 @@ mod tests {
             );
         }
 
-        assert_eq!(provider.best_block_number().unwrap(), 2, "best block must be 2");
-        assert!(provider.header_by_number(1).unwrap().is_some(), "block 1 must exist");
-        assert!(provider.header_by_number(2).unwrap().is_some(), "block 2 must exist");
+        assert_eq!(
+            provider.best_block_number().unwrap(),
+            2,
+            "best block must be 2"
+        );
+        assert!(
+            provider.header_by_number(1).unwrap().is_some(),
+            "block 1 must exist"
+        );
+        assert!(
+            provider.header_by_number(2).unwrap().is_some(),
+            "block 2 must exist"
+        );
 
         let deposit_to = address!("3f1eae7d46d88f08fc2f8ed27fcb2ab183eb2d0e");
         let single_deposit = U256::from(111_000_000_000_000_000u128);


### PR DESCRIPTION
Replace the DynPrecompile/PrecompilesMap node path (which dispatched ArbOS precompiles through alloy-evm's context-blind PrecompileInput/EvmInternals, forcing a hardcoded call depth and hiding ArbChainContext) with ArbPrecompilesMap: the real revm PrecompileProvider over the full ArbContext. ArbOS addresses dispatch through arb_revm's static run_dispatch (so precompiles see real call depth, tx type, and ArbChainContext, matching the in-EVM path); all other addresses delegate to an inner PrecompilesMap, which is also exposed as the EvmFactory::Precompiles associated type to satisfy reth's ConfigureEvm bound and keep reth's eth-precompile cache working.

Bumps arb-revm to fc912e5.

Closes #2 