### PR TITLE
chore: ignore IntelliJ IDEA files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
+.idea/
 Cargo.lock
 *.pyc


### PR DESCRIPTION
Ignore JetBrains IntelliJ IDEA project metadata so local IDE settings no longer appear as untracked files.