### PR TITLE
Add execution loop metrics and Robinhood runbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ The command above is for a snapshot-seeded database. Orbit chains can instead bo
 ```
 
 See [node command](docs/commands/node.md) before selecting persistence or feed options.
+For a complete Robinhood mainnet invocation, see the [Robinhood chain guide](docs/chains/robinhood-mainnet.md).
 
 ## Commands
 

--- a/crates/arb-reth-derive/Cargo.toml
+++ b/crates/arb-reth-derive/Cargo.toml
@@ -17,7 +17,7 @@ alloy-primitives = "1"
 alloy-rlp = { workspace = true }
 # brotli is re-exported from arb_revm (which vendors it) so both crates share one brotli
 # source and avoid a lockfile collision. BUSL-licensed; see the arb_revm NOTICE.
-arb-revm = { git = "https://github.com/nuntax/arbitrum-revm", rev = "dd05d8abf79c7d5436ab6bf7bd6d979bee0bba5e" }
+arb-revm = { git = "https://github.com/nuntax/arbitrum-revm", rev = "96f826bfb531fc13f8337db584abfe1e6baaee4f" }
 
 [dev-dependencies]
 serde_json = { workspace = true }

--- a/crates/arb-reth-derive/Cargo.toml
+++ b/crates/arb-reth-derive/Cargo.toml
@@ -17,7 +17,7 @@ alloy-primitives = "1"
 alloy-rlp = { workspace = true }
 # brotli is re-exported from arb_revm (which vendors it) so both crates share one brotli
 # source and avoid a lockfile collision. BUSL-licensed; see the arb_revm NOTICE.
-arb-revm = { git = "https://github.com/nuntax/arbitrum-revm", rev = "96f826bfb531fc13f8337db584abfe1e6baaee4f" }
+arb-revm = { git = "https://github.com/nuntax/arbitrum-revm", rev = "e5b83cecdda6321e72893a83a616e1f9981e1a5a" }
 
 [dev-dependencies]
 serde_json = { workspace = true }

--- a/crates/arb-reth-engine/Cargo.toml
+++ b/crates/arb-reth-engine/Cargo.toml
@@ -14,7 +14,7 @@ authors.workspace = true
 [dependencies]
 arbitrum-alloy-consensus = { git = "https://github.com/nuntax/arbitrum-alloy", rev = "c49c1729668dbda31594b7c2524846f1c9a0bf21", default-features = false, features = ["reth"] }
 arb-reth-evm = { path = "../arb-reth-evm" }
-arb-revm = { git = "https://github.com/nuntax/arbitrum-revm", rev = "dd05d8abf79c7d5436ab6bf7bd6d979bee0bba5e" }
+arb-revm = { git = "https://github.com/nuntax/arbitrum-revm", rev = "96f826bfb531fc13f8337db584abfe1e6baaee4f" }
 arbitrum-alloy-sequencer = { git = "https://github.com/nuntax/arbitrum-alloy", rev = "c49c1729668dbda31594b7c2524846f1c9a0bf21", default-features = false, features = ["std"] }
 
 alloy-consensus = { version = "2.0", default-features = false }

--- a/crates/arb-reth-engine/Cargo.toml
+++ b/crates/arb-reth-engine/Cargo.toml
@@ -14,7 +14,7 @@ authors.workspace = true
 [dependencies]
 arbitrum-alloy-consensus = { git = "https://github.com/nuntax/arbitrum-alloy", rev = "c49c1729668dbda31594b7c2524846f1c9a0bf21", default-features = false, features = ["reth"] }
 arb-reth-evm = { path = "../arb-reth-evm" }
-arb-revm = { git = "https://github.com/nuntax/arbitrum-revm", rev = "96f826bfb531fc13f8337db584abfe1e6baaee4f" }
+arb-revm = { git = "https://github.com/nuntax/arbitrum-revm", rev = "e5b83cecdda6321e72893a83a616e1f9981e1a5a" }
 arbitrum-alloy-sequencer = { git = "https://github.com/nuntax/arbitrum-alloy", rev = "c49c1729668dbda31594b7c2524846f1c9a0bf21", default-features = false, features = ["std"] }
 
 alloy-consensus = { version = "2.0", default-features = false }
@@ -22,6 +22,7 @@ alloy-eips = { version = "2.0", default-features = false }
 alloy-primitives = { version = "1", default-features = false }
 alloy-rpc-types-engine = { version = "2.0", default-features = false, features = ["serde"] }
 eyre = "0.6.12"
+metrics = "0.24"
 serde = { version = "1", default-features = false, features = ["derive"] }
 tracing = "0.1"
 crossbeam-channel = "0.5"
@@ -34,6 +35,7 @@ reth-consensus = { git = "https://github.com/paradigmxyz/reth.git", rev = "224b0
 reth-engine-primitives = { git = "https://github.com/paradigmxyz/reth.git", rev = "224b087672690ae2ef85ad706bd18f40d8e5b265" }
 reth-engine-tree = { git = "https://github.com/paradigmxyz/reth.git", rev = "224b087672690ae2ef85ad706bd18f40d8e5b265" }
 reth-evm = { git = "https://github.com/paradigmxyz/reth.git", rev = "224b087672690ae2ef85ad706bd18f40d8e5b265" }
+reth-execution-cache = { git = "https://github.com/paradigmxyz/reth.git", rev = "224b087672690ae2ef85ad706bd18f40d8e5b265" }
 reth-execution-types = { git = "https://github.com/paradigmxyz/reth.git", rev = "224b087672690ae2ef85ad706bd18f40d8e5b265" }
 reth-exex-types = { git = "https://github.com/paradigmxyz/reth.git", rev = "224b087672690ae2ef85ad706bd18f40d8e5b265" }
 reth-payload-builder = { git = "https://github.com/paradigmxyz/reth.git", rev = "224b087672690ae2ef85ad706bd18f40d8e5b265" }

--- a/crates/arb-reth-engine/src/engine.rs
+++ b/crates/arb-reth-engine/src/engine.rs
@@ -207,6 +207,9 @@ fn produce_with_timing<'a>(
         .ctx_mut()
         .modify_block(|b| b.basefee = block_base_fee);
 
+    let execution_setup = phase_started_at.elapsed();
+    let mut start_block_transaction = Duration::ZERO;
+    let mut derived_transactions = Duration::ZERO;
     let mut first = builder.executor().start_block_tx();
     loop {
         let (tx, is_internal) = if let Some(t) = first.take() {
@@ -225,10 +228,17 @@ fn produce_with_timing<'a>(
         let recovered = Recovered::new_unchecked(tx, sender);
         let mut tx_logs: Vec<Log> = Vec::new();
         let mut tx_success = false;
+        let tx_started_at = Instant::now();
         if let Err(e) = builder.execute_transaction_with_result_closure(recovered, |res| {
             tx_success = res.result.result.is_success();
             tx_logs = res.result.result.logs().to_vec();
         }) {
+            let tx_execution = tx_started_at.elapsed();
+            if is_internal {
+                start_block_transaction += tx_execution;
+            } else {
+                derived_transactions += tx_execution;
+            }
             // Nitro `arbos/block_processor.go` (~l.503-549): a derived tx that is INVALID under the
             // state transition, a validation failure like lack-of-funds / NonceTooHigh, NOT a
             // revert, is reverted and dropped, and block production continues without it. This is
@@ -255,6 +265,13 @@ fn produce_with_timing<'a>(
             let retries =
                 scheduled_retries_from_redeem_logs(builder.evm_mut().ctx_mut(), &tx_logs, chain_id);
             redeems.extend(retries);
+        }
+
+        let tx_execution = tx_started_at.elapsed();
+        if is_internal {
+            start_block_transaction += tx_execution;
+        } else {
+            derived_transactions += tx_execution;
         }
     }
 
@@ -294,6 +311,9 @@ fn produce_with_timing<'a>(
             message_preparation,
             state_setup,
             execution,
+            execution_setup,
+            start_block_transaction,
+            derived_transactions,
             finish,
         },
     ))
@@ -807,6 +827,12 @@ pub struct ArbAppliedMessageTiming {
     pub block_state_setup: Duration,
     /// ArbOS pre-execution and transaction execution.
     pub block_execution: Duration,
+    /// Block-builder creation, pre-execution changes, and base-fee setup before the first tx.
+    pub block_execution_setup: Duration,
+    /// Execution of ArbOS's mandatory internal start-block transaction.
+    pub block_start_block_transaction: Duration,
+    /// Execution of derived user and retry transactions, including retry scheduling.
+    pub block_derived_transactions: Duration,
     /// State-root computation plus final block and header construction.
     pub block_finish: Duration,
     /// Sending the executed block to the engine tree.
@@ -826,6 +852,9 @@ struct ArbBlockProductionTiming {
     message_preparation: Duration,
     state_setup: Duration,
     execution: Duration,
+    execution_setup: Duration,
+    start_block_transaction: Duration,
+    derived_transactions: Duration,
     finish: Duration,
 }
 
@@ -1474,6 +1503,9 @@ where
                 block_message_preparation: production_timing.message_preparation,
                 block_state_setup: production_timing.state_setup,
                 block_execution: production_timing.execution,
+                block_execution_setup: production_timing.execution_setup,
+                block_start_block_transaction: production_timing.start_block_transaction,
+                block_derived_transactions: production_timing.derived_transactions,
                 block_finish: production_timing.finish,
                 engine_insert,
                 engine_forkchoice,

--- a/crates/arb-reth-engine/src/engine.rs
+++ b/crates/arb-reth-engine/src/engine.rs
@@ -19,14 +19,14 @@ use alloy_consensus::transaction::Recovered;
 use alloy_eips::eip2718::Typed2718;
 use alloy_primitives::map::{HashMap, HashSet};
 use alloy_primitives::{Address, B256, BlockNumber, Bytes, Log, StorageKey, StorageValue};
-use arbitrum_alloy_consensus::reth::{ArbBlock, ArbPrimitives};
-use arbitrum_alloy_consensus::{ArbReceiptEnvelope, ArbTxEnvelope};
 use arb_reth_evm::ArbEvmConfig;
 use arb_reth_evm::config::ArbNextBlockEnvAttributes;
 use arb_revm::ArbosState;
 use arb_revm::executor::{
     ArbExecCfg, ArbParentHeader, digest_message, scheduled_retries_from_redeem_logs,
 };
+use arbitrum_alloy_consensus::reth::{ArbBlock, ArbPrimitives};
+use arbitrum_alloy_consensus::{ArbReceiptEnvelope, ArbTxEnvelope};
 use arbitrum_alloy_sequencer::sequencer::feed::BroadcastFeedMessage;
 use eyre::{WrapErr as _, eyre};
 use std::time::{Duration, Instant};
@@ -40,9 +40,12 @@ use reth_engine_primitives::{
 };
 use reth_engine_tree::engine::{EngineApiEvent, EngineApiKind, EngineApiRequest, FromEngine};
 use reth_engine_tree::persistence::PersistenceHandle;
-use reth_engine_tree::tree::{BasicEngineValidator, EngineApiTreeHandler};
+use reth_engine_tree::tree::precompile_cache::PrecompileCacheMap;
+use reth_engine_tree::tree::{BasicEngineValidator, EngineApiTreeHandler, PayloadProcessor};
 use reth_evm::ConfigureEvm as _;
+use reth_evm::Evm as _;
 use reth_evm::execute::BlockBuilder as _;
+use reth_execution_cache::{CacheFillMode, CacheStats, CachedStateProvider, ExecutionCache};
 use reth_execution_types::{BlockExecutionOutput, BlockExecutionResult};
 use reth_payload_builder::PayloadBuilderHandle;
 use reth_payload_primitives::BuiltPayloadExecutedBlock;
@@ -70,6 +73,7 @@ use reth_trie_common::{
 };
 use reth_trie_db::ChangesetCache;
 use reth_trie_parallel::root::ParallelStateRoot;
+use reth_trie_parallel::state_root_task::StateRootHandle;
 use revm::context_interface::ContextTr as _;
 use revm_database::BundleState;
 
@@ -96,17 +100,16 @@ pub fn produce<'a>(
     exec_state_provider: Box<dyn StateProvider + 'a>,
     trie_state_provider: Box<dyn StateProvider + 'a>,
 ) -> eyre::Result<BuiltPayloadExecutedBlock<ArbPrimitives>> {
-    Ok(
-        produce_with_timing(
-            evm_config,
-            chain_id,
-            parent,
-            feed_msg,
-            exec_state_provider,
-            trie_state_provider,
-        )?
-        .0,
-    )
+    Ok(produce_with_timing(
+        evm_config,
+        chain_id,
+        parent,
+        feed_msg,
+        exec_state_provider,
+        trie_state_provider,
+        None,
+    )?
+    .0)
 }
 
 /// Produce one block and retain a breakdown of the local block-production work.
@@ -119,7 +122,11 @@ fn produce_with_timing<'a>(
     feed_msg: &BroadcastFeedMessage,
     exec_state_provider: Box<dyn StateProvider + 'a>,
     trie_state_provider: Box<dyn StateProvider + 'a>,
-) -> eyre::Result<(BuiltPayloadExecutedBlock<ArbPrimitives>, ArbBlockProductionTiming)> {
+    mut sparse_state_root: Option<(StateRootHandle, SparseStateRootMode)>,
+) -> eyre::Result<(
+    BuiltPayloadExecutedBlock<ArbPrimitives>,
+    ArbBlockProductionTiming,
+)> {
     let started_at = Instant::now();
     let parent_header = parent.header();
     let version = arbitrum_alloy_consensus::header::ArbHeaderInfo::decode_header(parent_header)
@@ -173,6 +180,12 @@ fn produce_with_timing<'a>(
     let mut builder = evm_config
         .builder_for_next_block(&mut state, parent, attrs)
         .map_err(|e| eyre!("builder_for_next_block: {e:?}"))?;
+    if let Some((handle, _)) = sparse_state_root.as_ref() {
+        builder
+            .evm_mut()
+            .db_mut()
+            .set_state_hook(Some(Box::new(handle.state_hook())));
+    }
     builder
         .apply_pre_execution_changes()
         .wrap_err("apply_pre_execution_changes failed")?;
@@ -208,9 +221,14 @@ fn produce_with_timing<'a>(
         .modify_block(|b| b.basefee = block_base_fee);
 
     let execution_setup = phase_started_at.elapsed();
+    let phase_started_at = Instant::now();
+    let mut first = builder.executor().start_block_tx();
+    let start_block_transaction_construction = phase_started_at.elapsed();
+    let phase_started_at = Instant::now();
     let mut start_block_transaction = Duration::ZERO;
     let mut derived_transactions = Duration::ZERO;
-    let mut first = builder.executor().start_block_tx();
+    let mut derived_transaction_execution = Duration::ZERO;
+    let mut derived_retry_scheduling = Duration::ZERO;
     loop {
         let (tx, is_internal) = if let Some(t) = first.take() {
             (t, true)
@@ -238,6 +256,7 @@ fn produce_with_timing<'a>(
                 start_block_transaction += tx_execution;
             } else {
                 derived_transactions += tx_execution;
+                derived_transaction_execution += tx_execution;
             }
             // Nitro `arbos/block_processor.go` (~l.503-549): a derived tx that is INVALID under the
             // state transition, a validation failure like lack-of-funds / NonceTooHigh, NOT a
@@ -260,10 +279,13 @@ fn produce_with_timing<'a>(
             );
             continue;
         }
+        let mut retry_scheduling = Duration::ZERO;
         if tx_success {
             // FIFO, drained before the next user tx, matching Nitro's cascading-redeem order.
+            let retry_scheduling_started_at = Instant::now();
             let retries =
                 scheduled_retries_from_redeem_logs(builder.evm_mut().ctx_mut(), &tx_logs, chain_id);
+            retry_scheduling = retry_scheduling_started_at.elapsed();
             redeems.extend(retries);
         }
 
@@ -272,15 +294,71 @@ fn produce_with_timing<'a>(
             start_block_transaction += tx_execution;
         } else {
             derived_transactions += tx_execution;
+            derived_transaction_execution += tx_execution.saturating_sub(retry_scheduling);
+            derived_retry_scheduling += retry_scheduling;
         }
     }
 
-    let execution = phase_started_at.elapsed();
+    let derived_transactions_unattributed = derived_transactions
+        .saturating_sub(derived_transaction_execution + derived_retry_scheduling);
+
+    let execution =
+        phase_started_at.elapsed() + execution_setup + start_block_transaction_construction;
+    let execution_unattributed = execution.saturating_sub(
+        execution_setup
+            + start_block_transaction_construction
+            + start_block_transaction
+            + derived_transactions,
+    );
     let phase_started_at = Instant::now();
 
+    // Dropping the hook sends `FinishedStateUpdates`, allowing the sparse-trie task to finalize.
+    if sparse_state_root.is_some() {
+        builder.evm_mut().db_mut().set_state_hook(None);
+    }
+
+    let sparse_precomputed = match sparse_state_root.as_mut() {
+        Some((handle, SparseStateRootMode::Drive)) => {
+            let result = handle
+                .state_root()
+                .map_err(|e| eyre!("sparse state-root computation failed: {e}"))?;
+            Some((result.state_root, Arc::unwrap_or_clone(result.trie_updates)))
+        }
+        _ => None,
+    };
+
     let outcome = builder
-        .finish(trie_state_provider, None)
+        .finish(trie_state_provider, sparse_precomputed)
         .wrap_err("BlockBuilder::finish failed")?;
+
+    if let Some((handle, SparseStateRootMode::Shadow)) = sparse_state_root.as_mut() {
+        let sparse = handle
+            .state_root()
+            .map_err(|e| eyre!("shadow sparse state-root computation failed: {e}"))?;
+        let sparse_updates = Arc::unwrap_or_clone(sparse.trie_updates).into_sorted();
+        let authoritative_updates = outcome.trie_updates.clone().into_sorted();
+        let root_matches = sparse.state_root == outcome.block.header().state_root;
+        let updates_match = sparse_updates == authoritative_updates;
+        metrics::counter!(
+            "arb_reth.sparse_state_root_shadow_total",
+            "result" => match (root_matches, updates_match) {
+                (true, true) => "root_and_updates_match",
+                (true, false) => "root_matches_updates_differ",
+                (false, _) => "root_mismatch",
+            },
+        )
+        .increment(1);
+        if !root_matches {
+            return Err(eyre!(
+                "sparse state-root shadow mismatch at block {}: root_matches={} updates_match={} sparse={} authoritative={}",
+                outcome.block.header().number,
+                root_matches,
+                updates_match,
+                sparse.state_root,
+                outcome.block.header().state_root,
+            ));
+        }
+    }
 
     let finish = phase_started_at.elapsed();
 
@@ -312,11 +390,41 @@ fn produce_with_timing<'a>(
             state_setup,
             execution,
             execution_setup,
+            start_block_transaction_construction,
             start_block_transaction,
             derived_transactions,
+            derived_transaction_execution,
+            derived_retry_scheduling,
+            derived_transactions_unattributed,
+            execution_unattributed,
             finish,
         },
     ))
+}
+
+/// Sparse-trie rollout mode. Shadow computes both algorithms and refuses to insert a block on any
+/// mismatch. Drive passes the sparse result into `BlockBuilder::finish`, skipping the fallback
+/// parallel trie walk.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+enum SparseStateRootMode {
+    #[default]
+    Off,
+    Shadow,
+    Drive,
+}
+
+impl SparseStateRootMode {
+    fn from_env() -> Self {
+        match std::env::var("ARB_SPARSE_STATEROOT") {
+            Err(_) => Self::Drive,
+            Ok(value) => match value.to_ascii_lowercase().as_str() {
+                "shadow" => Self::Shadow,
+                "1" | "true" | "on" | "yes" | "drive" => Self::Drive,
+                "0" | "false" | "off" | "no" => Self::Off,
+                _ => Self::Off,
+            },
+        }
+    }
 }
 
 /// A [`StateProvider`] that wraps the ring-overlay trie provider and overrides only the
@@ -521,6 +629,216 @@ type CoalescedAccounts = HashMap<Address, Option<Account>>;
 /// Ring-flattened storage values (newest-wins), keyed by (address, slot).
 type CoalescedStorage = HashMap<(Address, StorageKey), StorageValue>;
 
+/// Records the source and duration of an execution-state lookup. A historical-provider lookup is
+/// an MDBX-provider request, not necessarily a physical disk read: MDBX is memory-mapped and the
+/// OS page cache can satisfy it without I/O.
+#[inline]
+fn record_state_read(kind: &'static str, source: &'static str, started_at: Instant) {
+    let elapsed = started_at.elapsed().as_secs_f64();
+    metrics::counter!(
+        "arb_reth.state_read_total",
+        "kind" => kind,
+        "source" => source,
+    )
+    .increment(1);
+    metrics::histogram!(
+        "arb_reth.state_read_seconds",
+        "kind" => kind,
+        "source" => source,
+    )
+    .record(elapsed);
+}
+
+/// Flush one block's cross-block execution-cache statistics after the provider has dropped.
+/// Keeping these counters block-local avoids a metrics operation on every cache access.
+fn record_execution_cache_stats(stats: &CacheStats) {
+    for (kind, hits, misses) in [
+        ("account", stats.account_hits(), stats.account_misses()),
+        ("storage", stats.storage_hits(), stats.storage_misses()),
+        ("bytecode", stats.code_hits(), stats.code_misses()),
+    ] {
+        metrics::counter!(
+            "arb_reth.execution_cache_access_total",
+            "kind" => kind,
+            "result" => "hit",
+        )
+        .increment(hits as u64);
+        metrics::counter!(
+            "arb_reth.execution_cache_access_total",
+            "kind" => kind,
+            "result" => "miss",
+        )
+        .increment(misses as u64);
+        metrics::histogram!(
+            "arb_reth.execution_cache_accesses_per_block",
+            "kind" => kind,
+            "result" => "hit",
+        )
+        .record(hits as f64);
+        metrics::histogram!(
+            "arb_reth.execution_cache_accesses_per_block",
+            "kind" => kind,
+            "result" => "miss",
+        )
+        .record(misses as f64);
+    }
+}
+
+/// Exact read-source wrapper for reth's ordinary ring overlay.
+///
+/// The wrapper implements the same newest-first ring walk as
+/// `MemoryOverlayStateProviderRef` for account and storage reads, while exposing whether a read
+/// resolved from an unpersisted block or fell through to the pinned historical provider. Other
+/// provider methods delegate unchanged to reth's overlay implementation.
+struct InstrumentedRingOverlayProvider<'a> {
+    historical: Box<dyn StateProvider + 'a>,
+    inner: Box<dyn StateProvider + 'a>,
+    in_memory: Vec<ExecutedBlock<ArbPrimitives>>,
+}
+
+impl BlockHashReader for InstrumentedRingOverlayProvider<'_> {
+    fn block_hash(&self, number: BlockNumber) -> ProviderResult<Option<B256>> {
+        self.inner.block_hash(number)
+    }
+
+    fn canonical_hashes_range(
+        &self,
+        start: BlockNumber,
+        end: BlockNumber,
+    ) -> ProviderResult<Vec<B256>> {
+        self.inner.canonical_hashes_range(start, end)
+    }
+}
+
+impl AccountReader for InstrumentedRingOverlayProvider<'_> {
+    fn basic_account(&self, address: &Address) -> ProviderResult<Option<Account>> {
+        let started_at = Instant::now();
+        for block in &self.in_memory {
+            if let Some(account) = block.execution_output.account(address) {
+                record_state_read("account", "ring_overlay", started_at);
+                return Ok(account);
+            }
+        }
+
+        let account = self.historical.basic_account(address)?;
+        record_state_read("account", "historical_provider", started_at);
+        Ok(account)
+    }
+}
+
+impl BytecodeReader for InstrumentedRingOverlayProvider<'_> {
+    fn bytecode_by_hash(&self, code_hash: &B256) -> ProviderResult<Option<Bytecode>> {
+        self.inner.bytecode_by_hash(code_hash)
+    }
+}
+
+impl StorageRootProvider for InstrumentedRingOverlayProvider<'_> {
+    fn storage_root(
+        &self,
+        address: Address,
+        hashed_storage: HashedStorage,
+    ) -> ProviderResult<B256> {
+        self.inner.storage_root(address, hashed_storage)
+    }
+
+    fn storage_proof(
+        &self,
+        address: Address,
+        slot: B256,
+        hashed_storage: HashedStorage,
+    ) -> ProviderResult<StorageProof> {
+        self.inner.storage_proof(address, slot, hashed_storage)
+    }
+
+    fn storage_multiproof(
+        &self,
+        address: Address,
+        slots: &[B256],
+        hashed_storage: HashedStorage,
+    ) -> ProviderResult<StorageMultiProof> {
+        self.inner
+            .storage_multiproof(address, slots, hashed_storage)
+    }
+}
+
+impl StateProofProvider for InstrumentedRingOverlayProvider<'_> {
+    fn proof(
+        &self,
+        input: TrieInput,
+        address: Address,
+        slots: &[B256],
+    ) -> ProviderResult<AccountProof> {
+        self.inner.proof(input, address, slots)
+    }
+
+    fn multiproof(
+        &self,
+        input: TrieInput,
+        targets: MultiProofTargets,
+    ) -> ProviderResult<MultiProof> {
+        self.inner.multiproof(input, targets)
+    }
+
+    fn witness(
+        &self,
+        input: TrieInput,
+        target: HashedPostState,
+        mode: ExecutionWitnessMode,
+    ) -> ProviderResult<Vec<Bytes>> {
+        self.inner.witness(input, target, mode)
+    }
+}
+
+impl HashedPostStateProvider for InstrumentedRingOverlayProvider<'_> {
+    fn hashed_post_state(&self, bundle_state: &BundleState) -> HashedPostState {
+        self.inner.hashed_post_state(bundle_state)
+    }
+}
+
+impl StateRootProvider for InstrumentedRingOverlayProvider<'_> {
+    fn state_root(&self, hashed_state: HashedPostState) -> ProviderResult<B256> {
+        self.inner.state_root(hashed_state)
+    }
+
+    fn state_root_from_nodes(&self, input: TrieInput) -> ProviderResult<B256> {
+        self.inner.state_root_from_nodes(input)
+    }
+
+    fn state_root_with_updates(
+        &self,
+        hashed_state: HashedPostState,
+    ) -> ProviderResult<(B256, TrieUpdates)> {
+        self.inner.state_root_with_updates(hashed_state)
+    }
+
+    fn state_root_from_nodes_with_updates(
+        &self,
+        input: TrieInput,
+    ) -> ProviderResult<(B256, TrieUpdates)> {
+        self.inner.state_root_from_nodes_with_updates(input)
+    }
+}
+
+impl StateProvider for InstrumentedRingOverlayProvider<'_> {
+    fn storage(
+        &self,
+        address: Address,
+        storage_key: StorageKey,
+    ) -> ProviderResult<Option<StorageValue>> {
+        let started_at = Instant::now();
+        for block in &self.in_memory {
+            if let Some(value) = block.execution_output.storage(&address, storage_key.into()) {
+                record_state_read("storage", "ring_overlay", started_at);
+                return Ok(Some(value));
+            }
+        }
+
+        let value = self.historical.storage(address, storage_key)?;
+        record_state_read("storage", "historical_provider", started_at);
+        Ok(value)
+    }
+}
+
 struct CoalescedExecProvider<'a> {
     /// DB anchor for value fallthrough (a `LatestStateProviderRef` over the pinned RO tx).
     historical: Box<dyn StateProvider + 'a>,
@@ -596,9 +914,17 @@ impl BlockHashReader for CoalescedExecProvider<'_> {
 
 impl AccountReader for CoalescedExecProvider<'_> {
     fn basic_account(&self, address: &Address) -> ProviderResult<Option<Account>> {
+        let started_at = Instant::now();
         let v = match self.accounts.get(address) {
-            Some(a) => *a,
-            None => self.historical.basic_account(address)?,
+            Some(a) => {
+                record_state_read("account", "coalesced", started_at);
+                *a
+            }
+            None => {
+                let account = self.historical.basic_account(address)?;
+                record_state_read("account", "historical_provider", started_at);
+                account
+            }
         };
         if self.shadow {
             let want = self.inner.basic_account(address)?;
@@ -615,7 +941,11 @@ impl BytecodeReader for CoalescedExecProvider<'_> {
 }
 
 impl StorageRootProvider for CoalescedExecProvider<'_> {
-    fn storage_root(&self, address: Address, hashed_storage: HashedStorage) -> ProviderResult<B256> {
+    fn storage_root(
+        &self,
+        address: Address,
+        hashed_storage: HashedStorage,
+    ) -> ProviderResult<B256> {
         self.inner.storage_root(address, hashed_storage)
     }
     fn storage_proof(
@@ -632,7 +962,8 @@ impl StorageRootProvider for CoalescedExecProvider<'_> {
         slots: &[B256],
         hashed_storage: HashedStorage,
     ) -> ProviderResult<StorageMultiProof> {
-        self.inner.storage_multiproof(address, slots, hashed_storage)
+        self.inner
+            .storage_multiproof(address, slots, hashed_storage)
     }
 }
 
@@ -695,10 +1026,21 @@ impl StateProvider for CoalescedExecProvider<'_> {
         account: Address,
         storage_key: StorageKey,
     ) -> ProviderResult<Option<StorageValue>> {
+        let started_at = Instant::now();
         let v = match self.storage.get(&(account, storage_key)) {
-            Some(val) => Some(*val),
-            None if self.known.contains(&account) => Some(StorageValue::ZERO),
-            None => self.historical.storage(account, storage_key)?,
+            Some(val) => {
+                record_state_read("storage", "coalesced", started_at);
+                Some(*val)
+            }
+            None if self.known.contains(&account) => {
+                record_state_read("storage", "coalesced", started_at);
+                Some(StorageValue::ZERO)
+            }
+            None => {
+                let value = self.historical.storage(account, storage_key)?;
+                record_state_read("storage", "historical_provider", started_at);
+                value
+            }
         };
         if self.shadow {
             let want = self.inner.storage(account, storage_key)?;
@@ -727,9 +1069,10 @@ where
     loop {
         // committed to DB?
         if let Ok(best) = provider.best_block_number()
-            && best >= bn {
-                return true;
-            }
+            && best >= bn
+        {
+            return true;
+        }
         // canonical in memory (not yet persisted)?
         let head = canonical.get_canonical_head();
         if head.header().number >= bn && head.hash() == expected_hash {
@@ -829,10 +1172,20 @@ pub struct ArbAppliedMessageTiming {
     pub block_execution: Duration,
     /// Block-builder creation, pre-execution changes, and base-fee setup before the first tx.
     pub block_execution_setup: Duration,
+    /// Construction of ArbOS's mandatory internal start-block transaction.
+    pub block_start_block_transaction_construction: Duration,
     /// Execution of ArbOS's mandatory internal start-block transaction.
     pub block_start_block_transaction: Duration,
     /// Execution of derived user and retry transactions, including retry scheduling.
     pub block_derived_transactions: Duration,
+    /// Derived transaction execution and commit work, excluding retry scheduling.
+    pub block_derived_transaction_execution: Duration,
+    /// Extraction and enqueueing of retries emitted by successful derived transactions.
+    pub block_derived_retry_scheduling: Duration,
+    /// Small remainder after named derived-transaction phases, kept for exact accounting.
+    pub block_derived_transactions_unattributed: Duration,
+    /// Small remainder after the named block-execution phases, kept to make the breakdown exact.
+    pub block_execution_unattributed: Duration,
     /// State-root computation plus final block and header construction.
     pub block_finish: Duration,
     /// Sending the executed block to the engine tree.
@@ -853,8 +1206,13 @@ struct ArbBlockProductionTiming {
     state_setup: Duration,
     execution: Duration,
     execution_setup: Duration,
+    start_block_transaction_construction: Duration,
     start_block_transaction: Duration,
     derived_transactions: Duration,
+    derived_transaction_execution: Duration,
+    derived_retry_scheduling: Duration,
+    derived_transactions_unattributed: Duration,
+    execution_unattributed: Duration,
     finish: Duration,
 }
 
@@ -918,6 +1276,16 @@ where
     coalesce_overlay: bool,
     /// `ARB_COALESCE_SHADOW=1`: when coalescing, assert each value read equals reth's overlay walk.
     coalesce_shadow: bool,
+    /// Cross-block account/storage/bytecode cache used by the execution provider. This is updated
+    /// from each canonical block's final `BundleState`, so it always represents `execution_cache_tip`.
+    execution_cache: ExecutionCache,
+    execution_cache_tip: B256,
+    execution_cache_enabled: bool,
+    /// Retained sparse-trie pipeline for the direct feed driver. It streams transaction state
+    /// updates during execution and preserves revealed trie nodes across the linear chain.
+    state_root_processor: PayloadProcessor<ArbEvmConfig>,
+    state_root_config: TreeConfig,
+    sparse_state_root_mode: SparseStateRootMode,
     /// reth's native "ring" for the parallel/overlay path: resolves the (trie + hashed) overlay for
     /// the unpersisted blocks between the persisted anchor and the parent. Kept in lockstep with
     /// `ring` (insert on produce, remove on persist). Only populated when `shadow_stateroot` is on.
@@ -995,6 +1363,22 @@ where
         let coalesce_shadow = std::env::var("ARB_COALESCE_SHADOW")
             .map(|v| matches!(v.as_str(), "1" | "true" | "on" | "yes"))
             .unwrap_or(false);
+        // The engine tree owns a separate cache for its validation/payload paths. The direct
+        // feed driver does not execute through that path, so keep a dedicated sequential cache.
+        // 256 MiB holds roughly 1.8 million storage entries and avoids duplicating reth's 4 GiB
+        // default allocation. Operators can tune it without changing consensus behavior.
+        let execution_cache_enabled = std::env::var("ARB_EXECUTION_CACHE")
+            .map(|v| !matches!(v.as_str(), "0" | "false" | "off" | "no"))
+            .unwrap_or(true);
+        let execution_cache_mb = std::env::var("ARB_EXECUTION_CACHE_MB")
+            .ok()
+            .and_then(|v| v.parse::<usize>().ok())
+            .filter(|&mb| mb > 0)
+            .unwrap_or(256);
+        let execution_cache_bytes = execution_cache_mb.saturating_mul(1024 * 1024);
+        let execution_cache = ExecutionCache::new(execution_cache_bytes);
+        let execution_cache_tip = genesis_tip.hash();
+        let sparse_state_root_mode = SparseStateRootMode::from_env();
 
         // The serial state root only actually runs when parallel is disabled OR the ring overlay is
         // off (parallel is a ring-overlay-only path). Warn loudly while we phase serial out.
@@ -1028,6 +1412,13 @@ where
         let changeset_cache = ChangesetCache::new();
         let driver_changeset_cache = changeset_cache.clone();
         let tree_config = tuning.to_tree_config();
+        let state_root_config = tree_config.clone();
+        let state_root_processor = PayloadProcessor::new(
+            driver_runtime.clone(),
+            evm_config.clone(),
+            &state_root_config,
+            PrecompileCacheMap::default(),
+        );
         tracing::info!(
             target: "arb-reth::engine",
             persistence_threshold = tuning.persistence_threshold,
@@ -1038,6 +1429,9 @@ where
             parallel_stateroot,
             coalesce_overlay,
             coalesce_shadow,
+            execution_cache_enabled,
+            execution_cache_mb,
+            ?sparse_state_root_mode,
             "engine-tree persistence tuning",
         );
 
@@ -1112,6 +1506,12 @@ where
             parallel_stateroot,
             coalesce_overlay,
             coalesce_shadow,
+            execution_cache,
+            execution_cache_tip,
+            execution_cache_enabled,
+            state_root_processor,
+            state_root_config,
+            sparse_state_root_mode,
             state_trie_overlays,
             provider_factory: driver_factory,
             changeset_cache: driver_changeset_cache,
@@ -1124,9 +1524,24 @@ where
     /// Build the two parent-state providers and produce one block. Selects the immune ring overlay
     /// (`--ring-overlay`) or the legacy `state_by_block_hash(parent)` path.
     fn build_block(
-        &self,
+        &mut self,
         msg: &BroadcastFeedMessage,
-    ) -> eyre::Result<(BuiltPayloadExecutedBlock<ArbPrimitives>, ArbBlockProductionTiming)> {
+    ) -> eyre::Result<(
+        BuiltPayloadExecutedBlock<ArbPrimitives>,
+        ArbBlockProductionTiming,
+    )> {
+        // A discontinuity can only happen on restart/reorg today, but the hash guard makes stale
+        // cached values impossible if another caller changes the driver's tip in the future.
+        if self.execution_cache_enabled && self.execution_cache_tip != self.tip.hash() {
+            tracing::warn!(
+                target: "arb-reth::engine",
+                cache_tip = %self.execution_cache_tip,
+                parent = %self.tip.hash(),
+                "execution cache tip mismatch; clearing cache",
+            );
+            self.execution_cache.clear();
+            self.execution_cache_tip = self.tip.hash();
+        }
         let started_at = Instant::now();
         if self.ring_overlay {
             // Pin one MDBX RO tx: read the persisted tip and the immune latest state from the same
@@ -1169,7 +1584,8 @@ where
                 Box::new(LatestStateProviderRef::new(&db_ro));
             let trie_hist: Box<dyn StateProvider + '_> =
                 Box::new(LatestStateProviderRef::new(&db_ro));
-            let exec_overlay = MemoryOverlayStateProviderRef::new(exec_hist, ring_vec.clone()).boxed();
+            let exec_overlay =
+                MemoryOverlayStateProviderRef::new(exec_hist, ring_vec.clone()).boxed();
             // Coalesced exec provider (opt-in): flatten the ring for O(1) value reads over the same
             // pinned anchor; falls through to the DB on a miss, exactly like the overlay walk.
             let exec_sp: Box<dyn StateProvider + '_> = if self.coalesce_overlay {
@@ -1183,13 +1599,19 @@ where
                     shadow: self.coalesce_shadow,
                 })
             } else {
-                exec_overlay
+                Box::new(InstrumentedRingOverlayProvider {
+                    historical: Box::new(LatestStateProviderRef::new(&db_ro)),
+                    inner: exec_overlay,
+                    in_memory: ring_vec.clone(),
+                })
             };
             let trie_sp = MemoryOverlayStateProviderRef::new(trie_hist, ring_vec).boxed();
             // Parallel state-root mode: wrap the trie provider so `finish`'s
             // `state_root_with_updates` runs in parallel and DRIVES the block. Exec provider is
             // left untouched. Off = the serial `finish` path exactly as before.
-            let trie_sp: Box<dyn StateProvider + '_> = if self.parallel_stateroot {
+            let trie_sp: Box<dyn StateProvider + '_> = if self.parallel_stateroot
+                && self.sparse_state_root_mode != SparseStateRootMode::Drive
+            {
                 Box::new(ParallelRootProvider {
                     inner: trie_sp,
                     provider_factory: self.provider_factory.clone(),
@@ -1201,6 +1623,40 @@ where
             } else {
                 trie_sp
             };
+            let sparse_state_root = if self.sparse_state_root_mode == SparseStateRootMode::Off {
+                None
+            } else {
+                let overlay_builder =
+                    OverlayBuilder::new(self.tip.hash(), self.changeset_cache.clone())
+                        .with_state_trie_overlay_manager(self.state_trie_overlays.clone());
+                let overlay_factory = OverlayStateProviderFactory::new(
+                    self.provider_factory.clone(),
+                    overlay_builder,
+                );
+                Some((
+                    self.state_root_processor.spawn_state_root(
+                        overlay_factory,
+                        self.tip.header().state_root,
+                        false,
+                        &self.state_root_config,
+                        None,
+                    ),
+                    self.sparse_state_root_mode,
+                ))
+            };
+            let cache_stats = self
+                .execution_cache_enabled
+                .then(|| Arc::new(CacheStats::default()));
+            let exec_sp: Box<dyn StateProvider + '_> = match &cache_stats {
+                Some(stats) => Box::new(CachedStateProvider::new_with_mode(
+                    exec_sp,
+                    self.execution_cache.clone(),
+                    CacheFillMode::FillOnMiss,
+                    None,
+                    Some(Arc::clone(stats)),
+                )),
+                None => exec_sp,
+            };
             let (built, mut timing) = produce_with_timing(
                 &self.evm_config,
                 self.chain_id,
@@ -1208,10 +1664,14 @@ where
                 msg,
                 exec_sp,
                 trie_sp,
+                sparse_state_root,
             )?;
-            timing.parent_state = started_at
-                .elapsed()
-                .saturating_sub(timing.message_preparation + timing.state_setup + timing.execution + timing.finish);
+            if let Some(stats) = cache_stats {
+                record_execution_cache_stats(&stats);
+            }
+            timing.parent_state = started_at.elapsed().saturating_sub(
+                timing.message_preparation + timing.state_setup + timing.execution + timing.finish,
+            );
             // Zero-risk probe: also compute the root in parallel and assert it equals the serial
             // one just produced (serial still drives the chain). No-op unless ARB_SHADOW_STATEROOT
             // is set.
@@ -1226,6 +1686,19 @@ where
                 .provider
                 .state_by_block_hash(self.tip.hash())
                 .wrap_err("state_by_block_hash (trie) failed")?;
+            let cache_stats = self
+                .execution_cache_enabled
+                .then(|| Arc::new(CacheStats::default()));
+            let exec_sp: Box<dyn StateProvider + '_> = match &cache_stats {
+                Some(stats) => Box::new(CachedStateProvider::new_with_mode(
+                    exec_sp,
+                    self.execution_cache.clone(),
+                    CacheFillMode::FillOnMiss,
+                    None,
+                    Some(Arc::clone(stats)),
+                )),
+                None => exec_sp,
+            };
             let (built, mut timing) = produce_with_timing(
                 &self.evm_config,
                 self.chain_id,
@@ -1233,10 +1706,14 @@ where
                 msg,
                 exec_sp,
                 trie_sp,
+                None,
             )?;
-            timing.parent_state = started_at
-                .elapsed()
-                .saturating_sub(timing.message_preparation + timing.state_setup + timing.execution + timing.finish);
+            if let Some(stats) = cache_stats {
+                record_execution_cache_stats(&stats);
+            }
+            timing.parent_state = started_at.elapsed().saturating_sub(
+                timing.message_preparation + timing.state_setup + timing.execution + timing.finish,
+            );
             Ok((built, timing))
         }
     }
@@ -1321,28 +1798,36 @@ where
         // Mirror the block into reth's overlay manager (the parallel/shadow root path reads it),
         // in lockstep with `ring`. Only when shadowing or driving the parallel root, to avoid its
         // cache work otherwise.
-        if self.shadow_stateroot || self.parallel_stateroot {
+        if self.shadow_stateroot
+            || self.parallel_stateroot
+            || self.sparse_state_root_mode != SparseStateRootMode::Off
+        {
             self.state_trie_overlays.insert_block(exec.clone());
         }
         self.ring.push_back(exec);
         // Prune everything at/below the persisted (on-disk) tip. Use the RO provider's tip, not
         // `BlockchainProvider::best_block_number` (that's the in-memory canonical tip).
         if let Ok(db_ro) = self.provider.database_provider_ro()
-            && let Ok(persisted) = db_ro.best_block_number() {
-                let mut pruned: Vec<B256> = Vec::new();
-                while self
-                    .ring
-                    .front()
-                    .is_some_and(|b| b.recovered_block.header().number <= persisted)
-                {
-                    if let Some(b) = self.ring.pop_front() {
-                        pruned.push(b.recovered_block.hash());
-                    }
-                }
-                if (self.shadow_stateroot || self.parallel_stateroot) && !pruned.is_empty() {
-                    self.state_trie_overlays.remove_blocks(pruned);
+            && let Ok(persisted) = db_ro.best_block_number()
+        {
+            let mut pruned: Vec<B256> = Vec::new();
+            while self
+                .ring
+                .front()
+                .is_some_and(|b| b.recovered_block.header().number <= persisted)
+            {
+                if let Some(b) = self.ring.pop_front() {
+                    pruned.push(b.recovered_block.hash());
                 }
             }
+            if (self.shadow_stateroot
+                || self.parallel_stateroot
+                || self.sparse_state_root_mode != SparseStateRootMode::Off)
+                && !pruned.is_empty()
+            {
+                self.state_trie_overlays.remove_blocks(pruned);
+            }
+        }
     }
 
     /// Produce, insert, and canonicalize one block from a feed message.
@@ -1415,6 +1900,7 @@ where
         let new_hash = built.recovered_block.hash();
         let new_header = built.recovered_block.header().clone();
         let new_number = new_header.number;
+        let execution_output = Arc::clone(&built.execution_output);
         let block_production = started_at.elapsed();
 
         // Ring bookkeeping (no-op unless `--ring-overlay`): record this block as an unpersisted
@@ -1473,6 +1959,27 @@ where
         let canonicalization_wait = phase_started_at.elapsed();
         let total = started_at.elapsed();
 
+        // Source-independent production timings. The feed-latency recorder only observes messages
+        // seen on the websocket and therefore intentionally omits L1-derived catch-up blocks.
+        // These histograms cover every canonical block and are the stable benchmark surface for
+        // execution/cache/state-root work.
+        metrics::histogram!("arb_reth.engine_block_production_seconds")
+            .record(block_production.as_secs_f64());
+        metrics::histogram!("arb_reth.engine_block_parent_state_seconds")
+            .record(production_timing.parent_state.as_secs_f64());
+        metrics::histogram!("arb_reth.engine_block_execution_seconds")
+            .record(production_timing.execution.as_secs_f64());
+        metrics::histogram!("arb_reth.engine_block_finish_seconds")
+            .record(production_timing.finish.as_secs_f64());
+        metrics::histogram!("arb_reth.engine_block_total_seconds").record(total.as_secs_f64());
+        let production_seconds = block_production.as_secs_f64();
+        let mgas_per_second = if production_seconds > 0.0 {
+            new_header.gas_used as f64 / 1_000_000.0 / production_seconds
+        } else {
+            0.0
+        };
+        metrics::histogram!("arb_reth.engine_block_mgas_per_second").record(mgas_per_second);
+
         // Per-block production trace (observability) + per-phase timing breakdown.
         tracing::info!(
             target: "arb-reth::engine",
@@ -1494,6 +2001,25 @@ where
         );
 
         self.tip = SealedHeader::new(new_header, new_hash);
+        if self.execution_cache_enabled {
+            let cache_update_started_at = Instant::now();
+            if self
+                .execution_cache
+                .insert_state(&execution_output.state)
+                .is_err()
+            {
+                tracing::warn!(
+                    target: "arb-reth::engine",
+                    number = new_number,
+                    "inconsistent execution-cache update; clearing cache",
+                );
+                self.execution_cache.clear();
+            }
+            self.execution_cache_tip = new_hash;
+            let cache_update_seconds = cache_update_started_at.elapsed().as_secs_f64();
+            metrics::histogram!("arb_reth.execution_cache_update_seconds")
+                .record(cache_update_seconds);
+        }
         Ok((
             new_hash,
             ArbAppliedMessageTiming {
@@ -1504,8 +2030,16 @@ where
                 block_state_setup: production_timing.state_setup,
                 block_execution: production_timing.execution,
                 block_execution_setup: production_timing.execution_setup,
+                block_start_block_transaction_construction: production_timing
+                    .start_block_transaction_construction,
                 block_start_block_transaction: production_timing.start_block_transaction,
                 block_derived_transactions: production_timing.derived_transactions,
+                block_derived_transaction_execution: production_timing
+                    .derived_transaction_execution,
+                block_derived_retry_scheduling: production_timing.derived_retry_scheduling,
+                block_derived_transactions_unattributed: production_timing
+                    .derived_transactions_unattributed,
+                block_execution_unattributed: production_timing.execution_unattributed,
                 block_finish: production_timing.finish,
                 engine_insert,
                 engine_forkchoice,
@@ -1534,9 +2068,10 @@ where
         let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
         loop {
             if let Ok(best) = self.provider.best_block_number()
-                && best >= target {
-                    return;
-                }
+                && best >= target
+            {
+                return;
+            }
             if std::time::Instant::now() >= deadline {
                 return;
             }

--- a/crates/arb-reth-engine/src/engine.rs
+++ b/crates/arb-reth-engine/src/engine.rs
@@ -29,6 +29,7 @@ use arb_revm::executor::{
 };
 use arbitrum_alloy_sequencer::sequencer::feed::BroadcastFeedMessage;
 use eyre::{WrapErr as _, eyre};
+use std::time::{Duration, Instant};
 
 use reth_chain_state::{
     CanonicalInMemoryState, ComputedTrieData, ExecutedBlock, MemoryOverlayStateProviderRef,
@@ -95,6 +96,31 @@ pub fn produce<'a>(
     exec_state_provider: Box<dyn StateProvider + 'a>,
     trie_state_provider: Box<dyn StateProvider + 'a>,
 ) -> eyre::Result<BuiltPayloadExecutedBlock<ArbPrimitives>> {
+    Ok(
+        produce_with_timing(
+            evm_config,
+            chain_id,
+            parent,
+            feed_msg,
+            exec_state_provider,
+            trie_state_provider,
+        )?
+        .0,
+    )
+}
+
+/// Produce one block and retain a breakdown of the local block-production work.
+///
+/// Kept private so the public [`produce`] helper remains the small, stable test-facing API.
+fn produce_with_timing<'a>(
+    evm_config: &ArbEvmConfig,
+    chain_id: u64,
+    parent: &SealedHeader<Header>,
+    feed_msg: &BroadcastFeedMessage,
+    exec_state_provider: Box<dyn StateProvider + 'a>,
+    trie_state_provider: Box<dyn StateProvider + 'a>,
+) -> eyre::Result<(BuiltPayloadExecutedBlock<ArbPrimitives>, ArbBlockProductionTiming)> {
+    let started_at = Instant::now();
     let parent_header = parent.header();
     let version = arbitrum_alloy_consensus::header::ArbHeaderInfo::decode_header(parent_header)
         .map(|i| i.arbos_format_version as u8)
@@ -130,8 +156,7 @@ pub fn produce<'a>(
         withdrawals: None,
     };
 
-    // Bench sub-timing: overlay build vs execution vs state-root `finish`.
-    let __ov0 = std::time::Instant::now();
+    let phase_started_at = Instant::now();
 
     // `exec_state_provider` / `trie_state_provider` are supplied by the caller and must be
     // independent instances (sharing one corrupts execution reads vs the trie build). The caller
@@ -141,8 +166,9 @@ pub fn produce<'a>(
         .with_bundle_update()
         .build();
 
-    let __us_overlay = __ov0.elapsed().as_micros();
-    let __ex0 = std::time::Instant::now();
+    let state_setup = phase_started_at.elapsed();
+    let message_preparation = started_at.elapsed().saturating_sub(state_setup);
+    let phase_started_at = Instant::now();
 
     let mut builder = evm_config
         .builder_for_next_block(&mut state, parent, attrs)
@@ -232,21 +258,14 @@ pub fn produce<'a>(
         }
     }
 
-    let __us_exec = __ex0.elapsed().as_micros();
-    let __fi0 = std::time::Instant::now();
+    let execution = phase_started_at.elapsed();
+    let phase_started_at = Instant::now();
 
     let outcome = builder
         .finish(trie_state_provider, None)
         .wrap_err("BlockBuilder::finish failed")?;
 
-    tracing::debug!(
-        target: "arb-reth::engine::timing",
-        block = parent_header.number + 1,
-        us_overlay = __us_overlay as u64,
-        us_exec = __us_exec as u64,
-        us_finish = __fi0.elapsed().as_micros() as u64,
-        "produce timing",
-    );
+    let finish = phase_started_at.elapsed();
 
     let bundle = state.take_bundle();
     drop(state);
@@ -263,12 +282,21 @@ pub fn produce<'a>(
     });
 
     // BuiltPayloadExecutedBlock wants unsorted hashed_state / trie_updates.
-    Ok(BuiltPayloadExecutedBlock {
-        recovered_block: Arc::new(recovered_block),
-        execution_output,
-        hashed_state: Arc::new(outcome.hashed_state),
-        trie_updates: Arc::new(outcome.trie_updates),
-    })
+    Ok((
+        BuiltPayloadExecutedBlock {
+            recovered_block: Arc::new(recovered_block),
+            execution_output,
+            hashed_state: Arc::new(outcome.hashed_state),
+            trie_updates: Arc::new(outcome.trie_updates),
+        },
+        ArbBlockProductionTiming {
+            parent_state: Duration::ZERO,
+            message_preparation,
+            state_setup,
+            execution,
+            finish,
+        },
+    ))
 }
 
 /// A [`StateProvider`] that wraps the ring-overlay trie provider and overrides only the
@@ -760,6 +788,47 @@ impl ArbEngineTuning {
     }
 }
 
+/// Timings for one message that produced a canonical block.
+///
+/// `block_production` includes ArbOS execution, state-root computation, and header sealing.
+/// The other fields cover the engine-tree handoff through in-memory canonicalization. Persistence
+/// to MDBX remains asynchronous and is intentionally outside this critical-path measurement.
+#[derive(Debug, Clone, Copy)]
+pub struct ArbAppliedMessageTiming {
+    /// Instant immediately before block production begins.
+    pub started_at: Instant,
+    /// Execution, state-root computation, and block/header construction.
+    pub block_production: Duration,
+    /// Parent-state provider setup before `produce` begins.
+    pub block_parent_state: Duration,
+    /// Feed-message digesting and next-block environment construction.
+    pub block_message_preparation: Duration,
+    /// Creation of revm's journaled state over the parent provider.
+    pub block_state_setup: Duration,
+    /// ArbOS pre-execution and transaction execution.
+    pub block_execution: Duration,
+    /// State-root computation plus final block and header construction.
+    pub block_finish: Duration,
+    /// Sending the executed block to the engine tree.
+    pub engine_insert: Duration,
+    /// Forkchoice request and response from the engine tree.
+    pub engine_forkchoice: Duration,
+    /// Waiting for the shared canonical in-memory state to observe the new head.
+    pub canonicalization_wait: Duration,
+    /// Total time in the in-order apply path.
+    pub total: Duration,
+}
+
+/// Breakdown of local work performed while producing an Arbitrum block.
+#[derive(Debug, Clone, Copy)]
+struct ArbBlockProductionTiming {
+    parent_state: Duration,
+    message_preparation: Duration,
+    state_setup: Duration,
+    execution: Duration,
+    finish: Duration,
+}
+
 /// Engine-tree driver for `ArbNode`.
 ///
 /// Owns the tree's request sender, the current tip, and a receiver of canonicalization
@@ -1028,7 +1097,8 @@ where
     fn build_block(
         &self,
         msg: &BroadcastFeedMessage,
-    ) -> eyre::Result<BuiltPayloadExecutedBlock<ArbPrimitives>> {
+    ) -> eyre::Result<(BuiltPayloadExecutedBlock<ArbPrimitives>, ArbBlockProductionTiming)> {
+        let started_at = Instant::now();
         if self.ring_overlay {
             // Pin one MDBX RO tx: read the persisted tip and the immune latest state from the same
             // tx so the state-root path's historical anchor sits exactly at `persisted_tip` (the
@@ -1102,7 +1172,7 @@ where
             } else {
                 trie_sp
             };
-            let built = produce(
+            let (built, mut timing) = produce_with_timing(
                 &self.evm_config,
                 self.chain_id,
                 &self.tip,
@@ -1110,11 +1180,14 @@ where
                 exec_sp,
                 trie_sp,
             )?;
+            timing.parent_state = started_at
+                .elapsed()
+                .saturating_sub(timing.message_preparation + timing.state_setup + timing.execution + timing.finish);
             // Zero-risk probe: also compute the root in parallel and assert it equals the serial
             // one just produced (serial still drives the chain). No-op unless ARB_SHADOW_STATEROOT
             // is set.
             self.shadow_compare(&built);
-            Ok(built)
+            Ok((built, timing))
         } else {
             let exec_sp = self
                 .provider
@@ -1124,14 +1197,18 @@ where
                 .provider
                 .state_by_block_hash(self.tip.hash())
                 .wrap_err("state_by_block_hash (trie) failed")?;
-            produce(
+            let (built, mut timing) = produce_with_timing(
                 &self.evm_config,
                 self.chain_id,
                 &self.tip,
                 msg,
                 exec_sp,
                 trie_sp,
-            )
+            )?;
+            timing.parent_state = started_at
+                .elapsed()
+                .saturating_sub(timing.message_preparation + timing.state_setup + timing.execution + timing.finish);
+            Ok((built, timing))
         }
     }
 
@@ -1248,6 +1325,20 @@ where
     /// applies it if it is the next expected message, or buffers it as feed-ahead otherwise; after
     /// applying, drains any now-contiguous buffered messages. Returns the resulting head hash.
     pub async fn advance(&mut self, msg: &BroadcastFeedMessage) -> eyre::Result<B256> {
+        self.advance_with_applied(msg, |_, _| {}).await
+    }
+
+    /// Like [`Self::advance`], while notifying the caller after each message has become the
+    /// canonical in-memory head. This includes buffered feed-ahead messages drained after a gap
+    /// closes, and deliberately excludes duplicate messages that were not applied.
+    pub async fn advance_with_applied<F>(
+        &mut self,
+        msg: &BroadcastFeedMessage,
+        mut on_applied: F,
+    ) -> eyre::Result<B256>
+    where
+        F: FnMut(u64, ArbAppliedMessageTiming),
+    {
         const MAX_PENDING: usize = 50_000;
         let seq = msg.sequence_number;
         if seq < self.next_seq {
@@ -1262,10 +1353,13 @@ where
             return Ok(self.tip.hash());
         }
         // seq == next_seq: this is the next block. Apply it, then drain the buffer forward.
-        let mut hash = self.apply_one(msg).await?;
+        let (mut hash, timing) = self.apply_one(msg).await?;
+        on_applied(seq, timing);
         self.next_seq += 1;
         while let Some(buffered) = self.pending.remove(&self.next_seq) {
-            hash = self.apply_one(&buffered).await?;
+            let (new_hash, timing) = self.apply_one(&buffered).await?;
+            hash = new_hash;
+            on_applied(self.next_seq, timing);
             self.next_seq += 1;
         }
         // Discard any stragglers now below the cursor (a feed dup that lost the race to L1).
@@ -1276,9 +1370,11 @@ where
     /// Apply exactly one in-order message: build the next block from `self.tip`, insert it into the
     /// engine tree, canonicalize, and advance `self.tip`. [`Self::advance`]'s sequence guard ensures
     /// this is only called for the message that produces `tip + 1`.
-    async fn apply_one(&mut self, msg: &BroadcastFeedMessage) -> eyre::Result<B256> {
-        use std::time::Instant;
-        let __t0 = Instant::now();
+    async fn apply_one(
+        &mut self,
+        msg: &BroadcastFeedMessage,
+    ) -> eyre::Result<(B256, ArbAppliedMessageTiming)> {
+        let started_at = Instant::now();
 
         // Legacy path (`ring_overlay=false`): `produce` reads parent state via
         // `provider.state_by_block_hash(parent)`, which snapshots the tree overlay + the DB
@@ -1286,11 +1382,11 @@ where
         // deep-buffer failures with a retry: some torn reads mis-execute without erroring, baking a
         // wrong root into the chain. The `--ring-overlay` path reads from the driver-held ring over
         // the immune latest provider and is not raced by persistence.
-        let built = self.build_block(msg)?;
+        let (built, production_timing) = self.build_block(msg)?;
         let new_hash = built.recovered_block.hash();
         let new_header = built.recovered_block.header().clone();
         let new_number = new_header.number;
-        let __us_produce = __t0.elapsed().as_micros();
+        let block_production = started_at.elapsed();
 
         // Ring bookkeeping (no-op unless `--ring-overlay`): record this block as an unpersisted
         // parent for the next `build_block`, and prune what the DB has since persisted. Must run
@@ -1298,16 +1394,16 @@ where
         self.maintain_ring(&built);
 
         // Feed the executed block to the tree (no re-execution).
-        let __t = Instant::now();
+        let phase_started_at = Instant::now();
         self.to_tree
             .send(FromEngine::Request(EngineApiRequest::InsertExecutedBlock(
                 built,
             )))
             .map_err(|e| eyre!("send InsertExecutedBlock: {e}"))?;
-        let __us_insert = __t.elapsed().as_micros();
+        let engine_insert = phase_started_at.elapsed();
 
         // Drive canonicalization via ForkchoiceUpdated (head = new block).
-        let __t = Instant::now();
+        let phase_started_at = Instant::now();
         let (fcu_tx, fcu_rx) = tokio::sync::oneshot::channel();
         let fcu_state = alloy_rpc_types_engine::ForkchoiceState {
             head_block_hash: new_hash,
@@ -1328,10 +1424,10 @@ where
         fcu_res
             .await
             .map_err(|e| eyre!("block {new_number} FCU error: {e:?}"))?;
-        let __us_fcu = __t.elapsed().as_micros();
+        let engine_forkchoice = phase_started_at.elapsed();
 
         // Wait for the tree to actually canonicalize the block (bounded).
-        let __t = Instant::now();
+        let phase_started_at = Instant::now();
         let canonicalized = wait_for_head(
             &self.provider,
             &self.provider.canonical_in_memory_state(),
@@ -1345,7 +1441,8 @@ where
                 "block {new_number} was NOT canonicalized within timeout (head hash {new_hash:#x})"
             ));
         }
-        let __us_wait = __t.elapsed().as_micros();
+        let canonicalization_wait = phase_started_at.elapsed();
+        let total = started_at.elapsed();
 
         // Per-block production trace (observability) + per-phase timing breakdown.
         tracing::info!(
@@ -1359,16 +1456,31 @@ where
         tracing::debug!(
             target: "arb-reth::engine::timing",
             number = new_number,
-            us_produce = __us_produce,
-            us_insert = __us_insert,
-            us_fcu = __us_fcu,
-            us_wait = __us_wait,
-            us_total = __t0.elapsed().as_micros(),
+            us_produce = block_production.as_micros(),
+            us_insert = engine_insert.as_micros(),
+            us_fcu = engine_forkchoice.as_micros(),
+            us_wait = canonicalization_wait.as_micros(),
+            us_total = total.as_micros(),
             "advance timing",
         );
 
         self.tip = SealedHeader::new(new_header, new_hash);
-        Ok(new_hash)
+        Ok((
+            new_hash,
+            ArbAppliedMessageTiming {
+                started_at,
+                block_production,
+                block_parent_state: production_timing.parent_state,
+                block_message_preparation: production_timing.message_preparation,
+                block_state_setup: production_timing.state_setup,
+                block_execution: production_timing.execution,
+                block_finish: production_timing.finish,
+                engine_insert,
+                engine_forkchoice,
+                canonicalization_wait,
+                total,
+            },
+        ))
     }
 
     /// Returns the current chain tip (the parent for the next block).

--- a/crates/arb-reth-engine/src/lib.rs
+++ b/crates/arb-reth-engine/src/lib.rs
@@ -23,7 +23,7 @@ use arbitrum_alloy_consensus::reth::{ArbBlock, ArbPrimitives};
 pub mod engine;
 pub mod engine_spike;
 
-pub use engine::{produce, wait_for_head, ArbEngineDriver, ArbEngineTuning};
+pub use engine::{produce, wait_for_head, ArbAppliedMessageTiming, ArbEngineDriver, ArbEngineTuning};
 pub use engine_spike::ArbPayloadValidator;
 
 /// A minimal built-payload stub for Arbitrum.

--- a/crates/arb-reth-evm/Cargo.toml
+++ b/crates/arb-reth-evm/Cargo.toml
@@ -9,7 +9,7 @@ authors.workspace = true
 # extension points. See docs/arb-reth-roadmap.md.
 
 [dependencies]
-arb-revm = { git = "https://github.com/nuntax/arbitrum-revm", rev = "96f826bfb531fc13f8337db584abfe1e6baaee4f", features = ["stylus"] } # pure revm/ArbOS; stylus feature is self-contained (vendors Nitro's wasmer)
+arb-revm = { git = "https://github.com/nuntax/arbitrum-revm", rev = "e5b83cecdda6321e72893a83a616e1f9981e1a5a", features = ["stylus"] } # pure revm/ArbOS; stylus feature is self-contained (vendors Nitro's wasmer)
 revm = { workspace = true }
 
 # Arbitrum consensus primitives (ArbTxEnvelope, ArbReceiptEnvelope, ArbHeaderInfo). reth-trait

--- a/crates/arb-reth-evm/Cargo.toml
+++ b/crates/arb-reth-evm/Cargo.toml
@@ -9,7 +9,7 @@ authors.workspace = true
 # extension points. See docs/arb-reth-roadmap.md.
 
 [dependencies]
-arb-revm = { git = "https://github.com/nuntax/arbitrum-revm", rev = "dd05d8abf79c7d5436ab6bf7bd6d979bee0bba5e", features = ["stylus"] } # pure revm/ArbOS; stylus feature is self-contained (vendors Nitro's wasmer)
+arb-revm = { git = "https://github.com/nuntax/arbitrum-revm", rev = "96f826bfb531fc13f8337db584abfe1e6baaee4f", features = ["stylus"] } # pure revm/ArbOS; stylus feature is self-contained (vendors Nitro's wasmer)
 revm = { workspace = true }
 
 # Arbitrum consensus primitives (ArbTxEnvelope, ArbReceiptEnvelope, ArbHeaderInfo). reth-trait
@@ -19,6 +19,7 @@ arbitrum-alloy-consensus = { git = "https://github.com/nuntax/arbitrum-alloy", r
 reth-evm = { git = "https://github.com/paradigmxyz/reth.git", rev = "224b087672690ae2ef85ad706bd18f40d8e5b265" }
 alloy-evm = { version = "0.37", default-features = false }
 reth-primitives-traits = { version = "0.5.0", default-features = false }
+metrics = "0.24"
 
 # alloy consensus traits used to lower ArbTxEnvelope into the revm tx env.
 alloy-consensus = { version = "2.0", default-features = false }

--- a/crates/arb-reth-evm/src/block.rs
+++ b/crates/arb-reth-evm/src/block.rs
@@ -225,6 +225,8 @@ where
         // `InternalTxStartBlock` (0x6a) is NOT run here. It is a real block transaction with its
         // own receipt; the caller drives it through `execute_transaction` like any other tx. Running
         // it here would exclude it from the transactions/receipts roots and diverge from Nitro.
+        let execution_histogram =
+            metrics::histogram!("arb_reth.arbos.pre_execution_system_call_seconds");
         let started_at = Instant::now();
         let result = self
             .evm
@@ -233,8 +235,8 @@ where
                 HISTORY_STORAGE_ADDRESS,
                 Bytes::copy_from_slice(self.ctx.parent_hash.as_slice()),
             );
-        metrics::histogram!("arb_reth.arbos.pre_execution_system_call_seconds")
-            .record(started_at.elapsed().as_secs_f64());
+        let execution_seconds = started_at.elapsed().as_secs_f64();
+        execution_histogram.record(execution_seconds);
         let result = result.map_err(|err| BlockExecutionError::evm(err, self.ctx.parent_hash))?;
         self.evm.db_mut().commit(result.state);
 
@@ -249,15 +251,16 @@ where
         let tx_type = tx.tx().ty();
         let tx_type_label = tx_type_label(tx_type);
 
+        let execution_histogram = metrics::histogram!(
+            "arb_reth.arbos.transaction_execution_seconds",
+            "tx_type" => tx_type_label,
+        );
         let started_at = Instant::now();
         let result = self
             .evm
             .transact(tx_env);
-        metrics::histogram!(
-            "arb_reth.arbos.transaction_execution_seconds",
-            "tx_type" => tx_type_label,
-        )
-        .record(started_at.elapsed().as_secs_f64());
+        let execution_seconds = started_at.elapsed().as_secs_f64();
+        execution_histogram.record(execution_seconds);
         let result = result.map_err(|err| BlockExecutionError::evm(err, tx.tx().trie_hash()))?;
 
         // `chain().poster_gas` is set by the ArbOS handler during pre_execution; it is the
@@ -272,7 +275,6 @@ where
     }
 
     fn commit_transaction(&mut self, output: Self::Result) -> GasOutput {
-        let started_at = Instant::now();
         let ArbTxResult {
             result: ResultAndState { result, state },
             gas_used_for_l1,
@@ -280,32 +282,49 @@ where
         } = output;
 
         let gas_used = result.tx_gas_used();
-        self.gas_used += gas_used;
+        let tx_type_label = tx_type_label(tx_type);
+        let receipt_histogram = metrics::histogram!(
+            "arb_reth.arbos.transaction_receipt_build_seconds",
+            "tx_type" => tx_type_label,
+        );
+        let state_commit_histogram = metrics::histogram!(
+            "arb_reth.arbos.transaction_state_commit_seconds",
+            "tx_type" => tx_type_label,
+        );
+        let commit_histogram = metrics::histogram!(
+            "arb_reth.arbos.transaction_commit_seconds",
+            "tx_type" => tx_type_label,
+        );
+        let gas_used_histogram = metrics::histogram!(
+            "arb_reth.arbos.transaction_gas_used",
+            "tx_type" => tx_type_label,
+        );
+        let l1_gas_used_histogram = metrics::histogram!(
+            "arb_reth.arbos.transaction_l1_gas_used",
+            "tx_type" => tx_type_label,
+        );
 
+        let started_at = Instant::now();
+        let receipt_started_at = Instant::now();
+        self.gas_used += gas_used;
         self.receipts.push(build_arb_receipt(
             tx_type,
             result,
             self.gas_used,
             gas_used_for_l1,
         ));
+        let receipt_seconds = receipt_started_at.elapsed().as_secs_f64();
 
+        let state_commit_started_at = Instant::now();
         self.evm.db_mut().commit(state);
+        let state_commit_seconds = state_commit_started_at.elapsed().as_secs_f64();
+        let commit_seconds = started_at.elapsed().as_secs_f64();
 
-        metrics::histogram!(
-            "arb_reth.arbos.transaction_commit_seconds",
-            "tx_type" => tx_type_label(tx_type),
-        )
-        .record(started_at.elapsed().as_secs_f64());
-        metrics::histogram!(
-            "arb_reth.arbos.transaction_gas_used",
-            "tx_type" => tx_type_label(tx_type),
-        )
-        .record(gas_used as f64);
-        metrics::histogram!(
-            "arb_reth.arbos.transaction_l1_gas_used",
-            "tx_type" => tx_type_label(tx_type),
-        )
-        .record(gas_used_for_l1 as f64);
+        receipt_histogram.record(receipt_seconds);
+        state_commit_histogram.record(state_commit_seconds);
+        commit_histogram.record(commit_seconds);
+        gas_used_histogram.record(gas_used as f64);
+        l1_gas_used_histogram.record(gas_used_for_l1 as f64);
 
         GasOutput::new(gas_used)
     }
@@ -317,11 +336,13 @@ where
         // base fee) and write it to the shared ctx cell for the assembler. All txs are committed at
         // this point, so the journal reads committed values. Mirrors what Nitro's `FinalizeBlock`/
         // `createNewHeader` pull from `arbosState`.
+        let header_info_histogram =
+            metrics::histogram!("arb_reth.arbos.post_execution_header_info_seconds");
         let started_at = Instant::now();
         let header_info = ArbosState::read_block_header_info(self.evm.ctx_mut().journal_mut())
             .map_err(|e| BlockExecutionError::msg(format!("read ArbOS block header info: {e}")))?;
-        metrics::histogram!("arb_reth.arbos.post_execution_header_info_seconds")
-            .record(started_at.elapsed().as_secs_f64());
+        let header_info_seconds = started_at.elapsed().as_secs_f64();
+        header_info_histogram.record(header_info_seconds);
         if let Ok(mut slot) = self.ctx.header_info_out.lock() {
             *slot = Some(header_info);
         }

--- a/crates/arb-reth-evm/src/block.rs
+++ b/crates/arb-reth-evm/src/block.rs
@@ -22,7 +22,10 @@ use alloy_consensus::{
     TxReceipt, proofs,
 };
 use alloy_eips::{Encodable2718, Typed2718};
-use std::sync::{Arc, Mutex};
+use std::{
+    sync::{Arc, Mutex},
+    time::Instant,
+};
 use alloy_evm::{
     Database, Evm, EvmFactory, FromRecoveredTx, FromTxWithEncoded, RecoveredTx,
     block::{
@@ -184,6 +187,25 @@ fn receipt_envelope_for_type(
     }
 }
 
+/// Stable, low-cardinality label for the consensus transaction families ArbOS executes.
+#[inline]
+fn tx_type_label(tx_type: u8) -> &'static str {
+    match tx_type {
+        0x00 => "legacy",
+        0x01 => "eip2930",
+        0x02 => "eip1559",
+        0x03 => "eip4844",
+        0x04 => "eip7702",
+        0x64 => "deposit",
+        0x65 => "unsigned",
+        0x66 => "contract",
+        0x68 => "retry",
+        0x69 => "submit_retryable",
+        0x6a => "internal",
+        _ => "unknown",
+    }
+}
+
 impl<DB, I, H> BlockExecutor for ArbBlockExecutor<ArbEvm<DB, I>, H>
 where
     DB: Database + DatabaseCommit + StateDB,
@@ -203,14 +225,17 @@ where
         // `InternalTxStartBlock` (0x6a) is NOT run here. It is a real block transaction with its
         // own receipt; the caller drives it through `execute_transaction` like any other tx. Running
         // it here would exclude it from the transactions/receipts roots and diverge from Nitro.
+        let started_at = Instant::now();
         let result = self
             .evm
             .transact_system_call(
                 SYSTEM_ADDRESS,
                 HISTORY_STORAGE_ADDRESS,
                 Bytes::copy_from_slice(self.ctx.parent_hash.as_slice()),
-            )
-            .map_err(|err| BlockExecutionError::evm(err, self.ctx.parent_hash))?;
+            );
+        metrics::histogram!("arb_reth.arbos.pre_execution_system_call_seconds")
+            .record(started_at.elapsed().as_secs_f64());
+        let result = result.map_err(|err| BlockExecutionError::evm(err, self.ctx.parent_hash))?;
         self.evm.db_mut().commit(result.state);
 
         Ok(())
@@ -222,11 +247,18 @@ where
     ) -> Result<Self::Result, BlockExecutionError> {
         let (tx_env, tx) = tx.into_parts();
         let tx_type = tx.tx().ty();
+        let tx_type_label = tx_type_label(tx_type);
 
+        let started_at = Instant::now();
         let result = self
             .evm
-            .transact(tx_env)
-            .map_err(|err| BlockExecutionError::evm(err, tx.tx().trie_hash()))?;
+            .transact(tx_env);
+        metrics::histogram!(
+            "arb_reth.arbos.transaction_execution_seconds",
+            "tx_type" => tx_type_label,
+        )
+        .record(started_at.elapsed().as_secs_f64());
+        let result = result.map_err(|err| BlockExecutionError::evm(err, tx.tx().trie_hash()))?;
 
         // `chain().poster_gas` is set by the ArbOS handler during pre_execution; it is the
         // L2-gas equivalent of the L1 poster cost, recorded as the receipt's `gas_used_for_l1`.
@@ -240,6 +272,7 @@ where
     }
 
     fn commit_transaction(&mut self, output: Self::Result) -> GasOutput {
+        let started_at = Instant::now();
         let ArbTxResult {
             result: ResultAndState { result, state },
             gas_used_for_l1,
@@ -258,6 +291,22 @@ where
 
         self.evm.db_mut().commit(state);
 
+        metrics::histogram!(
+            "arb_reth.arbos.transaction_commit_seconds",
+            "tx_type" => tx_type_label(tx_type),
+        )
+        .record(started_at.elapsed().as_secs_f64());
+        metrics::histogram!(
+            "arb_reth.arbos.transaction_gas_used",
+            "tx_type" => tx_type_label(tx_type),
+        )
+        .record(gas_used as f64);
+        metrics::histogram!(
+            "arb_reth.arbos.transaction_l1_gas_used",
+            "tx_type" => tx_type_label(tx_type),
+        )
+        .record(gas_used_for_l1 as f64);
+
         GasOutput::new(gas_used)
     }
 
@@ -268,8 +317,11 @@ where
         // base fee) and write it to the shared ctx cell for the assembler. All txs are committed at
         // this point, so the journal reads committed values. Mirrors what Nitro's `FinalizeBlock`/
         // `createNewHeader` pull from `arbosState`.
+        let started_at = Instant::now();
         let header_info = ArbosState::read_block_header_info(self.evm.ctx_mut().journal_mut())
             .map_err(|e| BlockExecutionError::msg(format!("read ArbOS block header info: {e}")))?;
+        metrics::histogram!("arb_reth.arbos.post_execution_header_info_seconds")
+            .record(started_at.elapsed().as_secs_f64());
         if let Ok(mut slot) = self.ctx.header_info_out.lock() {
             *slot = Some(header_info);
         }

--- a/crates/arb-reth-genesis/Cargo.toml
+++ b/crates/arb-reth-genesis/Cargo.toml
@@ -9,7 +9,7 @@ authors.workspace = true
 # Nitro's `InitializeArbosInDatabase` (via arb_revm::arbos_init) and verifying the state root.
 
 [dependencies]
-arb-revm = { git = "https://github.com/nuntax/arbitrum-revm", rev = "96f826bfb531fc13f8337db584abfe1e6baaee4f" }
+arb-revm = { git = "https://github.com/nuntax/arbitrum-revm", rev = "e5b83cecdda6321e72893a83a616e1f9981e1a5a" }
 
 alloy-primitives = { version = "1", default-features = false }
 alloy-trie = { version = "0.9", default-features = false }

--- a/crates/arb-reth-genesis/Cargo.toml
+++ b/crates/arb-reth-genesis/Cargo.toml
@@ -9,7 +9,7 @@ authors.workspace = true
 # Nitro's `InitializeArbosInDatabase` (via arb_revm::arbos_init) and verifying the state root.
 
 [dependencies]
-arb-revm = { git = "https://github.com/nuntax/arbitrum-revm", rev = "dd05d8abf79c7d5436ab6bf7bd6d979bee0bba5e" }
+arb-revm = { git = "https://github.com/nuntax/arbitrum-revm", rev = "96f826bfb531fc13f8337db584abfe1e6baaee4f" }
 
 alloy-primitives = { version = "1", default-features = false }
 alloy-trie = { version = "0.9", default-features = false }

--- a/crates/arb-reth-node/Cargo.toml
+++ b/crates/arb-reth-node/Cargo.toml
@@ -14,7 +14,7 @@ authors.workspace = true
 [dependencies]
 arbitrum-alloy-consensus = { git = "https://github.com/nuntax/arbitrum-alloy", rev = "c49c1729668dbda31594b7c2524846f1c9a0bf21", default-features = false, features = ["reth"] }
 arb-reth-evm = { path = "../arb-reth-evm", features = ["rpc"] }
-arb-revm = { git = "https://github.com/nuntax/arbitrum-revm", rev = "dd05d8abf79c7d5436ab6bf7bd6d979bee0bba5e" }
+arb-revm = { git = "https://github.com/nuntax/arbitrum-revm", rev = "96f826bfb531fc13f8337db584abfe1e6baaee4f" }
 
 alloy-primitives = { version = "1", default-features = false }
 alloy-consensus = { version = "2.0", default-features = false }

--- a/crates/arb-reth-node/Cargo.toml
+++ b/crates/arb-reth-node/Cargo.toml
@@ -14,7 +14,7 @@ authors.workspace = true
 [dependencies]
 arbitrum-alloy-consensus = { git = "https://github.com/nuntax/arbitrum-alloy", rev = "c49c1729668dbda31594b7c2524846f1c9a0bf21", default-features = false, features = ["reth"] }
 arb-reth-evm = { path = "../arb-reth-evm", features = ["rpc"] }
-arb-revm = { git = "https://github.com/nuntax/arbitrum-revm", rev = "96f826bfb531fc13f8337db584abfe1e6baaee4f" }
+arb-revm = { git = "https://github.com/nuntax/arbitrum-revm", rev = "e5b83cecdda6321e72893a83a616e1f9981e1a5a" }
 
 alloy-primitives = { version = "1", default-features = false }
 alloy-consensus = { version = "2.0", default-features = false }

--- a/crates/arb-reth-node/Cargo.toml
+++ b/crates/arb-reth-node/Cargo.toml
@@ -75,6 +75,7 @@ reth-static-file-types = { git = "https://github.com/paradigmxyz/reth.git", rev 
 # H/#1: launch genesis-acceptance gate (init_genesis_with_settings_and_validate)
 reth-db-common = { git = "https://github.com/paradigmxyz/reth.git", rev = "224b087672690ae2ef85ad706bd18f40d8e5b265" }
 tracing = "0.1"
+metrics = "0.24"
 
 # D.4: standalone launcher (tokio channels)
 tokio = { version = "1", features = ["rt-multi-thread", "sync", "time"] }
@@ -94,6 +95,7 @@ clap = { version = "4", features = ["derive"] }
 reth-cli-runner = { git = "https://github.com/paradigmxyz/reth.git", rev = "224b087672690ae2ef85ad706bd18f40d8e5b265" }
 reth-tracing = { git = "https://github.com/paradigmxyz/reth.git", rev = "224b087672690ae2ef85ad706bd18f40d8e5b265" }
 reth-node-core = { git = "https://github.com/paradigmxyz/reth.git", rev = "224b087672690ae2ef85ad706bd18f40d8e5b265" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth.git", rev = "224b087672690ae2ef85ad706bd18f40d8e5b265" }
 
 # D.5: Arbitrum RPC converters (receipt/rpc converters), consumed by the canonical RpcAddOns wiring.
 arb-reth-rpc = { path = "../arb-reth-rpc" }

--- a/crates/arb-reth-node/src/commands/node.rs
+++ b/crates/arb-reth-node/src/commands/node.rs
@@ -20,7 +20,7 @@
 //! With `--chain <PATH>` an Arbitrum chain-config JSON is parsed to produce a real
 //! ArbOS genesis allocation instead of the MAINNET placeholder.
 
-use std::{fs, net::IpAddr, path::PathBuf};
+use std::{fs, net::{IpAddr, SocketAddr}, path::PathBuf};
 
 use alloy_primitives::Address;
 use alloy_provider::{Provider, ProviderBuilder};
@@ -31,6 +31,7 @@ use crate::{
 };
 use arbitrum_alloy_sequencer::init_message::parse_init_message_from_body;
 use crate::launcher::ArbLauncher;
+use crate::metrics::FeedLatencyTracker;
 use reth_provider::BlockNumReader;
 use arbitrum_alloy_sequencer::sequencer::feed::{BroadcastFeedMessage, Root};
 use clap::Parser;
@@ -39,7 +40,7 @@ use reth_cli_runner::CliContext;
 use reth_db::{init_db, mdbx::DatabaseArguments, mdbx::SyncMode, ClientVersion};
 use reth_node_builder::{LaunchContext, LaunchNode, NodeBuilder, NodeConfig};
 use reth_node_core::{
-    args::DatadirArgs,
+    args::{DatadirArgs, MetricArgs},
     dirs::{DataDirPath, MaybePlatformPath},
 };
 use reth_tracing::tracing::info;
@@ -64,6 +65,10 @@ pub struct NodeArgs {
     /// HTTP-RPC server port.
     #[arg(long = "http.port", default_value_t = 8545)]
     http_port: u16,
+
+    /// Enable the reth Prometheus endpoint at this address.
+    #[arg(long = "metrics", alias = "metrics.prometheus", value_name = "ADDR")]
+    metrics: Option<SocketAddr>,
 
     /// Engine-tree persistence threshold: persist once the canonical tip is this many blocks
     /// ahead of the last persisted block (larger = bigger, less frequent commit batches).
@@ -443,7 +448,12 @@ pub async fn run(ctx: CliContext, args: NodeArgs) -> eyre::Result<()> {
         }
         None => DatadirArgs::default(),
     };
-    let config = NodeConfig::new(chain_spec).with_datadir_args(datadir_args);
+    let config = NodeConfig::new(chain_spec)
+        .with_datadir_args(datadir_args)
+        .with_metrics(MetricArgs {
+            prometheus: args.metrics,
+            ..Default::default()
+        });
     let data_dir = config.datadir();
 
     // Resolve the L1-derivation resume log path before `data_dir` is moved into the launcher.
@@ -461,6 +471,9 @@ pub async fn run(ctx: CliContext, args: NodeArgs) -> eyre::Result<()> {
 
     // The held sender keeps the driver parked (and the node alive) until SIGTERM.
     let (feed_tx, feed_rx) = tokio::sync::mpsc::channel::<BroadcastFeedMessage>(4096);
+    // Only live WebSocket messages carry an ingress timestamp. L1-derived and replay messages
+    // still drive the same engine callback, but have no sample to record.
+    let feed_latency = args.feed_url.as_ref().map(|_| FeedLatencyTracker::new());
 
     let rpc_addr = args.http.then(|| (args.http_addr, args.http_port).into());
 
@@ -481,6 +494,7 @@ pub async fn run(ctx: CliContext, args: NodeArgs) -> eyre::Result<()> {
             ring_overlay: !args.no_ring_overlay,
         },
         messages: feed_rx,
+        feed_latency: feed_latency.clone(),
         rpc_addr,
     };
 
@@ -543,6 +557,7 @@ pub async fn run(ctx: CliContext, args: NodeArgs) -> eyre::Result<()> {
     // network and unbounded in time; the low-latency path that rides the sequencer tip directly.
     if let Some(feed_url) = args.feed_url.clone() {
         let tx = feed_tx.clone();
+        let feed_latency = feed_latency.expect("feed latency tracker exists with --feed-url");
         // Ask the relay to start at our tip's next message index (block - genesis + 1). The relay is
         // a bounded tip backlog: if this predates what it holds it just streams its current backlog,
         // and the driver's sequence guard dedups/buffers regardless, so this is an optimization.
@@ -578,6 +593,9 @@ pub async fn run(ctx: CliContext, args: NodeArgs) -> eyre::Result<()> {
                         info!(target: "arb-reth", url = %feed_url, from_seq = next_seq, "feed: connected to sequencer feed");
                         let mut pushed = 0usize;
                         while let Some(frame) = ws.next().await {
+                            // This is the ingress edge: take the timestamp before converting or
+                            // parsing the WebSocket frame so the metric includes that work too.
+                            let frame_received_at = std::time::Instant::now();
                             let text = match frame {
                                 Ok(Message::Text(t)) => t.as_str().to_owned(),
                                 Ok(Message::Binary(b)) => match core::str::from_utf8(b.as_ref()) {
@@ -597,8 +615,17 @@ pub async fn run(ctx: CliContext, args: NodeArgs) -> eyre::Result<()> {
                             // and are skipped.
                             match serde_json::from_str::<Root>(&text) {
                                 Ok(root) => {
+                                    let ready_for_channel_at = std::time::Instant::now();
                                     for msg in root.messages.into_iter().flatten() {
                                         next_seq = msg.sequence_number + 1;
+                                        feed_latency.record_frame_arrival(
+                                            msg.sequence_number,
+                                            frame_received_at,
+                                        );
+                                        feed_latency.record_ready_for_channel(
+                                            msg.sequence_number,
+                                            ready_for_channel_at,
+                                        );
                                         if tx.send(msg).await.is_err() {
                                             reth_tracing::tracing::warn!(target: "arb-reth", "feed channel closed; stopping feed follower");
                                             return;

--- a/crates/arb-reth-node/src/launcher.rs
+++ b/crates/arb-reth-node/src/launcher.rs
@@ -12,6 +12,7 @@
 use core::{future::Future, pin::Pin};
 use std::net::SocketAddr;
 
+use crate::metrics::FeedLatencyTracker;
 use alloy_consensus::Header;
 use arbitrum_alloy_consensus::reth::ArbPrimitives;
 use arbitrum_alloy_sequencer::sequencer::feed::BroadcastFeedMessage;
@@ -89,6 +90,9 @@ pub struct ArbLauncher {
     /// Feed channel of sequencer messages. The driver infers the ArbOS version from the chain
     /// tip, so no per-message version is carried.
     pub messages: tokio::sync::mpsc::Receiver<BroadcastFeedMessage>,
+    /// Correlates live WebSocket feed messages with canonical in-memory state for Prometheus.
+    /// `None` keeps replay and L1-only operation free of feed-latency instrumentation.
+    pub feed_latency: Option<FeedLatencyTracker>,
     /// Optional HTTP bind address for the `eth_*` RPC server (`None` disables RPC).
     pub rpc_addr: Option<SocketAddr>,
 }
@@ -190,6 +194,7 @@ impl ArbLauncher {
             genesis_block,
             tuning,
             messages,
+            feed_latency,
             rpc_addr,
         } = self;
 
@@ -240,6 +245,10 @@ impl ArbLauncher {
                 disabled_stages,
             )
             .await?;
+
+        // Install reth's Prometheus recorder before any feed metric handles are initialized, and
+        // serve it when `--metrics <addr>` is configured.
+        let ctx = ctx.with_prometheus_server().await?;
 
         // Open the DB in storage v2 (hashed-state canonical, `PackedKeyAdapter`). This has to
         // happen before `with_genesis()` uses the factory. Cache the flag so every provider
@@ -321,8 +330,18 @@ impl ArbLauncher {
                         break;
                     };
                     bench_recv_us += __r.elapsed().as_micros();
+                    let driver_dequeued_at = std::time::Instant::now();
+                    if let Some(feed_latency) = feed_latency.as_ref() {
+                        feed_latency.record_driver_dequeue(msg.sequence_number, driver_dequeued_at);
+                    }
                     let __w = std::time::Instant::now();
-                    driver.advance(&msg).await?;
+                    driver
+                        .advance_with_applied(&msg, |sequence_number, applied| {
+                            if let Some(feed_latency) = feed_latency.as_ref() {
+                                feed_latency.record_canonical(sequence_number, applied);
+                            }
+                        })
+                        .await?;
                     bench_work_us += __w.elapsed().as_micros();
                     bench_n += 1;
                     if bench_n.is_multiple_of(1000) {
@@ -441,6 +460,7 @@ mod tests {
             genesis_block: 0,
             tuning: ArbEngineTuning::reth_defaults(),
             messages: rx,
+            feed_latency: None,
             rpc_addr: None,
         };
 

--- a/crates/arb-reth-node/src/lib.rs
+++ b/crates/arb-reth-node/src/lib.rs
@@ -51,6 +51,9 @@ pub use arb_reth_sync::resume::{L1ResumeCheckpoint, L1ResumeLog};
 pub mod launcher;
 pub use launcher::{ArbLauncher, ArbNodeHandle};
 
+mod metrics;
+pub use metrics::FeedLatencyTracker;
+
 pub mod executor;
 pub use executor::ArbExecutorBuilder;
 

--- a/crates/arb-reth-node/src/metrics.rs
+++ b/crates/arb-reth-node/src/metrics.rs
@@ -36,6 +36,12 @@ struct FeedLatencyMetrics {
     block_state_setup_seconds: Histogram,
     /// ArbOS pre-execution and transaction execution.
     block_execution_seconds: Histogram,
+    /// Block-builder creation, ArbOS pre-execution changes, and base-fee setup.
+    block_execution_setup_seconds: Histogram,
+    /// Execution of ArbOS's mandatory internal start-block transaction.
+    block_start_block_transaction_seconds: Histogram,
+    /// Execution of derived user and retry transactions, including retry scheduling.
+    block_derived_transactions_seconds: Histogram,
     /// State-root computation plus final block and header construction.
     block_finish_seconds: Histogram,
     /// Sending the executed block to reth's engine tree.
@@ -186,6 +192,15 @@ impl FeedLatencyTracker {
             metrics
                 .block_execution_seconds
                 .record(applied.block_execution.as_secs_f64());
+            metrics
+                .block_execution_setup_seconds
+                .record(applied.block_execution_setup.as_secs_f64());
+            metrics
+                .block_start_block_transaction_seconds
+                .record(applied.block_start_block_transaction.as_secs_f64());
+            metrics
+                .block_derived_transactions_seconds
+                .record(applied.block_derived_transactions.as_secs_f64());
             metrics
                 .block_finish_seconds
                 .record(applied.block_finish.as_secs_f64());

--- a/crates/arb-reth-node/src/metrics.rs
+++ b/crates/arb-reth-node/src/metrics.rs
@@ -1,0 +1,216 @@
+//! Metrics for the live sequencer-feed path.
+
+use arb_reth_engine::ArbAppliedMessageTiming;
+use reth_metrics::{
+    Metrics,
+    metrics::{Counter, Histogram},
+};
+use std::{
+    collections::BTreeMap,
+    sync::{Arc, Mutex, OnceLock},
+    time::Instant,
+};
+
+const MAX_TRACKED_MESSAGES: usize = 16_384;
+
+/// End-to-end latency from receiving a WebSocket data frame to the corresponding block becoming
+/// the canonical in-memory head.
+#[derive(Metrics)]
+#[metrics(scope = "arb_reth.feed")]
+struct FeedLatencyMetrics {
+    /// Time from receiving a sequencer-feed WebSocket frame to canonical in-memory state.
+    frame_to_canonical_seconds: Histogram,
+    /// WebSocket text/binary conversion and JSON decoding before a message is ready for the channel.
+    frame_decode_seconds: Histogram,
+    /// Channel send backpressure and time waiting in the driver input channel.
+    channel_wait_seconds: Histogram,
+    /// Time after driver dequeue before this sequence becomes eligible for in-order application.
+    sequencing_wait_seconds: Histogram,
+    /// ArbOS execution, state-root calculation, and block/header construction.
+    block_production_seconds: Histogram,
+    /// Parent-state provider setup before block production.
+    block_parent_state_seconds: Histogram,
+    /// Feed-message digesting and next-block environment construction.
+    block_message_preparation_seconds: Histogram,
+    /// Creation of revm's journaled state over the parent provider.
+    block_state_setup_seconds: Histogram,
+    /// ArbOS pre-execution and transaction execution.
+    block_execution_seconds: Histogram,
+    /// State-root computation plus final block and header construction.
+    block_finish_seconds: Histogram,
+    /// Sending the executed block to reth's engine tree.
+    engine_insert_seconds: Histogram,
+    /// Forkchoice request and response through reth's engine tree.
+    engine_forkchoice_seconds: Histogram,
+    /// Waiting for the canonical in-memory provider state to observe the block.
+    canonicalization_wait_seconds: Histogram,
+    /// In-order apply-path work not covered by the named engine phases.
+    engine_apply_overhead_seconds: Histogram,
+    /// Samples that could not be tracked without blocking the feed or execution task.
+    tracking_dropped_total: Counter,
+}
+
+struct FeedLatencyInner {
+    messages: Mutex<BTreeMap<u64, FeedMessageTiming>>,
+    metrics: OnceLock<FeedLatencyMetrics>,
+}
+
+#[derive(Clone, Copy)]
+struct FeedMessageTiming {
+    frame_received_at: Instant,
+    ready_for_channel_at: Option<Instant>,
+    driver_dequeued_at: Option<Instant>,
+}
+
+/// Correlates an inbound feed message with the point at which its block is canonical in reth's
+/// shared in-memory state. Contention intentionally drops a sample instead of delaying either the
+/// WebSocket reader or the engine driver.
+#[derive(Clone)]
+pub struct FeedLatencyTracker {
+    inner: Arc<FeedLatencyInner>,
+}
+
+impl FeedLatencyTracker {
+    pub(crate) fn new() -> Self {
+        Self {
+            inner: Arc::new(FeedLatencyInner {
+                messages: Mutex::new(BTreeMap::new()),
+                metrics: OnceLock::new(),
+            }),
+        }
+    }
+
+    /// Records the instant at which a WebSocket data frame was received, before parsing it.
+    pub(crate) fn record_frame_arrival(&self, sequence_number: u64, received_at: Instant) {
+        let mut messages = match self.inner.messages.try_lock() {
+            Ok(messages) => messages,
+            Err(_) => {
+                self.metrics().tracking_dropped_total.increment(1);
+                return;
+            }
+        };
+
+        // Keep the first receipt for a sequence. A duplicated frame must not overwrite the
+        // latency start of the message that was actually queued first.
+        if messages.contains_key(&sequence_number) {
+            return;
+        }
+        if messages.len() == MAX_TRACKED_MESSAGES {
+            messages.pop_first();
+            self.metrics().tracking_dropped_total.increment(1);
+        }
+        messages.insert(
+            sequence_number,
+            FeedMessageTiming {
+                frame_received_at: received_at,
+                ready_for_channel_at: None,
+                driver_dequeued_at: None,
+            },
+        );
+    }
+
+    /// Records the instant after a WebSocket frame has been decoded and the message is ready to
+    /// send through the driver channel.
+    pub(crate) fn record_ready_for_channel(&self, sequence_number: u64, ready_at: Instant) {
+        let mut messages = match self.inner.messages.try_lock() {
+            Ok(messages) => messages,
+            Err(_) => {
+                self.metrics().tracking_dropped_total.increment(1);
+                return;
+            }
+        };
+        if let Some(timing) = messages.get_mut(&sequence_number) {
+            timing.ready_for_channel_at = Some(ready_at);
+        }
+    }
+
+    /// Records the instant at which the engine driver dequeues a message.
+    pub(crate) fn record_driver_dequeue(&self, sequence_number: u64, dequeued_at: Instant) {
+        let mut messages = match self.inner.messages.try_lock() {
+            Ok(messages) => messages,
+            Err(_) => {
+                self.metrics().tracking_dropped_total.increment(1);
+                return;
+            }
+        };
+        if let Some(timing) = messages.get_mut(&sequence_number) {
+            timing.driver_dequeued_at = Some(dequeued_at);
+        }
+    }
+
+    /// Records the end of the measurement and each engine phase after reth has canonicalized the
+    /// corresponding block.
+    pub(crate) fn record_canonical(
+        &self,
+        sequence_number: u64,
+        applied: ArbAppliedMessageTiming,
+    ) {
+        let timing = match self.inner.messages.try_lock() {
+            Ok(mut messages) => messages.remove(&sequence_number),
+            Err(_) => {
+                self.metrics().tracking_dropped_total.increment(1);
+                return;
+            }
+        };
+
+        if let Some(timing) = timing {
+            let metrics = self.metrics();
+            metrics
+                .frame_to_canonical_seconds
+                .record(timing.frame_received_at.elapsed().as_secs_f64());
+            if let Some(ready_at) = timing.ready_for_channel_at {
+                metrics
+                    .frame_decode_seconds
+                    .record(ready_at.saturating_duration_since(timing.frame_received_at).as_secs_f64());
+                if let Some(dequeued_at) = timing.driver_dequeued_at {
+                    metrics
+                        .channel_wait_seconds
+                        .record(dequeued_at.saturating_duration_since(ready_at).as_secs_f64());
+                    metrics
+                        .sequencing_wait_seconds
+                        .record(applied.started_at.saturating_duration_since(dequeued_at).as_secs_f64());
+                }
+            }
+            metrics
+                .block_production_seconds
+                .record(applied.block_production.as_secs_f64());
+            metrics
+                .block_parent_state_seconds
+                .record(applied.block_parent_state.as_secs_f64());
+            metrics
+                .block_message_preparation_seconds
+                .record(applied.block_message_preparation.as_secs_f64());
+            metrics
+                .block_state_setup_seconds
+                .record(applied.block_state_setup.as_secs_f64());
+            metrics
+                .block_execution_seconds
+                .record(applied.block_execution.as_secs_f64());
+            metrics
+                .block_finish_seconds
+                .record(applied.block_finish.as_secs_f64());
+            metrics
+                .engine_insert_seconds
+                .record(applied.engine_insert.as_secs_f64());
+            metrics
+                .engine_forkchoice_seconds
+                .record(applied.engine_forkchoice.as_secs_f64());
+            metrics
+                .canonicalization_wait_seconds
+                .record(applied.canonicalization_wait.as_secs_f64());
+            let named = applied.block_production
+                + applied.engine_insert
+                + applied.engine_forkchoice
+                + applied.canonicalization_wait;
+            metrics
+                .engine_apply_overhead_seconds
+                .record(applied.total.saturating_sub(named).as_secs_f64());
+        }
+    }
+
+    fn metrics(&self) -> &FeedLatencyMetrics {
+        // The live-feed task starts only after `with_prometheus_server` has installed reth's
+        // recorder, so metric handles are never initialized against the no-op recorder.
+        self.inner.metrics.get_or_init(FeedLatencyMetrics::default)
+    }
+}

--- a/crates/arb-reth-node/src/metrics.rs
+++ b/crates/arb-reth-node/src/metrics.rs
@@ -38,10 +38,20 @@ struct FeedLatencyMetrics {
     block_execution_seconds: Histogram,
     /// Block-builder creation, ArbOS pre-execution changes, and base-fee setup.
     block_execution_setup_seconds: Histogram,
+    /// Construction of ArbOS's mandatory internal start-block transaction.
+    block_start_block_transaction_construction_seconds: Histogram,
     /// Execution of ArbOS's mandatory internal start-block transaction.
     block_start_block_transaction_seconds: Histogram,
     /// Execution of derived user and retry transactions, including retry scheduling.
     block_derived_transactions_seconds: Histogram,
+    /// Derived transaction execution and commit work, excluding retry scheduling.
+    block_derived_transaction_execution_seconds: Histogram,
+    /// Extraction and enqueueing of retries emitted by successful derived transactions.
+    block_derived_retry_scheduling_seconds: Histogram,
+    /// Remainder after named derived-transaction phases, retained for exact accounting.
+    block_derived_transactions_unattributed_seconds: Histogram,
+    /// Remainder after named block-execution phases, retained for exact accounting.
+    block_execution_unattributed_seconds: Histogram,
     /// State-root computation plus final block and header construction.
     block_finish_seconds: Histogram,
     /// Sending the executed block to reth's engine tree.
@@ -196,11 +206,26 @@ impl FeedLatencyTracker {
                 .block_execution_setup_seconds
                 .record(applied.block_execution_setup.as_secs_f64());
             metrics
+                .block_start_block_transaction_construction_seconds
+                .record(applied.block_start_block_transaction_construction.as_secs_f64());
+            metrics
                 .block_start_block_transaction_seconds
                 .record(applied.block_start_block_transaction.as_secs_f64());
             metrics
                 .block_derived_transactions_seconds
                 .record(applied.block_derived_transactions.as_secs_f64());
+            metrics
+                .block_derived_transaction_execution_seconds
+                .record(applied.block_derived_transaction_execution.as_secs_f64());
+            metrics
+                .block_derived_retry_scheduling_seconds
+                .record(applied.block_derived_retry_scheduling.as_secs_f64());
+            metrics
+                .block_derived_transactions_unattributed_seconds
+                .record(applied.block_derived_transactions_unattributed.as_secs_f64());
+            metrics
+                .block_execution_unattributed_seconds
+                .record(applied.block_execution_unattributed.as_secs_f64());
             metrics
                 .block_finish_seconds
                 .record(applied.block_finish.as_secs_f64());

--- a/crates/arb-reth-node/tests/rpc_integration.rs
+++ b/crates/arb-reth-node/tests/rpc_integration.rs
@@ -61,6 +61,7 @@
             genesis_block: 0,
             tuning: arb_reth_node::ArbEngineTuning::reth_defaults(),
             messages: rx,
+            feed_latency: None,
             rpc_addr: Some(rpc_addr),
         };
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,4 @@
-# Command guide
+# Documentation
 
 Use the release binary in the examples below. Replace paths and endpoints with values for the target chain.
 
@@ -7,5 +7,6 @@ Use the release binary in the examples below. Replace paths and endpoints with v
 - [genesis](commands/genesis.md): verify state roots before import.
 - [rewind](commands/rewind.md): remove a bad local suffix.
 - [dump-blocks](commands/dump-blocks.md): inspect persisted blocks.
+- [chains](chains/README.md): chain-specific operator notes.
 
 Every command exposes its complete flag list through `arb-reth <command> --help`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,5 +8,6 @@ Use the release binary in the examples below. Replace paths and endpoints with v
 - [rewind](commands/rewind.md): remove a bad local suffix.
 - [dump-blocks](commands/dump-blocks.md): inspect persisted blocks.
 - [chains](chains/README.md): chain-specific operator notes.
+- [observability](observability/README.md): Prometheus metrics for the execute and persist loop.
 
 Every command exposes its complete flag list through `arb-reth <command> --help`.

--- a/docs/chains/README.md
+++ b/docs/chains/README.md
@@ -1,0 +1,7 @@
+# Chains
+
+Operator notes for chains with committed boot fixtures or a known node configuration.
+
+- [Robinhood mainnet](robinhood-mainnet.md): bootstrap from the Orbit genesis files and follow L1 plus the sequencer feed.
+
+Use the command documentation for the complete option reference.

--- a/docs/chains/robinhood-mainnet.md
+++ b/docs/chains/robinhood-mainnet.md
@@ -1,8 +1,14 @@
 # Robinhood mainnet
 
-Robinhood Chain is an Orbit chain with chain ID `4663`, rooted on Ethereum mainnet. `arb-reth` boots it from the committed `chaininfo.json` and genesis files, then derives batches from L1. It can follow the public sequencer feed while it catches up.
+Robinhood Chain is an Orbit chain with chain ID `4663`, rooted on Ethereum mainnet. `arb-reth` boots it from Robinhood's `chaininfo.json` and genesis files, then derives batches from L1. It can follow the public sequencer feed while it catches up.
 
 This is an operator recipe for the current mainnet configuration. Keep credentials out of shell history, repository files, and process listings.
+
+## Bootstrap files
+
+Download the mainnet `chaininfo.json` and `genesis.json` from Robinhood's [Run a full node guide](https://docs.robinhood.com/chain/run-a-full-node/). Robinhood publishes both files there for full-node operators.
+
+The copies currently under `crates/arb-reth-node/tests/fixtures` exist to exercise the Orbit boot parser. They are test fixtures, not an operator distribution contract, and may be moved or removed from this repository at any time. Keep downloaded files in operator-controlled storage and pass their paths explicitly.
 
 ## Requirements
 
@@ -26,19 +32,21 @@ export L1_RPC="https://your-ethereum-archive-rpc.example"
 export L1_BEACON="https://your-ethereum-beacon-api.example"
 export FEED_URL="wss://feed.mainnet.chain.robinhood.com"
 export METRICS_ADDR="127.0.0.1:9001"
+export CHAIN_INFO="$HOME/rh/config/robinhood-chain-info.json"
+export GENESIS="$HOME/rh/config/robinhood-genesis.json"
 ```
 
 The canonical RPC is `https://rpc.mainnet.chain.robinhood.com`. It is useful for parity checks, not for L1 derivation.
 
 ## Start the node
 
-The committed boot fixtures are under `crates/arb-reth-node/tests/fixtures`. The command below creates the datadir when absent and resumes from its stored L1 checkpoint on later starts.
+The command below creates the datadir when absent and resumes from its stored L1 checkpoint on later starts.
 
 ```sh
 "$ARB_RETH/target/release/arb-reth" node \
   --datadir "$DATADIR" \
-  --chain-info "$ARB_RETH/crates/arb-reth-node/tests/fixtures/robinhood-chain-info.json" \
-  --genesis "$ARB_RETH/crates/arb-reth-node/tests/fixtures/robinhood-genesis.json" \
+  --chain-info "$CHAIN_INFO" \
+  --genesis "$GENESIS" \
   --l1-rpc "$L1_RPC" \
   --l1-beacon "$L1_BEACON" \
   --l1-getlogs-range 500 \
@@ -83,8 +91,8 @@ Stop the node before modifying the datadir. If `N` is the first divergent L2 blo
 ```sh
 "$ARB_RETH/target/release/arb-reth" rewind \
   --datadir "$DATADIR" \
-  --chain-info "$ARB_RETH/crates/arb-reth-node/tests/fixtures/robinhood-chain-info.json" \
-  --genesis "$ARB_RETH/crates/arb-reth-node/tests/fixtures/robinhood-genesis.json" \
+  --chain-info "$CHAIN_INFO" \
+  --genesis "$GENESIS" \
   --diverged-at N
 ```
 

--- a/docs/chains/robinhood-mainnet.md
+++ b/docs/chains/robinhood-mainnet.md
@@ -31,7 +31,6 @@ export DATADIR="$HOME/arb-data/robinhood-mainnet"
 export L1_RPC="https://your-ethereum-archive-rpc.example"
 export L1_BEACON="https://your-ethereum-beacon-api.example"
 export FEED_URL="wss://feed.mainnet.chain.robinhood.com"
-export METRICS_ADDR="127.0.0.1:9001"
 export CHAIN_INFO="$HOME/rh/config/robinhood-chain-info.json"
 export GENESIS="$HOME/rh/config/robinhood-genesis.json"
 ```
@@ -55,15 +54,12 @@ The command below creates the datadir when absent and resumes from its stored L1
   --persistence-threshold 128 \
   --memory-buffer-target 0 \
   --persistence-backpressure 512 \
-  --http --http.port 8547 \
-  --metrics "$METRICS_ADDR"
+  --http --http.port 8547
 ```
 
 The feed and L1 derivation may run together. The feed improves time at the tip, while L1 remains the source of durable historical derivation. Feed messages ahead of the L1 cursor are reconciled by sequence number and applied when they become contiguous.
 
 `--l1-getlogs-range 500` and `--l1-prefetch 32` are good starting values for an endpoint that permits wide log ranges and concurrent blob requests. Reduce the range when the provider limits `eth_getLogs`; reduce prefetch when the beacon service is rate-limited.
-
-Keep metrics on loopback unless a metrics network is explicitly configured. A local Prometheus container can scrape `127.0.0.1:9001` through the host bridge.
 
 ## Check progress
 
@@ -74,12 +70,6 @@ curl -fsS \
   -H 'content-type: application/json' \
   --data '{"jsonrpc":"2.0","id":1,"method":"eth_blockNumber","params":[]}' \
   http://127.0.0.1:8547
-```
-
-The Prometheus endpoint exposes feed latency, execution, engine-tree, parallel-root, and persistence metrics:
-
-```sh
-curl -fsS http://127.0.0.1:9001/metrics | grep -E 'reth_(arb_reth_feed|blockchain_tree|consensus_engine)'
 ```
 
 At the tip, compare the local and canonical block hashes and state roots only at a height both endpoints serve. The feed can place the local node slightly ahead of the canonical RPC, which is not a divergence.
@@ -98,4 +88,4 @@ Stop the node before modifying the datadir. If `N` is the first divergent L2 blo
 
 Run the same `node` command again afterwards. Start with `rewind --dry-run` when the target has not been independently verified.
 
-See the [node command](../commands/node.md) and [rewind command](../commands/rewind.md) for option details.
+See the [node command](../commands/node.md), [observability guide](../observability/README.md), and [rewind command](../commands/rewind.md) for option details.

--- a/docs/chains/robinhood-mainnet.md
+++ b/docs/chains/robinhood-mainnet.md
@@ -1,0 +1,93 @@
+# Robinhood mainnet
+
+Robinhood Chain is an Orbit chain with chain ID `4663`, rooted on Ethereum mainnet. `arb-reth` boots it from the committed `chaininfo.json` and genesis files, then derives batches from L1. It can follow the public sequencer feed while it catches up.
+
+This is an operator recipe for the current mainnet configuration. Keep credentials out of shell history, repository files, and process listings.
+
+## Requirements
+
+- A release build of `arb-reth`.
+- An archive-capable Ethereum mainnet execution RPC.
+- An Ethereum mainnet beacon API. Robinhood has blob batches, so the beacon endpoint is required for a complete sync.
+- Disk space for the full chain and a persistent datadir. Do not place the datadir in a temporary directory.
+
+Build the binary from the repository root:
+
+```sh
+cargo build --release -p arb-reth-node --bin arb-reth
+```
+
+Set the paths and RPC credentials in the environment. The execution and beacon endpoints below are placeholders and should be supplied by the operator.
+
+```sh
+export ARB_RETH="$PWD"
+export DATADIR="$HOME/arb-data/robinhood-mainnet"
+export L1_RPC="https://your-ethereum-archive-rpc.example"
+export L1_BEACON="https://your-ethereum-beacon-api.example"
+export FEED_URL="wss://feed.mainnet.chain.robinhood.com"
+export METRICS_ADDR="127.0.0.1:9001"
+```
+
+The canonical RPC is `https://rpc.mainnet.chain.robinhood.com`. It is useful for parity checks, not for L1 derivation.
+
+## Start the node
+
+The committed boot fixtures are under `crates/arb-reth-node/tests/fixtures`. The command below creates the datadir when absent and resumes from its stored L1 checkpoint on later starts.
+
+```sh
+"$ARB_RETH/target/release/arb-reth" node \
+  --datadir "$DATADIR" \
+  --chain-info "$ARB_RETH/crates/arb-reth-node/tests/fixtures/robinhood-chain-info.json" \
+  --genesis "$ARB_RETH/crates/arb-reth-node/tests/fixtures/robinhood-genesis.json" \
+  --l1-rpc "$L1_RPC" \
+  --l1-beacon "$L1_BEACON" \
+  --l1-getlogs-range 500 \
+  --l1-prefetch 32 \
+  --feed-url "$FEED_URL" \
+  --persistence-threshold 128 \
+  --memory-buffer-target 0 \
+  --persistence-backpressure 512 \
+  --http --http.port 8547 \
+  --metrics "$METRICS_ADDR"
+```
+
+The feed and L1 derivation may run together. The feed improves time at the tip, while L1 remains the source of durable historical derivation. Feed messages ahead of the L1 cursor are reconciled by sequence number and applied when they become contiguous.
+
+`--l1-getlogs-range 500` and `--l1-prefetch 32` are good starting values for an endpoint that permits wide log ranges and concurrent blob requests. Reduce the range when the provider limits `eth_getLogs`; reduce prefetch when the beacon service is rate-limited.
+
+Keep metrics on loopback unless a metrics network is explicitly configured. A local Prometheus container can scrape `127.0.0.1:9001` through the host bridge.
+
+## Check progress
+
+The local RPC reports the produced tip:
+
+```sh
+curl -fsS \
+  -H 'content-type: application/json' \
+  --data '{"jsonrpc":"2.0","id":1,"method":"eth_blockNumber","params":[]}' \
+  http://127.0.0.1:8547
+```
+
+The Prometheus endpoint exposes feed latency, execution, engine-tree, parallel-root, and persistence metrics:
+
+```sh
+curl -fsS http://127.0.0.1:9001/metrics | grep -E 'reth_(arb_reth_feed|blockchain_tree|consensus_engine)'
+```
+
+At the tip, compare the local and canonical block hashes and state roots only at a height both endpoints serve. The feed can place the local node slightly ahead of the canonical RPC, which is not a divergence.
+
+## Recover from a confirmed divergence
+
+Stop the node before modifying the datadir. If `N` is the first divergent L2 block, retain `N - 1` and re-derive the suffix after fixing the state-transition bug:
+
+```sh
+"$ARB_RETH/target/release/arb-reth" rewind \
+  --datadir "$DATADIR" \
+  --chain-info "$ARB_RETH/crates/arb-reth-node/tests/fixtures/robinhood-chain-info.json" \
+  --genesis "$ARB_RETH/crates/arb-reth-node/tests/fixtures/robinhood-genesis.json" \
+  --diverged-at N
+```
+
+Run the same `node` command again afterwards. Start with `rewind --dry-run` when the target has not been independently verified.
+
+See the [node command](../commands/node.md) and [rewind command](../commands/rewind.md) for option details.

--- a/docs/commands/node.md
+++ b/docs/commands/node.md
@@ -46,6 +46,23 @@ Use `--l1-start-block` and `--l1-start-delayed` only when the supplied values de
 
 `--no-l1-derive` makes the feed the only producer. It still needs `--l1-rpc` to bootstrap chain information, and it is appropriate only for a datadir that is already at the feed's retained range.
 
+## Metrics
+
+Pass `--metrics 127.0.0.1:9001` to serve reth's Prometheus endpoint. It includes reth's engine-tree and persistence metrics, so no separate pipeline service is needed.
+
+With `--feed-url`, `reth_arb_reth_feed_frame_to_canonical_seconds` measures from receiving a WebSocket data frame through JSON decoding, queueing, block execution, and reth in-memory canonicalization. It ends when the shared provider state backing RPC has the new canonical head. It does not include an RPC client's network round trip or response serialization.
+
+The dashboard should focus on the execution loop:
+
+- `reth_blockchain_tree_in_mem_state_num_blocks` and `reth_consensus_engine_beacon_backpressure_active` show the unpersisted window and whether it is stalling execution.
+- `reth_consensus_engine_beacon_persistence_duration` and `reth_consensus_engine_persistence_save_blocks_*` show persistence batch latency and size.
+- `reth_executor_worker_pool_job_{duration,queue_wait}_seconds{pool="state-ovly"}` exposes the parallel state-root worker pool.
+- `reth_sync_block_validation_state_trie_overlay_overlay_cache_*` and `reth_trie_parallel_*` show overlay reuse and parallel state-root work.
+
+The standard reth pipeline and `newPayload` metrics are also exported, but they stay unused in this execute-then-persist architecture.
+
+`reth_arb_reth_feed_tracking_dropped_total` counts samples intentionally skipped when telemetry would contend with the feed reader or block producer. It should stay at zero during normal operation.
+
 ## Persistence controls
 
 - `--persistence-threshold`: number of canonical blocks before a persistence batch.

--- a/docs/commands/node.md
+++ b/docs/commands/node.md
@@ -48,20 +48,7 @@ Use `--l1-start-block` and `--l1-start-delayed` only when the supplied values de
 
 ## Metrics
 
-Pass `--metrics 127.0.0.1:9001` to serve reth's Prometheus endpoint. It includes reth's engine-tree and persistence metrics, so no separate pipeline service is needed.
-
-With `--feed-url`, `reth_arb_reth_feed_frame_to_canonical_seconds` measures from receiving a WebSocket data frame through JSON decoding, queueing, block execution, and reth in-memory canonicalization. It ends when the shared provider state backing RPC has the new canonical head. It does not include an RPC client's network round trip or response serialization.
-
-The dashboard should focus on the execution loop:
-
-- `reth_blockchain_tree_in_mem_state_num_blocks` and `reth_consensus_engine_beacon_backpressure_active` show the unpersisted window and whether it is stalling execution.
-- `reth_consensus_engine_beacon_persistence_duration` and `reth_consensus_engine_persistence_save_blocks_*` show persistence batch latency and size.
-- `reth_executor_worker_pool_job_{duration,queue_wait}_seconds{pool="state-ovly"}` exposes the parallel state-root worker pool.
-- `reth_sync_block_validation_state_trie_overlay_overlay_cache_*` and `reth_trie_parallel_*` show overlay reuse and parallel state-root work.
-
-The standard reth pipeline and `newPayload` metrics are also exported, but they stay unused in this execute-then-persist architecture.
-
-`reth_arb_reth_feed_tracking_dropped_total` counts samples intentionally skipped when telemetry would contend with the feed reader or block producer. It should stay at zero during normal operation.
+Pass `--metrics 127.0.0.1:9001` to serve reth's Prometheus endpoint. See the [observability guide](../observability/README.md) for feed latency, engine-tree, persistence, and Prometheus scrape details.
 
 ## Persistence controls
 

--- a/docs/observability/README.md
+++ b/docs/observability/README.md
@@ -19,6 +19,26 @@ Use the phase metrics to locate the delay:
 - `reth_arb_reth_feed_engine_{insert,forkchoice}_seconds` and `canonicalization_wait_seconds` cover the reth handoff.
 - `reth_arb_reth_feed_tracking_dropped_total` should remain zero during normal operation.
 
+## ArbOS transaction execution
+
+The executor exports these bounded-label series for each consensus transaction family (`legacy`,
+`eip1559`, `deposit`, `unsigned`, `contract`, `retry`, `submit_retryable`, and `internal`):
+
+- `reth_arb_reth_arbos_transaction_execution_seconds` measures the full ArbOS handler transition,
+  including the applicable pre-execution hooks and EVM or protocol transaction body.
+- `reth_arb_reth_arbos_transaction_commit_seconds` measures receipt construction and the in-memory
+  state commit after that transition.
+- `reth_arb_reth_arbos_transaction_{,l1_}gas_used` records L2 gas and L1 poster-gas distributions.
+- `reth_arb_reth_arbos_pre_execution_system_call_seconds` measures the EIP-2935 parent-hash
+  prelude, and `post_execution_header_info_seconds` measures the ArbOS header-field read.
+- `reth_arb_revm_arbos_handler_phase_seconds{phase,tx_type,mode}` splits the transition itself.
+  `pre_execution` covers ArbOS gas charging and filtering, `execution` covers the protocol or EVM
+  frame, and `end_tx_hook` covers fee distribution, refunds, and backlog updates. `mode="execute"`
+  is block production; `mode="inspect"` is debug tracing and should be excluded from latency views.
+
+These labels deliberately exclude addresses, transaction hashes, block numbers, and ArbOS version
+to keep Prometheus cardinality bounded. Use a one-off profiler for per-contract or opcode detail.
+
 Samples collected while catching up from a feed backlog include that backlog in the end-to-end measurement. Use a node at the live tip to judge MEV-facing latency.
 
 ## Execute and persist loop

--- a/docs/observability/README.md
+++ b/docs/observability/README.md
@@ -1,0 +1,48 @@
+# Observability
+
+`arb-reth` serves reth's Prometheus endpoint with `--metrics <ADDR>`. Bind it to loopback unless the metrics network is deliberately exposed:
+
+```sh
+arb-reth node --metrics 127.0.0.1:9001 ...
+```
+
+The endpoint includes reth engine-tree, persistence, state-root, and RPC metrics. With `--feed-url`, arb-reth also records the live sequencer path. Telemetry deliberately drops a sample instead of blocking the feed reader or block producer.
+
+## Feed to canonical state
+
+`reth_arb_reth_feed_frame_to_canonical_seconds` measures from receiving a WebSocket data frame through decoding, queueing, block production, forkchoice, and in-memory canonicalization. It ends when the shared provider state used by RPC has the new canonical head. It does not include an RPC client's network round trip or response serialization.
+
+Use the phase metrics to locate the delay:
+
+- `reth_arb_reth_feed_frame_decode_seconds`, `channel_wait_seconds`, and `sequencing_wait_seconds` cover ingress and ordering.
+- `reth_arb_reth_feed_block_*_seconds` separates parent-state setup, message preparation, ArbOS execution, and state-root finalisation.
+- `reth_arb_reth_feed_engine_{insert,forkchoice}_seconds` and `canonicalization_wait_seconds` cover the reth handoff.
+- `reth_arb_reth_feed_tracking_dropped_total` should remain zero during normal operation.
+
+Samples collected while catching up from a feed backlog include that backlog in the end-to-end measurement. Use a node at the live tip to judge MEV-facing latency.
+
+## Execute and persist loop
+
+These reth metrics describe the path arb-reth actually uses:
+
+- `reth_blockchain_tree_in_mem_state_num_blocks` is the unpersisted in-memory window.
+- `reth_consensus_engine_beacon_backpressure_active` and `backpressure_stall_duration` show persistence-induced stalls.
+- `reth_consensus_engine_beacon_persistence_duration` and `reth_consensus_engine_persistence_save_blocks_*` show persistence batch latency and size.
+- `reth_consensus_engine_beacon_inserted_already_executed_blocks` and `forkchoice_updated_*` show engine-tree throughput and outcomes.
+- `reth_executor_worker_pool_job_{duration,queue_wait}_seconds{pool="state-ovly"}` shows parallel state-root worker saturation.
+- `reth_sync_block_validation_state_trie_overlay_overlay_cache_*` and `reth_trie_parallel_*` show overlay reuse and parallel root work.
+
+The standard reth pipeline and `newPayload` metrics are exported too, but they do not drive arb-reth's execute-then-persist loop.
+
+## Prometheus scrape
+
+For a Prometheus server on the host:
+
+```yaml
+scrape_configs:
+  - job_name: arb-reth
+    static_configs:
+      - targets: ["127.0.0.1:9001"]
+```
+
+When Prometheus runs in a local container, use the host address supplied by that container runtime, such as `host.docker.internal:9001`.


### PR DESCRIPTION
## Summary

- Add a Prometheus endpoint and low-contention feed-to-canonical latency metrics.
- Break block production into parent-state, preparation, execution, and state-root phases.
- Document the execution-loop metrics and add a Robinhood mainnet operator runbook.

## Impact

Operators can measure the live feed path alongside reth engine-tree, persistence, and parallel state-root metrics. Robinhood mainnet can be started from committed Orbit boot fixtures without putting RPC credentials in the repository.

## Validation

- `cargo check -p arb-reth-node --all-targets`
- `cargo clippy -p arb-reth-node --all-targets -- -D warnings`
- `git diff --check`
- Verified documented node and rewind flags against the release binary.
- Verified the Prometheus queries against the running node.
