### PR TITLE
fix(genesis): make bail match arm nightly-compatible

### DIFF
--- a/crates/arb-reth-node/src/commands/genesis.rs
+++ b/crates/arb-reth-node/src/commands/genesis.rs
@@ -284,7 +284,9 @@ pub fn verify_export(args: GenesisVerifyExportArgs) -> eyre::Result<()> {
             }
             Some("C") => n_code += 1,
             Some("H") | Some("B") | Some("R") | None => {}
-            Some(other) => eyre::bail!("unknown record type {other:?}"),
+            Some(other) => {
+                eyre::bail!("unknown record type {other:?}");
+            }
         }
     }
     flush_storage(cur_addr_hash, cur_storage_root, &mut cur_slots, &mut storage_checked);


### PR DESCRIPTION
Wrap the unknown-record `eyre::bail!` match arm in a block and terminate the macro invocation with a semicolon. The current nightly compiler rejects the previous single-expression arm, preventing optimized node builds from reaching the linker; runtime behavior is unchanged.

Checked with `cargo check -p arb-reth-node --bin arb-reth` and `git diff --check`.