### PR TITLE
build: add optimized Cargo profiles

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,59 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/nuntax/arbitrum-reth"
 version = "0.1.0"
 
+[profile.dev]
+# https://davidlattimore.github.io/posts/2024/02/04/speeding-up-the-rust-edit-build-run-cycle.html
+debug = "line-tables-only"
+split-debuginfo = "unpacked"
+
+# Speed up tests.
+[profile.dev.package]
+proptest.opt-level = 3
+rand_chacha.opt-level = 3
+rand_xorshift.opt-level = 3
+unarray.opt-level = 3
+
+# Meant for testing - all optimizations, but with debug assertions and overflow checks.
+[profile.hivetests]
+inherits = "test"
+opt-level = 3
+lto = "thin"
+
+[profile.release]
+opt-level = 3
+lto = "thin"
+debug = "none"
+strip = "symbols"
+panic = "unwind"
+codegen-units = 16
+
+# Use the `--profile profiling` flag to show symbols in release mode.
+# e.g. `cargo build --profile profiling`
+[profile.profiling]
+inherits = "release"
+debug = "full"
+strip = "none"
+
+# Include debug info in benchmarks too.
+[profile.bench]
+inherits = "profiling"
+
+[profile.maxperf]
+inherits = "release"
+lto = "fat"
+codegen-units = 1
+
+[profile.maxperf-symbols]
+inherits = "maxperf"
+debug = "full"
+strip = "none"
+
+[profile.reproducible]
+inherits = "release"
+panic = "abort"
+codegen-units = 1
+incremental = false
+
 [workspace.dependencies]
 # Keep the ArbOS implementation revision in one place. Individual crates opt into it with
 # `arb-revm.workspace = true`; only the EVM integration enables the Stylus runtime.
@@ -21,6 +74,5 @@ arb-revm = { git = "https://github.com/nuntax/arbitrum-revm", rev = "b61aa647ba6
 revm = { version = "41.0.0", features = ["optional_priority_fee_check", "optional_balance_check", "optional_eip7623", "optional_eip3541"] }
 alloy-rlp = "0.3.12"
 serde_json = "1.0.145"
-
 
 


### PR DESCRIPTION
Adds development, test, release, profiling, benchmark, maximum-performance, and reproducible Cargo profiles to the workspace manifest.

This improves local edit-build cycles, test execution, production build tuning, symbol-preserving profiling, and deterministic release builds. Cargo accepted the updated manifest via `cargo metadata --no-deps --format-version 1`.