### PR TITLE
refactor(node): use Reth's native node CLI

### DIFF
--- a/crates/arb-reth-engine/Cargo.toml
+++ b/crates/arb-reth-engine/Cargo.toml
@@ -53,6 +53,7 @@ reth-stages = { git = "https://github.com/nuntax/reth.git", rev = "547581ff58e62
 reth-storage-api = { git = "https://github.com/nuntax/reth.git", rev = "547581ff58e62577ef880e986a1b870feaa1a1b0", features = ["db-api"] }
 reth-storage-overlay = { git = "https://github.com/nuntax/reth.git", rev = "547581ff58e62577ef880e986a1b870feaa1a1b0" }
 reth-tasks = { git = "https://github.com/nuntax/reth.git", rev = "547581ff58e62577ef880e986a1b870feaa1a1b0" }
+reth-tokio-util = { git = "https://github.com/nuntax/reth.git", rev = "547581ff58e62577ef880e986a1b870feaa1a1b0" }
 reth-trie-db = { git = "https://github.com/nuntax/reth.git", rev = "547581ff58e62577ef880e986a1b870feaa1a1b0" }
 reth-trie = { git = "https://github.com/nuntax/reth.git", rev = "547581ff58e62577ef880e986a1b870feaa1a1b0" }
 

--- a/crates/arb-reth-engine/src/engine.rs
+++ b/crates/arb-reth-engine/src/engine.rs
@@ -13,8 +13,8 @@ use alloc::sync::Arc;
 use alloc::vec;
 use alloc::vec::Vec;
 
-use alloy_consensus::Header;
 use alloy_consensus::transaction::Recovered;
+use alloy_consensus::{Header, constants::GWEI_TO_WEI};
 use alloy_eips::eip2718::Typed2718;
 use alloy_evm::EvmEnv;
 use alloy_primitives::{Address, B256, BlockNumber, Bytes, Log, StorageKey, StorageValue};
@@ -53,7 +53,9 @@ use reth_execution_cache::CacheStats;
 use reth_execution_types::{BlockExecutionOutput, BlockExecutionResult};
 use reth_payload_builder::{PayloadBuilderHandle, PayloadBuilderService};
 use reth_payload_primitives::{BuiltPayload as _, BuiltPayloadExecutedBlock, PayloadKind};
-use reth_primitives_traits::{Account, Bytecode, RecoveredBlock, SealedHeader};
+use reth_primitives_traits::{
+    Account, Bytecode, RecoveredBlock, SealedHeader, format_gas, format_gas_throughput,
+};
 use reth_provider::providers::{BlockchainProvider, ProviderNodeTypes};
 use reth_provider::{
     AccountReader, BalProvider, BlockHashReader, BlockNumReader, BlockReader, BytecodeReader,
@@ -907,6 +909,7 @@ struct PendingAppliedBlock {
     sequence_number: u64,
     new_hash: B256,
     new_header: Header,
+    tx_count: usize,
     production_timing: ArbBlockProductionTiming,
     execution_cache_stats: Option<Arc<CacheStats>>,
     payload_timing: ArbPayloadJobTiming,
@@ -1184,6 +1187,7 @@ where
         tuning: ArbEngineTuning,
         prune_builder: Option<PrunerBuilder>,
         tx_log_stream: Option<ArbTxLogBroadcaster>,
+        engine_events: reth_tokio_util::EventSender<ConsensusEngineEvent<ArbPrimitives>>,
     ) -> eyre::Result<Self> {
         // ---- persistence service (real MDBX writer; pruner from --prune.* flags) ----
         let (_finished_exex_height_tx, finished_exex_height_rx) =
@@ -1274,11 +1278,11 @@ where
         let (obs_tx, obs_rx) = tokio::sync::mpsc::unbounded_channel::<(u64, B256)>();
         tokio::spawn(async move {
             while let Some(ev) = from_tree.recv().await {
-                if let EngineApiEvent::BeaconConsensus(
-                    ConsensusEngineEvent::CanonicalChainCommitted(header, _),
-                ) = ev
-                {
-                    let _ = obs_tx.send((header.number, header.hash()));
+                if let EngineApiEvent::BeaconConsensus(event) = ev {
+                    if let ConsensusEngineEvent::CanonicalChainCommitted(header, _) = &event {
+                        let _ = obs_tx.send((header.number, header.hash()));
+                    }
+                    engine_events.notify(event);
                 }
             }
         });
@@ -1515,6 +1519,7 @@ where
         debug_assert!(self.pending_applied.is_none());
         let new_hash = built.recovered_block.hash();
         let new_header = built.recovered_block.header().clone();
+        let tx_count = built.recovered_block.body().transactions().count();
         let new_number = new_header.number;
 
         // Feed the executed block to the tree (no re-execution).
@@ -1565,6 +1570,7 @@ where
             sequence_number,
             new_hash,
             new_header,
+            tx_count,
             production_timing,
             execution_cache_stats,
             payload_timing,
@@ -1653,6 +1659,7 @@ where
         let PendingAppliedBlock {
             new_hash,
             new_header,
+            tx_count,
             production_timing,
             execution_cache_stats,
             payload_timing,
@@ -1795,15 +1802,30 @@ where
         };
         block_metrics.mgas_per_second.record(mgas_per_second);
 
-        // Per-block production trace (observability) + per-phase timing breakdown.
-        tracing::info!(
-            target: "arb-reth::engine",
+        // Arbitrum headers deliberately use Nitro's permissive 2^50 Geth gas-limit envelope. It
+        // is not block capacity, so do not report it or derive a misleading fullness percentage
+        // from it. Likewise, measure throughput over actual block production rather than Reth's
+        // much smaller engine-tree insertion interval.
+        tracing::debug!(
+            target: "arb-reth::blocks",
             number = new_number,
-            %new_hash,
-            state_root = %new_header.state_root,
-            gas_used = new_header.gas_used,
-            "produced block",
+            hash = ?new_hash,
+            txs = tx_count,
+            gas_used = %format_gas(new_header.gas_used),
+            gas_throughput = %format_gas_throughput(new_header.gas_used, block_production),
+            base_fee = %format!(
+                "{:.2}Gwei",
+                new_header.base_fee_per_gas.unwrap_or(0) as f64 / GWEI_TO_WEI as f64
+            ),
+            execution_time = ?production_timing.execution,
+            state_root_time = ?production_timing.finish_state_root,
+            production_time = ?block_production,
+            engine_handoff_time = ?engine_handoff,
+            elapsed = ?total,
+            "Arbitrum block added to canonical chain",
         );
+
+        // Keep the full internal timing breakdown at debug.
         tracing::debug!(
             target: "arb-reth::engine::timing",
             number = new_number,

--- a/crates/arb-reth-engine/src/engine.rs
+++ b/crates/arb-reth-engine/src/engine.rs
@@ -733,31 +733,9 @@ where
 /// `persistence_backpressure_threshold=16`) suit a live validator: persist promptly, hold almost
 /// nothing in memory.
 ///
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub struct ArbEngineTuning {
-    /// Persist once the canonical tip is this many blocks ahead of the last persisted block.
-    pub persistence_threshold: u64,
-    /// Keep this many of the most-recent blocks in memory (target size of the unpersisted buffer).
-    pub memory_block_buffer_target: u64,
-    /// Hard backpressure: stall block production once this many blocks are unpersisted.
-    pub persistence_backpressure_threshold: u64,
-    /// Size in bytes of reth's cross-block execution cache.
-    ///
-    /// Reth's bare [`TreeConfig`] default is intentionally large for a general-purpose node. A
-    /// 256 MiB cache keeps the serial Arbitrum producer's fixed-cache tables dense and matches
-    /// the previously measured direct-driver configuration.
-    pub execution_cache_size: usize,
-    /// Share Reth's cross-block execution cache with the native payload builder.
-    ///
-    /// The Arbitrum driver builds one payload at a time, so the shared cache cannot race a
-    /// concurrent payload job and can safely serve repeated account, storage, and bytecode reads.
-    pub share_execution_cache_with_payload_builder: bool,
-    /// Share reth's sparse trie task with the native payload builder.
-    ///
-    /// This overlaps state-root computation with ArbOS execution. It is disabled by default to
-    /// retain reth's conservative payload-builder behavior on hosts that may build payloads in
-    /// parallel.
-    pub share_sparse_trie_with_payload_builder: bool,
+    tree_config: TreeConfig,
 }
 
 impl Default for ArbEngineTuning {
@@ -772,31 +750,30 @@ impl ArbEngineTuning {
     /// / small runs (and tests that assert a produced block is durably persisted immediately);
     /// use [`Default`] for bulk historical sync throughput.
     pub fn reth_defaults() -> Self {
-        Self {
-            persistence_threshold: 2,
-            memory_block_buffer_target: 0,
-            persistence_backpressure_threshold: 16,
-            execution_cache_size: 256 * 1024 * 1024,
-            share_execution_cache_with_payload_builder: true,
-            share_sparse_trie_with_payload_builder: false,
-        }
+        Self::from_tree_config(
+            TreeConfig::default()
+                // TreeConfig validates its invariants after every builder call. Set the upper
+                // bound first so deep configurations are valid in debug builds too.
+                .with_persistence_backpressure_threshold(16)
+                .with_persistence_threshold(2)
+                .with_memory_block_buffer_target(0)
+                .with_cross_block_cache_size(256 * 1024 * 1024)
+                .with_share_execution_cache_with_payload_builder(true)
+                .with_share_sparse_trie_with_payload_builder(false),
+        )
     }
 
-    /// Build a reth [`TreeConfig`] from these knobs (all other fields keep reth defaults).
-    pub fn to_tree_config(self) -> TreeConfig {
-        TreeConfig::default()
-            // TreeConfig validates its invariants after every builder call. Set the upper bound
-            // first so deep configurations are valid in debug builds too.
-            .with_persistence_backpressure_threshold(self.persistence_backpressure_threshold)
-            .with_persistence_threshold(self.persistence_threshold)
-            .with_memory_block_buffer_target(self.memory_block_buffer_target)
-            .with_cross_block_cache_size(self.execution_cache_size)
-            .with_share_execution_cache_with_payload_builder(
-                self.share_execution_cache_with_payload_builder,
-            )
-            .with_share_sparse_trie_with_payload_builder(
-                self.share_sparse_trie_with_payload_builder,
-            )
+    /// Retain the complete reth engine-tree configuration instead of selecting a local subset.
+    ///
+    /// This lets native CLI and TOML settings such as state-root fallback, sparse-trie pruning,
+    /// prewarming, and provider metrics reach the engine tree unchanged.
+    pub const fn from_tree_config(tree_config: TreeConfig) -> Self {
+        Self { tree_config }
+    }
+
+    /// Return the reth engine-tree configuration used by the driver.
+    pub fn to_tree_config(&self) -> TreeConfig {
+        self.tree_config.clone()
     }
 }
 
@@ -1238,11 +1215,11 @@ where
         let tree_config = tuning.to_tree_config();
         tracing::info!(
             target: "arb-reth::engine",
-            persistence_threshold = tuning.persistence_threshold,
-            memory_block_buffer_target = tuning.memory_block_buffer_target,
-            persistence_backpressure_threshold = tuning.persistence_backpressure_threshold,
-            share_execution_cache = tuning.share_execution_cache_with_payload_builder,
-            share_sparse_trie = tuning.share_sparse_trie_with_payload_builder,
+            persistence_threshold = tree_config.persistence_threshold(),
+            memory_block_buffer_target = tree_config.memory_block_buffer_target(),
+            persistence_backpressure_threshold = tree_config.persistence_backpressure_threshold(),
+            share_execution_cache = tree_config.share_execution_cache_with_payload_builder(),
+            share_sparse_trie = tree_config.share_sparse_trie_with_payload_builder(),
             "engine-tree payload and persistence configuration",
         );
 

--- a/crates/arb-reth-node/Cargo.toml
+++ b/crates/arb-reth-node/Cargo.toml
@@ -95,11 +95,14 @@ futures-util = "0.3"
 # aws-lc-rs provider once at startup (see bin/arb-reth.rs). Direct dep only for that install call.
 rustls = { version = "0.23", default-features = false, features = ["aws_lc_rs"] }
 
-# D.3b.4: bin/arb-reth (clap CLI, reth runtime/ctrl-c harness, tracing, node-core)
+# D.3b.4: bin/arb-reth (native Reth CLI, runtime/ctrl-c harness, tracing, node-core)
 clap = { version = "4", features = ["derive"] }
+reth-cli = { git = "https://github.com/nuntax/reth.git", rev = "547581ff58e62577ef880e986a1b870feaa1a1b0" }
+reth-cli-commands = { git = "https://github.com/nuntax/reth.git", rev = "547581ff58e62577ef880e986a1b870feaa1a1b0" }
 reth-cli-runner = { git = "https://github.com/nuntax/reth.git", rev = "547581ff58e62577ef880e986a1b870feaa1a1b0" }
 reth-tracing = { git = "https://github.com/nuntax/reth.git", rev = "547581ff58e62577ef880e986a1b870feaa1a1b0" }
 reth-node-core = { git = "https://github.com/nuntax/reth.git", rev = "547581ff58e62577ef880e986a1b870feaa1a1b0" }
+reth-node-metrics = { git = "https://github.com/nuntax/reth.git", rev = "547581ff58e62577ef880e986a1b870feaa1a1b0" }
 reth-metrics = { git = "https://github.com/nuntax/reth.git", rev = "547581ff58e62577ef880e986a1b870feaa1a1b0" }
 
 # D.5: Arbitrum RPC converters (receipt/rpc converters), consumed by the canonical RpcAddOns wiring.

--- a/crates/arb-reth-node/Cargo.toml
+++ b/crates/arb-reth-node/Cargo.toml
@@ -103,6 +103,7 @@ reth-cli-runner = { git = "https://github.com/nuntax/reth.git", rev = "547581ff5
 reth-tracing = { git = "https://github.com/nuntax/reth.git", rev = "547581ff58e62577ef880e986a1b870feaa1a1b0" }
 reth-node-core = { git = "https://github.com/nuntax/reth.git", rev = "547581ff58e62577ef880e986a1b870feaa1a1b0" }
 reth-node-metrics = { git = "https://github.com/nuntax/reth.git", rev = "547581ff58e62577ef880e986a1b870feaa1a1b0" }
+reth-node-events = { git = "https://github.com/nuntax/reth.git", rev = "547581ff58e62577ef880e986a1b870feaa1a1b0" }
 reth-metrics = { git = "https://github.com/nuntax/reth.git", rev = "547581ff58e62577ef880e986a1b870feaa1a1b0" }
 
 # D.5: Arbitrum RPC converters (receipt/rpc converters), consumed by the canonical RpcAddOns wiring.

--- a/crates/arb-reth-node/src/bin/arb-reth.rs
+++ b/crates/arb-reth-node/src/bin/arb-reth.rs
@@ -3,7 +3,7 @@
 //! Dispatches clap subcommands into the per-command implementations in
 //! [`arb_reth_node::commands`]:
 //!
-//! - `node`             the standalone no-engine node (feed / L1-derivation block producer + RPC)
+//! - `node`             the standalone Arbitrum node (feed / L1-derivation block producer + RPC)
 //! - `snapshot import`  import a Nitro genesis-state stream into reth MDBX
 //! - `snapshot import-full`  convert a full-snapshot stream (blocks + history + state)
 //! - `snapshot read`    read hashed-state from a converted snapshot
@@ -18,7 +18,7 @@ use arb_reth_node::commands::{
     self,
     dump_blocks::DumpBlocksArgs,
     genesis::{GenesisVerifyArgs, GenesisVerifyExportArgs},
-    node::NodeArgs,
+    node::{ArbChainSpecParser, ArbNodeArgs},
     rewind::RewindArgs,
     snapshot::{
         SnapshotBuildPreimagesArgs, SnapshotImportArgs, SnapshotReadArgs,
@@ -27,8 +27,14 @@ use arb_reth_node::commands::{
     snapshot_full::{SnapshotFinalizeArgs, SnapshotImportFullArgs},
 };
 use clap::{Args, Parser, Subcommand};
+use reth_cli_commands::node::NodeCommand;
 use reth_cli_runner::CliRunner;
-use reth_tracing::{RethTracer, Tracer};
+use reth_node_core::{
+    args::{DefaultEngineValues, LogArgs, OtlpInitStatus, TraceArgs},
+    version::version_metadata,
+};
+use reth_node_metrics::recorder::install_prometheus_recorder;
+use reth_tracing::{Layers, tracing::{info, warn}};
 
 /// Stack-probe shim for x86_64: wasmer references `__rust_probestack` which recent
 /// `compiler-builtins` no longer exports; this satisfies the linker. No-op on aarch64.
@@ -41,17 +47,32 @@ use reth_tracing::{RethTracer, Tracer};
 pub unsafe extern "C" fn __rust_probestack() {}
 
 #[derive(Debug, Parser)]
-#[command(name = "arb-reth", about = "Standalone no-engine Arbitrum (ArbOS-on-reth) node")]
+#[command(
+    author,
+    name = version_metadata().name_client.as_ref(),
+    version = version_metadata().short_version.as_ref(),
+    long_version = version_metadata().long_version.as_ref(),
+    about = "Standalone Arbitrum node built on Reth",
+    long_about = None
+)]
 struct Cli {
     #[command(subcommand)]
     command: Command,
+
+    /// Reth logging configuration.
+    #[command(flatten)]
+    logs: LogArgs,
+
+    /// Reth OpenTelemetry tracing configuration.
+    #[command(flatten)]
+    traces: TraceArgs,
 }
 
 #[derive(Debug, Subcommand)]
 #[allow(clippy::large_enum_variant)]
 enum Command {
-    /// Run the standalone no-engine Arbitrum node.
-    Node(NodeArgs),
+    /// Run the standalone Arbitrum node.
+    Node(Box<NodeCommand<ArbChainSpecParser, ArbNodeArgs>>),
     /// Snapshot import/read tools.
     Snapshot(SnapshotCmd),
     /// Genesis verification tools.
@@ -99,8 +120,36 @@ enum GenesisSub {
 }
 
 fn main() -> eyre::Result<()> {
-    // Idiomatic reth tracing; guard is held for the process lifetime.
-    let _guard = RethTracer::new().init()?;
+    // Use Reth's native engine flags while retaining Arbitrum's empirically sensible defaults.
+    // `try_init` must happen before clap evaluates the flag defaults.
+    DefaultEngineValues::default()
+        .with_persistence_threshold(2)
+        .with_persistence_backpressure_threshold(16)
+        .with_memory_block_buffer_target(0)
+        .with_cross_block_cache_size(256)
+        .with_share_execution_cache_with_payload_builder(true)
+        .with_share_sparse_trie_with_payload_builder(false)
+        .try_init()
+        .expect("arb-reth initializes engine defaults before any CLI parsing");
+
+    let mut cli = Cli::parse();
+    let runner = CliRunner::try_default_runtime()?;
+
+    let mut layers = Layers::new();
+    let otlp_status = runner.block_on(cli.traces.init_otlp_tracing(&mut layers))?;
+    let _guard = cli.logs.init_tracing_with_layers(layers, false)?;
+    match otlp_status {
+        OtlpInitStatus::Started(endpoint) => {
+            info!(target: "arb-reth", %endpoint, "OTLP trace export enabled");
+        }
+        OtlpInitStatus::NoFeature => {
+            warn!(target: "arb-reth", "OTLP tracing requested without the otlp feature");
+        }
+        OtlpInitStatus::Disabled => {}
+    }
+
+    // Install the native recorder before any Arbitrum or Reth metric handle is initialized.
+    install_prometheus_recorder();
 
     // rustls 0.23 carries both the aws-lc-rs and ring backends in our dep tree, so it can't pick a
     // process-default CryptoProvider on its own; the first wss:// feed connect (connect_async builds
@@ -108,13 +157,10 @@ fn main() -> eyre::Result<()> {
     // Install the aws-lc-rs provider once here. Err just means one is already installed, so ignore.
     let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
 
-    let cli = Cli::parse();
-
     match cli.command {
-        Command::Node(args) => {
-            let runner = CliRunner::try_default_runtime()?;
-            runner.run_command_until_exit(|ctx| commands::node::run(ctx, args))
-        }
+        Command::Node(command) => runner.run_command_until_exit(move |ctx| {
+            commands::node::run(ctx, *command)
+        }),
         Command::Snapshot(cmd) => match cmd.command {
             SnapshotSub::BuildPreimages(args) => commands::snapshot::build_preimages(args),
             SnapshotSub::Import(args) => commands::snapshot::import(args),

--- a/crates/arb-reth-node/src/bin/arb-reth.rs
+++ b/crates/arb-reth-node/src/bin/arb-reth.rs
@@ -34,7 +34,11 @@ use reth_node_core::{
     version::version_metadata,
 };
 use reth_node_metrics::recorder::install_prometheus_recorder;
-use reth_tracing::{Layers, tracing::{info, warn}};
+use reth_tasks::RayonConfig;
+use reth_tracing::{
+    Layers,
+    tracing::{info, warn},
+};
 
 /// Stack-probe shim for x86_64: wasmer references `__rust_probestack` which recent
 /// `compiler-builtins` no longer exports; this satisfies the linker. No-op on aarch64.
@@ -147,7 +151,17 @@ fn main() -> eyre::Result<()> {
     if matches!(&cli.command, Command::Node(_)) {
         cli.logs.apply_node_defaults();
     }
-    let runner = CliRunner::try_default_runtime()?;
+    let runtime_config = match &cli.command {
+        Command::Node(command) => reth_tasks::RuntimeConfig::default().with_rayon(RayonConfig {
+            reserved_cpu_cores: command.engine.reserved_cpu_cores,
+            proof_storage_worker_threads: command.engine.storage_worker_count,
+            proof_account_worker_threads: command.engine.account_worker_count,
+            prewarming_threads: command.engine.prewarming_threads,
+            ..Default::default()
+        }),
+        _ => reth_tasks::RuntimeConfig::default(),
+    };
+    let runner = CliRunner::try_with_runtime_config(runtime_config)?;
 
     let mut layers = Layers::new();
     let otlp_status = runner.block_on(cli.traces.init_otlp_tracing(&mut layers))?;
@@ -172,9 +186,9 @@ fn main() -> eyre::Result<()> {
     let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
 
     match cli.command {
-        Command::Node(command) => runner.run_command_until_exit(move |ctx| {
-            commands::node::run(ctx, *command)
-        }),
+        Command::Node(command) => {
+            runner.run_command_until_exit(move |ctx| commands::node::run(ctx, *command))
+        }
         Command::Snapshot(cmd) => match cmd.command {
             SnapshotSub::BuildPreimages(args) => commands::snapshot::build_preimages(args),
             SnapshotSub::Import(args) => commands::snapshot::import(args),

--- a/crates/arb-reth-node/src/bin/arb-reth.rs
+++ b/crates/arb-reth-node/src/bin/arb-reth.rs
@@ -30,7 +30,7 @@ use clap::{Args, Parser, Subcommand};
 use reth_cli_commands::node::NodeCommand;
 use reth_cli_runner::CliRunner;
 use reth_node_core::{
-    args::{DefaultEngineValues, LogArgs, OtlpInitStatus, TraceArgs},
+    args::{DefaultEngineValues, DefaultLogArgs, LogArgs, OtlpInitStatus, TraceArgs},
     version::version_metadata,
 };
 use reth_node_metrics::recorder::install_prometheus_recorder;
@@ -120,6 +120,17 @@ enum GenesisSub {
 }
 
 fn main() -> eyre::Result<()> {
+    // Ethereum's per-payload and per-commit INFO logs are too noisy for Arbitrum's block cadence.
+    // Keep periodic progress, lifecycle events, warnings, and errors at INFO. Operators can still
+    // opt into either hot-path target with the native log-filter flags.
+    const ARB_NODE_LOG_FILTER: &str = "payload_builder=warn,reth_node_events::node=warn";
+    const ARB_NODE_FILE_LOG_FILTER: &str = "info,payload_builder=warn,reth_node_events::node=warn";
+    DefaultLogArgs::default()
+        .with_log_stdout_filter(ARB_NODE_LOG_FILTER.to_string())
+        .with_log_file_filter(ARB_NODE_FILE_LOG_FILTER.to_string())
+        .try_init()
+        .expect("arb-reth initializes log defaults before any CLI parsing");
+
     // Use Reth's native engine flags while retaining Arbitrum's empirically sensible defaults.
     // `try_init` must happen before clap evaluates the flag defaults.
     DefaultEngineValues::default()
@@ -133,6 +144,9 @@ fn main() -> eyre::Result<()> {
         .expect("arb-reth initializes engine defaults before any CLI parsing");
 
     let mut cli = Cli::parse();
+    if matches!(&cli.command, Command::Node(_)) {
+        cli.logs.apply_node_defaults();
+    }
     let runner = CliRunner::try_default_runtime()?;
 
     let mut layers = Layers::new();

--- a/crates/arb-reth-node/src/bin/arb-reth.rs
+++ b/crates/arb-reth-node/src/bin/arb-reth.rs
@@ -21,12 +21,11 @@ use arb_reth_node::commands::{
     node::{ArbChainSpecParser, ArbNodeArgs},
     rewind::RewindArgs,
     snapshot::{
-        SnapshotBuildPreimagesArgs, SnapshotImportArgs, SnapshotReadArgs,
-        SnapshotRepairHistoryArgs,
+        SnapshotBuildPreimagesArgs, SnapshotImportArgs, SnapshotReadArgs, SnapshotRepairHistoryArgs,
     },
     snapshot_full::{SnapshotFinalizeArgs, SnapshotImportFullArgs},
 };
-use clap::{Args, Parser, Subcommand};
+use clap::{Args, Parser, Subcommand, error::ErrorKind};
 use reth_cli_commands::node::NodeCommand;
 use reth_cli_runner::CliRunner;
 use reth_node_core::{
@@ -123,6 +122,30 @@ enum GenesisSub {
     VerifyExport(GenesisVerifyExportArgs),
 }
 
+const CLI_MIGRATION_NOTE: &str = "note: the arb-reth node CLI migrated to Reth's native layout; see https://github.com/nuntax/arbitrum-reth/blob/main/docs/cli-migration.md";
+
+fn migration_note(error: &clap::Error) -> Option<&'static str> {
+    matches!(
+        error.kind(),
+        ErrorKind::InvalidSubcommand | ErrorKind::UnknownArgument
+    )
+    .then_some(CLI_MIGRATION_NOTE)
+}
+
+fn parse_cli() -> Cli {
+    Cli::try_parse().unwrap_or_else(|error| {
+        let note = migration_note(&error);
+        let exit_code = error.exit_code();
+        if let Err(print_error) = error.print() {
+            eprintln!("{print_error}");
+        }
+        if let Some(note) = note {
+            eprintln!("\n{note}");
+        }
+        std::process::exit(exit_code);
+    })
+}
+
 fn main() -> eyre::Result<()> {
     // Ethereum's per-payload and per-commit INFO logs are too noisy for Arbitrum's block cadence.
     // Keep periodic progress, lifecycle events, warnings, and errors at INFO. Operators can still
@@ -147,7 +170,7 @@ fn main() -> eyre::Result<()> {
         .try_init()
         .expect("arb-reth initializes engine defaults before any CLI parsing");
 
-    let mut cli = Cli::parse();
+    let mut cli = parse_cli();
     if matches!(&cli.command, Command::Node(_)) {
         cli.logs.apply_node_defaults();
     }
@@ -203,5 +226,38 @@ fn main() -> eyre::Result<()> {
         },
         Command::Rewind(args) => commands::rewind::run(args),
         Command::DumpBlocks(args) => commands::dump_blocks::run(args),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unknown_subcommand_points_to_cli_migration() {
+        let error = Cli::try_parse_from(["arb-reth", "run"]).unwrap_err();
+
+        assert_eq!(error.kind(), ErrorKind::InvalidSubcommand);
+        assert_eq!(migration_note(&error), Some(CLI_MIGRATION_NOTE));
+    }
+
+    #[test]
+    fn unknown_argument_points_to_cli_migration() {
+        let error =
+            Cli::try_parse_from(["arb-reth", "node", "--persistence-threshold", "2"]).unwrap_err();
+
+        assert_eq!(error.kind(), ErrorKind::UnknownArgument);
+        assert_eq!(migration_note(&error), Some(CLI_MIGRATION_NOTE));
+    }
+
+    #[test]
+    fn other_cli_errors_do_not_point_to_migration() {
+        let error = Cli::try_parse_from(["arb-reth"]).unwrap_err();
+
+        assert_eq!(
+            error.kind(),
+            ErrorKind::DisplayHelpOnMissingArgumentOrSubcommand
+        );
+        assert_eq!(migration_note(&error), None);
     }
 }

--- a/crates/arb-reth-node/src/commands/node.rs
+++ b/crates/arb-reth-node/src/commands/node.rs
@@ -249,7 +249,6 @@ pub struct ArbNodeArgs {
     /// Use with `--datadir <imported-dir>`; no separate Reth chain spec is needed.
     #[arg(long = "snapshot-head", value_name = "PATH")]
     snapshot_head: Option<PathBuf>,
-
 }
 
 /// The L1 rollup deployment arb-reth reads from: the contract addresses plus the L1 block the
@@ -408,19 +407,16 @@ struct NodeBootstrap {
 async fn resolve_bootstrap(
     args: &ArbNodeArgs,
     fallback_chain_spec: Arc<ChainSpec>,
+    snapshot_datadir: Option<&Path>,
 ) -> eyre::Result<NodeBootstrap> {
-
     // --chain-info plus --genesis boots an Orbit chain. The pair supplies both the chain spec and
     // prealloc state, plus the L1 rollup deployment. Accepting either file alone would silently
     // construct a different genesis.
-    let orbit = match orbit_boot_paths(
-        args.chain_info.as_deref(),
-        args.genesis_json.as_deref(),
-    )? {
+    let orbit = match orbit_boot_paths(args.chain_info.as_deref(), args.genesis_json.as_deref())? {
         Some((ci, genesis)) => {
             let ci_json = fs::read(ci).map_err(|e| eyre::eyre!("read chain-info {ci:?}: {e}"))?;
-            let genesis_json = fs::read(genesis)
-                .map_err(|e| eyre::eyre!("read genesis {genesis:?}: {e}"))?;
+            let genesis_json =
+                fs::read(genesis).map_err(|e| eyre::eyre!("read genesis {genesis:?}: {e}"))?;
             let (spec, init, info) = crate::orbit_chain_from_files(&ci_json, &genesis_json)?;
             Some((std::sync::Arc::new(spec), init, info))
         }
@@ -463,9 +459,8 @@ async fn resolve_bootstrap(
         (None, Some(head_path), _) => {
             let (num, hash, header) = crate::read_head_header(head_path)?;
             snapshot_delayed = Some(u64::from_be_bytes(header.nonce.0));
-            let datadir = args.datadir.as_deref().ok_or_else(|| {
-                eyre::eyre!("--snapshot-head requires an explicit --datadir")
-            })?;
+            let datadir = snapshot_datadir
+                .ok_or_else(|| eyre::eyre!("--snapshot-head requires an explicit --datadir"))?;
             super::snapshot::validate_snapshot_import_for_launch(
                 datadir,
                 &(num, hash, header.clone()),
@@ -552,7 +547,13 @@ pub async fn run(
         }
     }
 
-    let bootstrap = resolve_bootstrap(&command.ext, command.chain.clone()).await?;
+    let snapshot_datadir = command.datadir.datadir.as_ref().map(Path::to_path_buf);
+    let bootstrap = resolve_bootstrap(
+        &command.ext,
+        command.chain.clone(),
+        snapshot_datadir.as_deref(),
+    )
+    .await?;
     command.chain = bootstrap.chain_spec.clone();
 
     command
@@ -599,18 +600,14 @@ fn validate_standalone_components(
             "dev mode is unsupported: ArbOS blocks must be derived from Arbitrum messages"
         ));
     }
-    if command.era.enabled
-        || command.era.source.path.is_some()
-        || command.era.source.url.is_some()
+    if command.era.enabled || command.era.source.path.is_some() || command.era.source.url.is_some()
     {
         return Err(eyre::eyre!(
             "ERA import is unsupported: it imports Ethereum block bodies rather than deriving ArbOS blocks"
         ));
     }
     if command.jit != Default::default() {
-        return Err(eyre::eyre!(
-            "--jit options are not wired to arb-revm yet"
-        ));
+        return Err(eyre::eyre!("--jit options are not wired to arb-revm yet"));
     }
 
     Ok(())
@@ -811,15 +808,21 @@ async fn launch(
         let (start_block, start_delayed, start_l2_block) = if let Some(b) = args.l1_start_block {
             // Manual override: the operator asserts `b` is the batch boundary the tip was built
             // from, so the next derived block is `db_tip + 1`.
-            let delayed = match args.l1_start_delayed {
-                Some(delayed) => delayed,
-                None => header_delayed_messages_read(&handle.provider, db_tip)?.ok_or_else(|| {
+            let delayed = args
+                .l1_start_delayed
+                .or(snapshot_delayed)
+                .or(if db_tip == l2_genesis_block {
+                    genesis_delayed
+                } else {
+                    None
+                })
+                .or(header_delayed_messages_read(&handle.provider, db_tip)?)
+                .ok_or_else(|| {
                     eyre::eyre!(
                         "cannot recover the delayed-message cursor: durable L2 tip header \
                          {db_tip} is missing; pass --l1-start-delayed explicitly"
                     )
-                })?,
-            };
+                })?;
             info!(target: "arb-reth", l1_block = b, delayed, l2_block = db_tip, "L1 resume point: --l1-start-block override");
             (b, delayed, db_tip)
         } else if let Some(log) = &resume_log {
@@ -914,9 +917,7 @@ async fn launch(
         let tx = l1_tx.clone();
         let fatal_tx = l1_fatal_tx;
         task_executor.spawn_with_graceful_shutdown_signal(|shutdown| async move {
-            if let Err(e) =
-                crate::supervise_l1_sync(sync_cfg, tx, persisted_tip, shutdown).await
-            {
+            if let Err(e) = crate::supervise_l1_sync(sync_cfg, tx, persisted_tip, shutdown).await {
                 reth_tracing::tracing::error!(
                     target: "arb-reth",
                     err = %e,
@@ -951,8 +952,8 @@ mod tests {
     use super::*;
     use alloy_consensus::Header;
     use alloy_primitives::{B64, B256};
-    use reth_provider::test_utils::MockEthProvider;
     use clap::{Parser, Subcommand};
+    use reth_provider::test_utils::MockEthProvider;
 
     const ROBINHOOD_CHAIN_INFO: &[u8] =
         include_bytes!("../../tests/fixtures/robinhood-chain-info.json");
@@ -1139,7 +1140,7 @@ mod tests {
         .command;
 
         assert_eq!(command.engine.persistence_threshold, 128);
-        assert_eq!(command.engine.memory_block_buffer_target, 64);
+        assert_eq!(command.engine.memory_block_buffer_target, Some(64));
         assert_eq!(command.engine.persistence_backpressure_threshold(), 512);
         assert_eq!(command.db.sync_mode, Some(SyncMode::SafeNoSync));
         assert!(command.pruning.full);
@@ -1152,26 +1153,19 @@ mod tests {
 
     #[test]
     fn generic_genesis_does_not_replace_arbos_bootstrap() {
-        let err = TestCli::try_parse_from([
-            "arb-reth",
-            "node",
-            "--chain",
-            "/tmp/ethereum-genesis.json",
-        ])
-        .expect_err("a generic Ethereum genesis is not an ArbOS bootstrap input");
+        let err =
+            TestCli::try_parse_from(["arb-reth", "node", "--chain", "/tmp/ethereum-genesis.json"])
+                .expect_err("a generic Ethereum genesis is not an ArbOS bootstrap input");
 
         assert!(err.to_string().contains("unsupported Arbitrum chain spec"));
     }
 
     #[test]
     fn noop_component_options_are_rejected() {
-        let TestCommand::Node(command) = TestCli::try_parse_from([
-            "arb-reth",
-            "node",
-            "--disable-discovery",
-        ])
-        .expect("the native parser should accept its standard flag")
-        .command;
+        let TestCommand::Node(command) =
+            TestCli::try_parse_from(["arb-reth", "node", "--disable-discovery"])
+                .expect("the native parser should accept its standard flag")
+                .command;
 
         let err = validate_standalone_components(&command)
             .expect_err("a no-op network setting must not be silently accepted");

--- a/crates/arb-reth-node/src/commands/node.rs
+++ b/crates/arb-reth-node/src/commands/node.rs
@@ -1122,6 +1122,8 @@ mod tests {
             "--ws",
             "--ws.port",
             "8548",
+            "--rpc.gascap",
+            "max",
             "--db.sync-mode",
             "safe-no-sync",
             "--engine.persistence-threshold",
@@ -1143,6 +1145,7 @@ mod tests {
         assert_eq!(command.engine.memory_block_buffer_target, Some(64));
         assert_eq!(command.engine.persistence_backpressure_threshold(), 512);
         assert_eq!(command.db.sync_mode, Some(SyncMode::SafeNoSync));
+        assert_eq!(command.rpc.rpc_gas_cap, u64::MAX);
         assert!(command.pruning.full);
         assert_eq!(
             command.ext.chain_config,

--- a/crates/arb-reth-node/src/commands/node.rs
+++ b/crates/arb-reth-node/src/commands/node.rs
@@ -17,13 +17,13 @@
 //! node alive until SIGTERM. This lets a user run a finite replay and then inspect
 //! the produced blocks via JSON-RPC.
 //!
-//! With `--chain <PATH>` an Arbitrum chain-config JSON is parsed to produce a real
+//! With `--arb-chain-config <PATH>` an Arbitrum chain-config JSON is parsed to produce a real
 //! ArbOS genesis allocation instead of the MAINNET placeholder.
 
 use std::{
     fs,
-    net::{IpAddr, SocketAddr},
     path::{Path, PathBuf},
+    sync::Arc,
 };
 
 use crate::feed;
@@ -39,107 +39,67 @@ use alloy_provider::{Provider, ProviderBuilder};
 use arb_reth_l1::{DelayedInboxReader, SequencerInboxReader};
 use arbitrum_alloy_sequencer::init_message::parse_init_message_from_body;
 use arbitrum_alloy_sequencer::sequencer::feed::BroadcastFeedMessage;
-use clap::Parser;
+use clap::Args;
 use reth_chainspec::{ChainSpec, MAINNET};
+use reth_cli::chainspec::ChainSpecParser;
+use reth_cli_commands::{launcher::FnLauncher, node::NodeCommand};
 use reth_cli_runner::CliContext;
-use reth_db::{ClientVersion, init_db, mdbx::DatabaseArguments, mdbx::SyncMode};
-use reth_node_builder::{LaunchContext, LaunchNode, NodeBuilder, NodeConfig};
-use reth_node_core::{
-    args::{DatadirArgs, MetricArgs, PruningArgs},
-    dirs::{DataDirPath, MaybePlatformPath},
-};
+use reth_db::{DatabaseEnv, mdbx::SyncMode};
+use reth_node_builder::{LaunchContext, NodeBuilder, WithLaunchContext};
 use reth_provider::{BlockNumReader, HeaderProvider};
 use reth_tracing::tracing::info;
 
-/// `arb-reth`: standalone no-engine Arbitrum (ArbOS-on-reth) node.
-#[derive(Debug, Parser)]
-#[command(
-    name = "arb-reth",
-    about = "Standalone no-engine Arbitrum (ArbOS-on-reth) node"
-)]
-pub struct NodeArgs {
-    /// Data directory for the node's database and static files.
-    /// Defaults to the platform-specific reth data directory for this chain.
-    #[arg(long, value_name = "PATH")]
-    datadir: Option<PathBuf>,
+/// Reth chain-spec parser for the standalone Arbitrum node.
+///
+/// `arb-one` is the placeholder specification used until an Arbitrum bootstrap source resolves
+/// the actual chain state. ArbOS genesis must come from `--arb-chain-config`, an Orbit
+/// `--chain-info`/`--genesis` pair, or `--snapshot-head`; a generic Ethereum genesis does not
+/// contain the ArbOS system state this node requires.
+#[derive(Debug, Clone, Default)]
+pub struct ArbChainSpecParser;
 
-    /// Enable the `eth_*` JSON-RPC HTTP server.
-    #[arg(long = "http")]
-    http: bool,
+impl ChainSpecParser for ArbChainSpecParser {
+    type ChainSpec = ChainSpec;
 
-    /// HTTP-RPC server bind address.
-    #[arg(long = "http.addr", default_value = "127.0.0.1")]
-    http_addr: IpAddr,
+    const SUPPORTED_CHAINS: &'static [&'static str] = &["arb-one"];
 
-    /// HTTP-RPC server port.
-    #[arg(long = "http.port", default_value_t = 8545)]
-    http_port: u16,
+    fn parse(value: &str) -> eyre::Result<Arc<Self::ChainSpec>> {
+        match value {
+            "arb-one" => Ok(MAINNET.clone()),
+            _ => Err(eyre::eyre!(
+                "unsupported Arbitrum chain spec; use --arb-chain-config, --chain-info with --genesis, or --snapshot-head"
+            )),
+        }
+    }
 
-    /// Enable the reth Prometheus endpoint at this address.
-    #[arg(long = "metrics", alias = "metrics.prometheus", value_name = "ADDR")]
-    metrics: Option<SocketAddr>,
+    fn help_message() -> String {
+        "Reth chain-spec identity for this standalone Arbitrum node.\n\
+         \n\
+         `arb-one` is the only built-in placeholder. Supply ArbOS state separately with \
+         `--arb-chain-config`, `--chain-info` plus `--genesis`, or `--snapshot-head`.\n\
+         \n\
+         Built-in chains:\n    arb-one"
+            .to_owned()
+    }
+}
 
-    /// Path to a local Unix socket that receives one newline-delimited JSON event immediately
-    /// after each ArbOS transaction executes. This is a best-effort, pre-canonical stream: an
-    /// enclosing block can still fail during root calculation or engine insertion.
-    #[arg(long = "mev-tx-log-ipc", value_name = "PATH")]
-    mev_tx_log_ipc: Option<PathBuf>,
-
-    /// Engine-tree persistence threshold: persist once the canonical tip is this many blocks
-    /// ahead of the last persisted block (larger = bigger, less frequent commit batches).
-    #[arg(long, default_value_t = 2)]
-    persistence_threshold: u64,
-
-    /// Engine-tree memory buffer target: keep this many recent blocks in memory before flushing.
-    #[arg(long = "memory-buffer-target", default_value_t = 0)]
-    memory_buffer_target: u64,
-
-    /// Engine-tree backpressure threshold: stall block production once this many blocks are
-    /// unpersisted (bounds memory; larger = production runs further ahead of the disk).
-    #[arg(long = "persistence-backpressure", default_value_t = 16)]
-    persistence_backpressure: u64,
-
-    /// Size in MiB of reth's cross-block account, storage, and bytecode cache.
+/// Arbitrum-specific arguments appended to Reth's native [`NodeCommand`].
+///
+/// Generic node concerns such as the datadir, RPC, metrics, database durability, pruning, and
+/// engine-tree tuning deliberately live in Reth's command. This type only describes the inputs
+/// that cannot exist on an L1 node.
+#[derive(Debug, Args)]
+pub struct ArbNodeArgs {
+    /// Compatibility alias for `--db.sync-mode safe-no-sync`.
     ///
-    /// The Arbitrum default is 256 MiB. Reth's generic TreeConfig default is 4 GiB, which makes
-    /// its fixed-cache tables needlessly sparse for this serial producer.
-    #[arg(long = "engine.cross-block-cache-size", default_value_t = 256, value_name = "MiB")]
-    execution_cache_size_mb: usize,
-
-    /// Share reth's cross-block execution cache with the serial native payload builder.
-    #[arg(
-        long = "share-execution-cache-with-payload-builder",
-        default_value_t = true,
-        action = clap::ArgAction::Set,
-    )]
-    share_execution_cache_with_payload_builder: bool,
-
-    /// Let the native payload builder use reth's sparse trie task to overlap state-root work
-    /// with ArbOS execution. Recommended for this serial Arbitrum producer on a multi-core host.
-    #[arg(
-        long = "share-sparse-trie-with-payload-builder",
-        default_value_t = false
-    )]
-    share_sparse_trie_with_payload_builder: bool,
-
-    /// Open MDBX in `SafeNoSync` durability mode: skip the per-commit fsync during bulk
-    /// historical sync. Each block still commits to MDBX (so the parent state is visible to the
-    /// child), but the OS flushes lazily, cutting ~50ms fsync latency off every block. Stays
-    /// crash-consistent (MDBX rolls back to the last synced meta page on restart); the only loss
-    /// on a crash is a suffix of recently-produced blocks, which the L1 derivation re-produces.
-    /// Not for a node expected to be durable across power loss without re-sync.
+    /// New invocations should use Reth's database flag directly. Keeping this temporarily avoids
+    /// breaking existing operator scripts while the CLI migrates.
     #[arg(long = "no-fsync", default_value_t = false)]
     no_fsync: bool,
 
     /// Arbitrum execution chain id used by the block driver.
     #[arg(long, default_value_t = ARB_ONE_CHAIN_ID)]
     chain_id: u64,
-
-    /// Path to an Arbitrum chain-config JSON file (the `ChainConfig` Go format:
-    /// `{"chainId":..., "arbitrum":{...}}`). When provided, the node boots with a
-    /// real ArbOS genesis allocation instead of the mainnet placeholder.
-    #[arg(long = "chain", value_name = "PATH")]
-    chain_config: Option<PathBuf>,
 
     /// Path to a Nitro `chaininfo.json` (array of chains: chain-id, parent-chain-id, chain-config,
     /// and the rollup deployment addresses). With `--genesis`, boots an Orbit chain end to end: the
@@ -155,7 +115,15 @@ pub struct NodeArgs {
     #[arg(long = "genesis", value_name = "PATH")]
     genesis_json: Option<PathBuf>,
 
-    /// Initial L1 base fee (wei) baked into the ArbOS genesis when booting from --chain.
+    /// Path to an Arbitrum chain-config JSON file (the Go `ChainConfig` format).
+    ///
+    /// This replaced the old `--chain` meaning. `--chain` is now the native Reth chain-spec
+    /// argument, while this flag specifically requests ArbOS genesis construction.
+    #[arg(long = "arb-chain-config", alias = "chain-config", value_name = "PATH")]
+    chain_config: Option<PathBuf>,
+
+    /// Initial L1 base fee (wei) baked into the ArbOS genesis when booting from
+    /// `--arb-chain-config`.
     /// Defaults to Nitro's `DefaultInitialL1BaseFee` of 50 GWei. This value is part of the
     /// genesis state, so a chain created with a different initial base fee (a nitro-testnode
     /// commonly uses a tiny value) needs this set to reproduce its genesis root.
@@ -171,6 +139,11 @@ pub struct NodeArgs {
     /// This lets you replay a finite file and then query the produced blocks.
     #[arg(long = "replay-feed", value_name = "PATH")]
     replay_feed: Option<PathBuf>,
+
+    /// Path to a local Unix socket that receives a best-effort event immediately after each ArbOS
+    /// transaction executes. An enclosing block can still fail before becoming canonical.
+    #[arg(long = "mev-tx-log-ipc", value_name = "PATH")]
+    mev_tx_log_ipc: Option<PathBuf>,
 
     /// Live sequencer-feed relay to follow, e.g. `ws://127.0.0.1:9642` (a nitro-testnode) or
     /// `wss://arb1.arbitrum.io/feed` (Arbitrum One). Repeat the option to race distinct relays. The
@@ -273,21 +246,10 @@ pub struct NodeArgs {
     /// Boot on a snapshot-imported datadir: path to the `reth-export --mode blocks` head stream
     /// (`H <num> <hash> <headerRLP>`). The node builds its chain spec from that head header so the
     /// genesis-hash check accepts the imported DB, and resumes from the snapshot's head block.
-    /// Use with `--datadir <imported-dir>` (do not pass `--chain`).
+    /// Use with `--datadir <imported-dir>`; no separate Reth chain spec is needed.
     #[arg(long = "snapshot-head", value_name = "PATH")]
     snapshot_head: Option<PathBuf>,
 
-    /// History-pruning / full-node configuration: reth's standard `--full` and granular
-    /// `--prune.*` flags (e.g. `--prune.account-history.distance <BLOCKS>`,
-    /// `--prune.storage-history.distance <BLOCKS>`, `--prune.receipts.distance <BLOCKS>`,
-    /// `--prune.transaction-lookup.full`, `--prune.sender-recovery.full`).
-    ///
-    /// With none of these set the node stays a full archive (keeps all state history). When any is
-    /// set, the engine-tree persistence service runs reth's pruner after each commit batch, dropping
-    /// the configured segments older than the requested window. `--full` applies reth's full-node
-    /// preset (keep only the most recent unwind-safe distance of account/storage history + receipts).
-    #[command(flatten)]
-    pruning: PruningArgs,
 }
 
 /// The L1 rollup deployment arb-reth reads from: the contract addresses plus the L1 block the
@@ -350,7 +312,7 @@ where
 ///   genesis default to a fresh chain (block 0), not Arbitrum One's heights. Either can still be
 ///   overridden explicitly.
 /// - Exactly one set: rejected, rather than pairing a custom address with an Arbitrum One one.
-fn resolve_rollup_deployment(args: &NodeArgs) -> eyre::Result<RollupDeployment> {
+fn resolve_rollup_deployment(args: &ArbNodeArgs) -> eyre::Result<RollupDeployment> {
     match (args.l1_sequencer_inbox, args.l1_bridge) {
         (None, None) => Ok(RollupDeployment {
             sequencer_inbox: arb_reth_l1::SEQUENCER_INBOX_MAINNET,
@@ -430,18 +392,23 @@ async fn derive_genesis_from_l1(
     Ok((spec, chain_id))
 }
 
-pub async fn run(ctx: CliContext, args: NodeArgs) -> eyre::Result<()> {
-    let task_executor = ctx.task_executor;
-    let feed_sources =
-        feed::expand_feed_sources(&args.feed_urls, args.feed_connections, &args.feed_sources)?;
-    if args.no_l1_derive && feed_sources.is_empty() {
-        return Err(eyre::eyre!("--no-l1-derive requires at least one --feed-url"));
-    }
-    let mev_tx_log_ipc = args
-        .mev_tx_log_ipc
-        .as_ref()
-        .map(|path| MevTxLogIpc::bind(path.clone()))
-        .transpose()?;
+struct NodeBootstrap {
+    chain_spec: Arc<ChainSpec>,
+    chain_id: u64,
+    rollup: RollupDeployment,
+    snapshot_delayed: Option<u64>,
+    genesis_delayed: Option<u64>,
+}
+
+/// Resolve Arbitrum's state-derived chain specification before Reth opens the database.
+///
+/// Reth's native node command owns generic configuration and database setup. Arbitrum's chain
+/// specification is different: a snapshot header, Nitro genesis, or the L1 Initialize message
+/// can be the source of truth, so it has to be resolved before handing the command to Reth.
+async fn resolve_bootstrap(
+    args: &ArbNodeArgs,
+    fallback_chain_spec: Arc<ChainSpec>,
+) -> eyre::Result<NodeBootstrap> {
 
     // --chain-info plus --genesis boots an Orbit chain. The pair supplies both the chain spec and
     // prealloc state, plus the L1 rollup deployment. Accepting either file alone would silently
@@ -470,13 +437,15 @@ pub async fn run(ctx: CliContext, args: NodeArgs) -> eyre::Result<()> {
             deployed_at: info.rollup.deployed_at,
             l2_genesis_block: init.genesis_block_number,
         },
-        None => resolve_rollup_deployment(&args)?,
+        None => resolve_rollup_deployment(args)?,
     };
 
     // --snapshot-head: boot on an imported snapshot DB by building the chain spec from its head
-    // header (so reth's genesis-hash check accepts the DB). Takes precedence over --chain.
-    // When --chain is provided the chain id is derived from the JSON so eth_chainId and the
-    // driver agree. When not provided, the mainnet placeholder is used with --chain-id.
+    // header (so reth's genesis-hash check accepts the DB). It takes precedence over the
+    // `arb-one` placeholder spec. The header anchors both eth_chainId and the driver.
+    // `snapshot_delayed` carries the L2 tip's `delayedMessagesRead` (the header nonce) so the
+    // L1-sync delayed cursor defaults to it without a manual flag.
+    let mut snapshot_delayed: Option<u64> = None;
     let (chain_spec, effective_chain_id) = match (&orbit, &args.snapshot_head, &args.chain_config) {
         (Some((spec, init, info)), _, _) => {
             info!(
@@ -493,6 +462,7 @@ pub async fn run(ctx: CliContext, args: NodeArgs) -> eyre::Result<()> {
         }
         (None, Some(head_path), _) => {
             let (num, hash, header) = crate::read_head_header(head_path)?;
+            snapshot_delayed = Some(u64::from_be_bytes(header.nonce.0));
             let datadir = args.datadir.as_deref().ok_or_else(|| {
                 eyre::eyre!("--snapshot-head requires an explicit --datadir")
             })?;
@@ -500,11 +470,10 @@ pub async fn run(ctx: CliContext, args: NodeArgs) -> eyre::Result<()> {
                 datadir,
                 &(num, hash, header.clone()),
             )?;
-            let delayed_messages_read = u64::from_be_bytes(header.nonce.0);
             info!(
                 target: "arb-reth",
                 head_block = num, %hash, chain_id = args.chain_id,
-                delayed_messages_read,
+                delayed_messages_read = snapshot_delayed.unwrap(),
                 "booting on snapshot head header",
             );
             (
@@ -548,19 +517,136 @@ pub async fn run(ctx: CliContext, args: NodeArgs) -> eyre::Result<()> {
                 );
                 (spec, cid)
             }
-            None => (MAINNET.clone(), args.chain_id),
+            None => (fallback_chain_spec, args.chain_id),
         },
     };
     let genesis_delayed =
         genesis_delayed_messages_read(chain_spec.as_ref(), rollup.l2_genesis_block);
 
-    // Resolve the pruning configuration from the `--prune.*` / `--full` flags before `chain_spec` is
-    // moved into the node config (the prune modes for `--full`/pre-merge presets are keyed off the
-    // chain's hardfork activations). `prune_config` returns `None` when no pruning flag is set, which
-    // keeps the node a full archive. The launcher passes the resulting config to both reth's
-    // provider factory and its pruner: the provider needs the modes while writing static files,
-    // while the pruner needs them when retiring old history.
-    let prune_config = args.pruning.prune_config(chain_spec.as_ref());
+    Ok(NodeBootstrap {
+        chain_spec,
+        chain_id: effective_chain_id,
+        rollup,
+        snapshot_delayed,
+        genesis_delayed,
+    })
+}
+
+/// Launch the native Reth node command with Arbitrum's derived chain state.
+pub async fn run(
+    ctx: CliContext,
+    mut command: NodeCommand<ArbChainSpecParser, ArbNodeArgs>,
+) -> eyre::Result<()> {
+    validate_standalone_components(&command)?;
+
+    if command.ext.no_fsync {
+        match command.db.sync_mode {
+            Some(SyncMode::SafeNoSync) | None => {
+                command.db.sync_mode = Some(SyncMode::SafeNoSync);
+            }
+            Some(mode) => {
+                return Err(eyre::eyre!(
+                    "--no-fsync conflicts with --db.sync-mode {mode:?}; use one durability mode"
+                ));
+            }
+        }
+    }
+
+    let bootstrap = resolve_bootstrap(&command.ext, command.chain.clone()).await?;
+    command.chain = bootstrap.chain_spec.clone();
+
+    command
+        .execute(
+            ctx,
+            FnLauncher::new::<ArbChainSpecParser, ArbNodeArgs>(move |builder, args| async move {
+                launch(builder, args, bootstrap).await
+            }),
+        )
+        .await
+}
+
+/// Reject native Reth option groups that have no component in this standalone topology.
+///
+/// `NodeCommand` owns the common node configuration, but Arbitrum derives blocks from L1/feed
+/// messages. It deliberately has no dev miner, devp2p network, transaction pool, generic payload
+/// builder, staged-pipeline debugger, ERA importer, or revmc-JIT wiring. Failing here is safer
+/// than accepting an option that the no-op component would ignore.
+fn validate_standalone_components(
+    command: &NodeCommand<ArbChainSpecParser, ArbNodeArgs>,
+) -> eyre::Result<()> {
+    if command.network != Default::default() {
+        return Err(eyre::eyre!(
+            "network options are unsupported: arb-reth derives Arbitrum messages from L1 and the sequencer feed, not devp2p"
+        ));
+    }
+    if command.txpool != Default::default() {
+        return Err(eyre::eyre!(
+            "txpool options are unsupported: the standalone node has no transaction pool"
+        ));
+    }
+    if command.builder != Default::default() {
+        return Err(eyre::eyre!(
+            "payload-builder options are unsupported: ArbOS messages are built by the Arbitrum engine driver"
+        ));
+    }
+    if command.debug != Default::default() {
+        return Err(eyre::eyre!(
+            "debug node options are unsupported by the standalone Arbitrum launcher"
+        ));
+    }
+    if command.dev != Default::default() {
+        return Err(eyre::eyre!(
+            "dev mode is unsupported: ArbOS blocks must be derived from Arbitrum messages"
+        ));
+    }
+    if command.era.enabled
+        || command.era.source.path.is_some()
+        || command.era.source.url.is_some()
+    {
+        return Err(eyre::eyre!(
+            "ERA import is unsupported: it imports Ethereum block bodies rather than deriving ArbOS blocks"
+        ));
+    }
+    if command.jit != Default::default() {
+        return Err(eyre::eyre!(
+            "--jit options are not wired to arb-revm yet"
+        ));
+    }
+
+    Ok(())
+}
+
+async fn launch(
+    mut builder: WithLaunchContext<NodeBuilder<DatabaseEnv, ChainSpec>>,
+    args: ArbNodeArgs,
+    bootstrap: NodeBootstrap,
+) -> eyre::Result<()> {
+    let task_executor = builder.task_executor().clone();
+    let feed_sources =
+        feed::expand_feed_sources(&args.feed_urls, args.feed_connections, &args.feed_sources)?;
+    if args.no_l1_derive && feed_sources.is_empty() {
+        return Err(eyre::eyre!("--no-l1-derive requires at least one --feed-url"));
+    }
+    let mev_tx_log_ipc = args
+        .mev_tx_log_ipc
+        .as_ref()
+        .map(|path| MevTxLogIpc::bind(path.clone()))
+        .transpose()?;
+    let NodeBootstrap {
+        chain_id: effective_chain_id,
+        rollup,
+        snapshot_delayed,
+        genesis_delayed,
+        ..
+    } = bootstrap;
+
+    // Resolve the pruning configuration from Reth's native `--prune.*` / `--full` arguments.
+    // It is passed both to the provider factory and the engine-tree pruner so static-file writes
+    // follow the same segment policy.
+    let prune_config = builder
+        .config()
+        .pruning
+        .prune_config(builder.config().chain.as_ref());
     match &prune_config {
         Some(pc) => info!(
             target: "arb-reth",
@@ -571,33 +657,10 @@ pub async fn run(ctx: CliContext, args: NodeArgs) -> eyre::Result<()> {
         ),
         None => info!(target: "arb-reth", "archive node (no pruning configured; keeping all history)"),
     }
-    let datadir_args = match args.datadir {
-        Some(path) => DatadirArgs {
-            datadir: MaybePlatformPath::<DataDirPath>::from(path),
-            ..Default::default()
-        },
-        None => DatadirArgs::default(),
-    };
-    let config = NodeConfig::new(chain_spec)
-        .with_datadir_args(datadir_args)
-        .with_metrics(MetricArgs {
-            prometheus: args.metrics,
-            ..Default::default()
-        });
-    let data_dir = config.datadir();
+    let data_dir = builder.config().datadir();
 
     // Resolve the L1-derivation resume log path before `data_dir` is moved into the launcher.
     let resume_checkpoint_path = L1ResumeLog::path_in(data_dir.data_dir());
-
-    let db_path = data_dir.db();
-    info!(target: "arb-reth", path = ?db_path, no_fsync = args.no_fsync, "opening database");
-    let mut db_args = DatabaseArguments::new(ClientVersion::default());
-    if args.no_fsync {
-        db_args = db_args.with_sync_mode(Some(SyncMode::SafeNoSync));
-    }
-    let db = init_db(db_path, db_args)?;
-
-    let node_builder = NodeBuilder::new(config).with_database(db).node(ArbNode);
 
     // The held senders keep the driver parked (and the node alive) until SIGTERM. Keep the
     // live-feed backlog separate from authoritative L1 derivation so a relay reconnect cannot
@@ -608,35 +671,34 @@ pub async fn run(ctx: CliContext, args: NodeArgs) -> eyre::Result<()> {
     // still drive the same engine callback, but have no sample to record.
     let feed_latency = (!feed_sources.is_empty()).then(FeedLatencyTracker::new);
 
-    let rpc_addr = args.http.then(|| (args.http_addr, args.http_port).into());
+    // Preserve the complete native tree configuration before `ArbNode` changes the builder's
+    // type-state to its custom no-op add-ons. The driver consumes this exact configuration below.
+    let tuning = crate::ArbEngineTuning::from_tree_config(builder.config().tree_config());
+
+    // ArbOS derives blocks internally, rather than receiving Engine API commands from a consensus
+    // client. Keep the native public RPC settings but never expose the unusable authenticated
+    // Engine API server.
+    builder.config_mut().rpc.disable_auth_server = true;
+    let node_builder = builder.node(ArbNode);
 
     let launcher = ArbLauncher {
         ctx: LaunchContext::new(task_executor.clone(), data_dir),
         chain_id: effective_chain_id,
         genesis_block: rollup.l2_genesis_block,
-        tuning: crate::ArbEngineTuning {
-            persistence_threshold: args.persistence_threshold,
-            memory_block_buffer_target: args.memory_buffer_target,
-            persistence_backpressure_threshold: args.persistence_backpressure,
-            execution_cache_size: args.execution_cache_size_mb.saturating_mul(1024 * 1024),
-            share_execution_cache_with_payload_builder: args
-                .share_execution_cache_with_payload_builder,
-            share_sparse_trie_with_payload_builder: args.share_sparse_trie_with_payload_builder,
-        },
+        tuning,
         prune_config,
         feed_messages: feed_rx,
         l1_messages: l1_rx,
         feed_latency: feed_latency.clone(),
-        rpc_addr,
         tx_log_stream: mev_tx_log_ipc.as_ref().map(MevTxLogIpc::broadcaster),
     };
 
-    let handle = launcher.launch_node(node_builder).await?;
+    let handle = node_builder.launch_with(launcher).await?;
 
     match handle.http_url() {
         Some(url) => info!(target: "arb-reth", %url, "arb-reth node started; eth_* RPC serving"),
         None => {
-            info!(target: "arb-reth", "arb-reth node started (RPC disabled; pass --http to enable)")
+            info!(target: "arb-reth", "arb-reth node started (HTTP RPC disabled; pass --http to enable it)")
         }
     }
 
@@ -908,6 +970,7 @@ mod tests {
     use alloy_consensus::Header;
     use alloy_primitives::{B64, B256};
     use reth_provider::test_utils::MockEthProvider;
+    use clap::{Parser, Subcommand};
 
     const ROBINHOOD_CHAIN_INFO: &[u8] =
         include_bytes!("../../tests/fixtures/robinhood-chain-info.json");
@@ -1000,10 +1063,22 @@ mod tests {
         );
     }
 
+    #[derive(Debug, Parser)]
+    struct TestCli {
+        #[command(subcommand)]
+        command: TestCommand,
+    }
+
+    #[derive(Debug, Subcommand)]
+    enum TestCommand {
+        Node(Box<NodeCommand<ArbChainSpecParser, ArbNodeArgs>>),
+    }
+
     #[test]
     fn cli_accepts_repeated_feed_urls_and_parallel_connections() {
-        let args = NodeArgs::try_parse_from([
+        let TestCommand::Node(command) = TestCli::try_parse_from([
             "arb-reth",
+            "node",
             "--feed-url",
             "wss://relay-a.example/feed",
             "--feed-url",
@@ -1011,23 +1086,25 @@ mod tests {
             "--feed-connections",
             "3",
         ])
-        .unwrap();
+        .unwrap()
+        .command;
 
         assert_eq!(
-            args.feed_urls,
+            command.ext.feed_urls,
             [
                 "wss://relay-a.example/feed",
                 "wss://relay-b.example/feed"
             ]
         );
-        assert_eq!(args.feed_connections, Some(3));
-        assert!(args.feed_sources.is_empty());
+        assert_eq!(command.ext.feed_connections, Some(3));
+        assert!(command.ext.feed_sources.is_empty());
     }
 
     #[test]
     fn cli_accepts_counted_feed_sources_without_an_implicit_unbound_lane() {
-        let args = NodeArgs::try_parse_from([
+        let TestCommand::Node(command) = TestCli::try_parse_from([
             "arb-reth",
+            "node",
             "--feed-url",
             "wss://relay.example/feed",
             "--feed-source",
@@ -1035,14 +1112,87 @@ mod tests {
             "--feed-source",
             "192.0.2.11=2",
         ])
-        .unwrap();
+        .unwrap()
+        .command;
 
-        assert_eq!(args.feed_connections, None);
+        assert_eq!(command.ext.feed_connections, None);
         assert_eq!(
-            args.feed_sources[0].local_ip,
+            command.ext.feed_sources[0].local_ip,
             "192.0.2.10".parse::<std::net::IpAddr>().unwrap()
         );
-        assert_eq!(args.feed_sources[0].connections, 3);
-        assert_eq!(args.feed_sources[1].connections, 2);
+        assert_eq!(command.ext.feed_sources[0].connections, 3);
+        assert_eq!(command.ext.feed_sources[1].connections, 2);
+    }
+
+    #[test]
+    fn native_node_arguments_and_arb_extension_parse_together() {
+        let TestCommand::Node(command) = TestCli::try_parse_from([
+            "arb-reth",
+            "node",
+            "--datadir",
+            "/tmp/arb-reth-node",
+            "--metrics",
+            "127.0.0.1:9001",
+            "--http",
+            "--http.port",
+            "8547",
+            "--ws",
+            "--ws.port",
+            "8548",
+            "--db.sync-mode",
+            "safe-no-sync",
+            "--engine.persistence-threshold",
+            "128",
+            "--engine.memory-block-buffer-target",
+            "64",
+            "--engine.persistence-backpressure-threshold",
+            "512",
+            "--full",
+            "--arb-chain-config",
+            "/tmp/chain-config.json",
+            "--feed-url",
+            "wss://feed.example",
+        ])
+        .expect("native and Arbitrum arguments should parse")
+        .command;
+
+        assert_eq!(command.engine.persistence_threshold, 128);
+        assert_eq!(command.engine.memory_block_buffer_target, 64);
+        assert_eq!(command.engine.persistence_backpressure_threshold(), 512);
+        assert_eq!(command.db.sync_mode, Some(SyncMode::SafeNoSync));
+        assert!(command.pruning.full);
+        assert_eq!(
+            command.ext.chain_config,
+            Some(PathBuf::from("/tmp/chain-config.json"))
+        );
+        assert_eq!(command.ext.feed_urls, ["wss://feed.example"]);
+    }
+
+    #[test]
+    fn generic_genesis_does_not_replace_arbos_bootstrap() {
+        let err = TestCli::try_parse_from([
+            "arb-reth",
+            "node",
+            "--chain",
+            "/tmp/ethereum-genesis.json",
+        ])
+        .expect_err("a generic Ethereum genesis is not an ArbOS bootstrap input");
+
+        assert!(err.to_string().contains("unsupported Arbitrum chain spec"));
+    }
+
+    #[test]
+    fn noop_component_options_are_rejected() {
+        let TestCommand::Node(command) = TestCli::try_parse_from([
+            "arb-reth",
+            "node",
+            "--disable-discovery",
+        ])
+        .expect("the native parser should accept its standard flag")
+        .command;
+
+        let err = validate_standalone_components(&command)
+            .expect_err("a no-op network setting must not be silently accepted");
+        assert!(err.to_string().contains("network options are unsupported"));
     }
 }

--- a/crates/arb-reth-node/src/commands/node.rs
+++ b/crates/arb-reth-node/src/commands/node.rs
@@ -640,23 +640,6 @@ async fn launch(
         ..
     } = bootstrap;
 
-    // Resolve the pruning configuration from Reth's native `--prune.*` / `--full` arguments.
-    // It is passed both to the provider factory and the engine-tree pruner so static-file writes
-    // follow the same segment policy.
-    let prune_config = builder
-        .config()
-        .pruning
-        .prune_config(builder.config().chain.as_ref());
-    match &prune_config {
-        Some(pc) => info!(
-            target: "arb-reth",
-            segments = ?pc.segments,
-            block_interval = pc.block_interval,
-            minimum_pruning_distance = pc.minimum_pruning_distance,
-            "history pruning enabled",
-        ),
-        None => info!(target: "arb-reth", "archive node (no pruning configured; keeping all history)"),
-    }
     let data_dir = builder.config().datadir();
 
     // Resolve the L1-derivation resume log path before `data_dir` is moved into the launcher.
@@ -686,7 +669,6 @@ async fn launch(
         chain_id: effective_chain_id,
         genesis_block: rollup.l2_genesis_block,
         tuning,
-        prune_config,
         feed_messages: feed_rx,
         l1_messages: l1_rx,
         feed_latency: feed_latency.clone(),

--- a/crates/arb-reth-node/src/launcher.rs
+++ b/crates/arb-reth-node/src/launcher.rs
@@ -20,7 +20,9 @@ use futures_util::StreamExt;
 use reth_chain_state::CanonicalInMemoryState;
 use reth_db::{Database, database_metrics::DatabaseMetrics};
 use reth_evm::ConfigureEvm;
-use reth_node_api::{AddOnsContext, FullNodeTypes, NodeTypes, NodeTypesWithDBAdapter};
+use reth_node_api::{
+    AddOnsContext, FullNodeTypes, NodeAddOns, NodeTypes, NodeTypesWithDBAdapter,
+};
 use reth_node_builder::hooks::NodeHooks;
 use reth_node_builder::{
     AddOns, LaunchContext, LaunchNode, Node, NodeAdapter, NodeBuilderWithComponents,
@@ -246,7 +248,7 @@ impl ArbLauncher {
                 AddOns {
                     hooks,
                     exexs: _,
-                    add_ons,
+                    add_ons: _,
                 },
             config,
         } = target;

--- a/crates/arb-reth-node/src/launcher.rs
+++ b/crates/arb-reth-node/src/launcher.rs
@@ -24,8 +24,7 @@ use reth_node_api::{AddOnsContext, FullNodeTypes, NodeTypes, NodeTypesWithDBAdap
 use reth_node_builder::hooks::NodeHooks;
 use reth_node_builder::{
     AddOns, LaunchContext, LaunchNode, Node, NodeAdapter, NodeBuilderWithComponents,
-    NodeComponents, NodeComponentsBuilder, NodeTypesAdapter, RethFullAdapter,
-    rpc::RethRpcAddOns,
+    NodeComponents, NodeComponentsBuilder, NodeTypesAdapter, RethFullAdapter, rpc::RethRpcAddOns,
 };
 use reth_primitives_traits::SealedHeader;
 use reth_provider::{
@@ -88,10 +87,6 @@ pub struct ArbLauncher {
     pub genesis_block: u64,
     /// Engine-tree persistence tuning (batch/buffer/backpressure knobs).
     pub tuning: ArbEngineTuning,
-    /// Optional history-pruning configuration from `--prune.*` / `--full`. `None` keeps the node
-    /// an archive node. A configured mode is applied to both the provider factory and the
-    /// engine-tree persistence pruner so static-file writes follow the same segment policy.
-    pub prune_config: Option<reth_config::PruneConfig>,
     /// Live-feed and replay messages. These may be ahead of the local canonical cursor when the
     /// relay's bounded backlog begins after the database tip.
     pub feed_messages: tokio::sync::mpsc::Receiver<BroadcastFeedMessage>,
@@ -237,7 +232,6 @@ impl ArbLauncher {
             chain_id,
             genesis_block,
             tuning,
-            prune_config,
             feed_messages,
             l1_messages,
             feed_latency,
@@ -281,6 +275,27 @@ impl ArbLauncher {
         // Apply this after TOML merging so no config file can inadvertently expose it.
         let mut ctx = ctx;
         ctx.node_config_mut().rpc.disable_auth_server = true;
+
+        // Use Reth's effective configuration after the native CLI and persisted `reth.toml` have
+        // been merged. The provider factory and persistence pruner must use these exact same modes:
+        // otherwise a run can try to append a static-file segment that an earlier run pruned.
+        let prune_config = ctx.prune_config();
+        if prune_config.is_default() {
+            reth_tracing::tracing::info!(
+                target: "arb-reth",
+                "archive node (no pruning configured; keeping all history)",
+            );
+        } else {
+            reth_tracing::tracing::info!(
+                target: "arb-reth",
+                segments = ?prune_config.segments,
+                block_interval = prune_config.block_interval,
+                minimum_pruning_distance = prune_config.minimum_pruning_distance,
+                "history pruning enabled",
+            );
+        }
+        let prune_builder =
+            (!prune_config.is_default()).then(|| reth_prune::PrunerBuilder::new(prune_config));
 
         let ctx = ctx
             .with_adjusted_configs()
@@ -329,17 +344,9 @@ impl ArbLauncher {
 
         let provider: BlockchainProvider<NodeTypesWithDBAdapter<N, DB>> =
             ctx.node_adapter().provider.clone();
-        // Reth's provider factory consults `PruneModes` while it writes static-file segments. In
-        // particular, full sender recovery pruning stops new TransactionSenders writes. Feeding
-        // the configuration only to `PrunerBuilder` would let the writer append to a segment the
-        // pruner deletes, breaking its contiguous-block invariant on the next persistence batch.
+        // `with_provider_factory` already applied the merged pruning modes above.
         let provider_factory: ProviderFactory<NodeTypesWithDBAdapter<N, DB>> =
-            ctx.provider_factory().clone().with_prune_modes(
-                prune_config
-                    .as_ref()
-                    .map(|config| config.segments.clone())
-                    .unwrap_or_default(),
-            );
+            ctx.provider_factory().clone();
         let task_executor: TaskExecutor = ctx.task_executor().clone();
         let head = ctx.head();
         let engine_events = reth_tokio_util::EventSender::default();
@@ -389,7 +396,7 @@ impl ArbLauncher {
             canonical,
             task_executor.clone(),
             tuning,
-            prune_config.map(reth_prune::PrunerBuilder::new),
+            prune_builder,
             tx_log_stream,
             engine_events.clone(),
         )?;
@@ -684,6 +691,14 @@ mod tests {
         let data_dir =
             maybe_path.unwrap_or_chain_default(chain_spec.chain(), config.datadir.clone());
 
+        // Persist pruning only in reth.toml. This exercises the same restart path as a datadir
+        // whose sender static files were pruned by an earlier run without repeating `--full`.
+        let mut reth_config = reth_config::Config::default();
+        reth_config.set_prune_config(prune_config);
+        reth_config
+            .save(&data_dir.config())
+            .expect("save test pruning config");
+
         let node_builder_with_components = NodeBuilder::new(config).with_database(db).node(ArbNode);
 
         let launcher = ArbLauncher {
@@ -691,7 +706,6 @@ mod tests {
             chain_id,
             genesis_block: 0,
             tuning: ArbEngineTuning::reth_defaults(),
-            prune_config: Some(prune_config),
             feed_messages: feed_rx,
             l1_messages: l1_rx,
             feed_latency: None,
@@ -802,7 +816,6 @@ mod tests {
                     .with_share_execution_cache_with_payload_builder(true)
                     .with_share_sparse_trie_with_payload_builder(false),
             ),
-            prune_config: None,
             feed_messages: feed_rx,
             l1_messages: l1_rx,
             feed_latency: None,

--- a/crates/arb-reth-node/src/launcher.rs
+++ b/crates/arb-reth-node/src/launcher.rs
@@ -16,6 +16,7 @@ use alloy_consensus::Header;
 use arbitrum_alloy_consensus::reth::ArbPrimitives;
 use arbitrum_alloy_sequencer::sequencer::feed::BroadcastFeedMessage;
 use eyre::eyre;
+use futures_util::StreamExt;
 use reth_chain_state::CanonicalInMemoryState;
 use reth_db::{Database, database_metrics::DatabaseMetrics};
 use reth_evm::ConfigureEvm;
@@ -341,6 +342,25 @@ impl ArbLauncher {
             );
         let task_executor: TaskExecutor = ctx.task_executor().clone();
         let head = ctx.head();
+        let engine_events = reth_tokio_util::EventSender::default();
+        // Reth's generic `CanonicalBlockAdded` log treats the consensus header gas limit as
+        // executable block capacity and its event elapsed time as execution throughput. Neither
+        // interpretation is valid for Arbitrum: the header carries Nitro's permissive `2^50`
+        // envelope, and ArbOS execution happened before insertion into the engine tree. The
+        // driver emits an Arbitrum-aware replacement with its measured production timings.
+        let node_events = engine_events.new_listener().filter_map(|event| {
+            futures_util::future::ready(
+                (!matches!(
+                    &event,
+                    reth_engine_primitives::ConsensusEngineEvent::CanonicalBlockAdded(..)
+                ))
+                .then(|| event.into()),
+            )
+        });
+        task_executor.spawn_critical_task(
+            "events task",
+            reth_node_events::node::handle_events(None, Some(head.number), node_events),
+        );
 
         // Clone the in-memory state from the provider so the tree updates the same instance that
         // BlockchainProvider serves for RPC queries.
@@ -371,6 +391,7 @@ impl ArbLauncher {
             tuning,
             prune_config.map(reth_prune::PrunerBuilder::new),
             tx_log_stream,
+            engine_events.clone(),
         )?;
 
         let (exit_tx, exit_rx) = oneshot::channel::<eyre::Result<()>>();
@@ -379,13 +400,16 @@ impl ArbLauncher {
 
         task_executor.spawn_critical_task("arb-engine-driver", async move {
             let res: eyre::Result<()> = async {
-                // Bench accounting: separate time spent WAITING for the next derived feed
-                // message (L1-fetch-bound) from time spent in advance() (compute/persist-bound).
-                // Emitted every 1000 blocks at target "arb-reth::bench"; harmless at info off.
-                let mut bench_recv_us: u128 = 0;
-                let mut bench_work_us: u128 = 0;
-                let mut bench_n: u64 = 0;
-                let mut bench_wall = std::time::Instant::now();
+                // Periodically summarize progress while distinguishing source wait from local
+                // production. Per-block and per-payload details remain available at DEBUG.
+                let mut status_recv_us: u128 = 0;
+                let mut status_work_us: u128 = 0;
+                let mut status_window_messages: u64 = 0;
+                let mut status_window_blocks: u64 = 0;
+                let mut status_total_blocks: u64 = 0;
+                let mut status_last_applied_sequence: Option<u64> = None;
+                let mut status_window = std::time::Instant::now();
+                const STATUS_INTERVAL: std::time::Duration = std::time::Duration::from_secs(30);
                 const MAX_MESSAGE_BATCH: usize = 64;
                 let mut feed_open = true;
                 let mut l1_open = true;
@@ -401,7 +425,7 @@ impl ArbLauncher {
                     else {
                         break;
                     };
-                    bench_recv_us += __r.elapsed().as_micros();
+                    status_recv_us += __r.elapsed().as_micros();
 
                     // A batch is a deterministic proof that another message is ready. It replaces
                     // the receiver's racy `is_empty()` hint: historical catch-up can overlap the
@@ -439,34 +463,49 @@ impl ArbLauncher {
                                 .record_driver_dequeue(msg.sequence_number, driver_dequeued_at);
                         }
                         let __w = std::time::Instant::now();
+                        let mut applied_blocks = 0u64;
+                        let mut last_applied_sequence = None;
                         driver
                             .advance_with_applied_overlap(
                                 &msg,
                                 index + 1 < batch_len,
                                 |sequence_number, applied| {
+                                    applied_blocks += 1;
+                                    last_applied_sequence = Some(sequence_number);
                                     if let Some(feed_latency) = feed_latency.as_ref() {
                                         feed_latency.record_canonical(sequence_number, applied);
                                     }
                                 },
                             )
                             .await?;
-                        bench_work_us += __w.elapsed().as_micros();
-                        bench_n += 1;
-                        if bench_n.is_multiple_of(1000) {
-                            let wall_ms = bench_wall.elapsed().as_millis().max(1);
+                        status_work_us += __w.elapsed().as_micros();
+                        status_window_messages += 1;
+                        status_window_blocks += applied_blocks;
+                        status_total_blocks += applied_blocks;
+                        if last_applied_sequence.is_some() {
+                            status_last_applied_sequence = last_applied_sequence;
+                        }
+                        if status_window.elapsed() >= STATUS_INTERVAL {
+                            let wall_ms = status_window.elapsed().as_millis().max(1);
                             tracing::info!(
-                                target: "arb-reth::bench",
-                                blocks = bench_n,
-                                blk_per_s = (1000u128 * 1000 / wall_ms) as u64,
-                                recv_ms = (bench_recv_us / 1000) as u64,
-                                work_ms = (bench_work_us / 1000) as u64,
-                                recv_pct = (100 * bench_recv_us
-                                    / (bench_recv_us + bench_work_us).max(1)) as u64,
-                                "bench: 1000-block window",
+                                target: "arb-reth::status",
+                                last_applied_sequence = ?status_last_applied_sequence,
+                                processed = status_total_blocks,
+                                input_messages = status_window_messages,
+                                window_blocks = status_window_blocks,
+                                blk_per_s =
+                                    (status_window_blocks as u128 * 1000 / wall_ms) as u64,
+                                source_wait_ms = (status_recv_us / 1000) as u64,
+                                processing_ms = (status_work_us / 1000) as u64,
+                                source_wait_pct = (100 * status_recv_us
+                                    / (status_recv_us + status_work_us).max(1)) as u64,
+                                "Arbitrum sync status",
                             );
-                            bench_recv_us = 0;
-                            bench_work_us = 0;
-                            bench_wall = std::time::Instant::now();
+                            status_recv_us = 0;
+                            status_work_us = 0;
+                            status_window_messages = 0;
+                            status_window_blocks = 0;
+                            status_window = std::time::Instant::now();
                         }
                     }
 
@@ -494,7 +533,7 @@ impl ArbLauncher {
                 node: ctx.node_adapter().clone(),
                 config: ctx.node_config(),
                 beacon_engine_handle,
-                engine_events: reth_tokio_util::EventSender::default(),
+                engine_events,
                 jwt_secret: ctx.auth_jwt_secret()?,
             };
             let mut add_ons = crate::addons::arb_add_ons();

--- a/crates/arb-reth-node/src/launcher.rs
+++ b/crates/arb-reth-node/src/launcher.rs
@@ -10,7 +10,6 @@
 //! Deadlock rule: never hold a read provider across a `provider_rw()`/`save_blocks()` call.
 
 use core::{future::Future, pin::Pin};
-use std::net::SocketAddr;
 
 use crate::metrics::FeedLatencyTracker;
 use alloy_consensus::Header;
@@ -20,11 +19,12 @@ use eyre::eyre;
 use reth_chain_state::CanonicalInMemoryState;
 use reth_db::{Database, database_metrics::DatabaseMetrics};
 use reth_evm::ConfigureEvm;
-use reth_node_api::{AddOnsContext, FullNodeTypes, NodeAddOns, NodeTypes, NodeTypesWithDBAdapter};
+use reth_node_api::{AddOnsContext, FullNodeTypes, NodeTypes, NodeTypesWithDBAdapter};
 use reth_node_builder::hooks::NodeHooks;
 use reth_node_builder::{
-    AddOns, LaunchContext, LaunchNode, Node, NodeBuilderWithComponents, NodeComponents,
-    NodeComponentsBuilder, NodeTypesAdapter, RethFullAdapter,
+    AddOns, LaunchContext, LaunchNode, Node, NodeAdapter, NodeBuilderWithComponents,
+    NodeComponents, NodeComponentsBuilder, NodeTypesAdapter, RethFullAdapter,
+    rpc::RethRpcAddOns,
 };
 use reth_primitives_traits::SealedHeader;
 use reth_provider::{
@@ -70,7 +70,7 @@ impl<P> ArbNodeHandle<P> {
     }
 }
 
-/// A custom `LaunchNode` for the no-engine Arbitrum node.
+/// A custom `LaunchNode` for the self-driven Arbitrum node.
 ///
 /// Reuses reth's `LaunchContext` type-state chain for DB/provider/blockchain-db/task
 /// infrastructure but skips the sync pipeline and consensus-engine orchestrator. Spawns
@@ -100,8 +100,6 @@ pub struct ArbLauncher {
     /// Correlates live WebSocket feed messages with canonical in-memory state for Prometheus.
     /// `None` keeps replay and L1-only operation free of feed-latency instrumentation.
     pub feed_latency: Option<FeedLatencyTracker>,
-    /// Optional HTTP bind address for the `eth_*` RPC server (`None` disables RPC).
-    pub rpc_addr: Option<SocketAddr>,
     /// Optional best-effort publisher for per-transaction execution logs.
     pub tx_log_stream: Option<ArbTxLogBroadcaster>,
 }
@@ -140,7 +138,7 @@ async fn recv_next_message(
     }
 }
 
-impl<N, DB, T, CB> LaunchNode<NodeBuilderWithComponents<T, CB, ()>> for ArbLauncher
+impl<N, DB, T, CB, AO> LaunchNode<NodeBuilderWithComponents<T, CB, AO>> for ArbLauncher
 where
     N: Node<RethFullAdapter<DB, N>>
         + NodeTypesForProvider
@@ -158,6 +156,7 @@ where
             DB = DB,
         >,
     CB: NodeComponentsBuilder<T> + 'static,
+    AO: RethRpcAddOns<NodeAdapter<T, CB::Components>> + 'static,
     <CB::Components as NodeComponents<T>>::Evm:
         ConfigureEvm<Primitives = ArbPrimitives> + Into<arb_reth_evm::ArbEvmConfig> + Clone,
     CB::Components: NodeComponents<T, Evm = arb_reth_evm::ArbEvmConfig>,
@@ -194,7 +193,7 @@ where
     type Node = ArbNodeHandle<BlockchainProvider<NodeTypesWithDBAdapter<N, DB>>>;
     type Future = Pin<Box<dyn Future<Output = eyre::Result<Self::Node>> + Send>>;
 
-    fn launch_node(self, target: NodeBuilderWithComponents<T, CB, ()>) -> Self::Future {
+    fn launch_node(self, target: NodeBuilderWithComponents<T, CB, AO>) -> Self::Future {
         Box::pin(self.launch_impl(target))
     }
 }
@@ -202,9 +201,9 @@ where
 impl ArbLauncher {
     /// Core async launch body. Separated from `launch_node` so it can be `async fn`
     /// (the trait requires a boxed future; `launch_node` boxes it).
-    async fn launch_impl<N, DB, T, CB>(
+    async fn launch_impl<N, DB, T, CB, AO>(
         self,
-        target: NodeBuilderWithComponents<T, CB, ()>,
+        target: NodeBuilderWithComponents<T, CB, AO>,
     ) -> eyre::Result<ArbNodeHandle<BlockchainProvider<NodeTypesWithDBAdapter<N, DB>>>>
     where
         N: Node<RethFullAdapter<DB, N>>
@@ -223,6 +222,7 @@ impl ArbLauncher {
                 DB = DB,
             >,
         CB: NodeComponentsBuilder<T> + 'static,
+        AO: RethRpcAddOns<NodeAdapter<T, CB::Components>> + 'static,
         <CB::Components as NodeComponents<T>>::Evm:
             ConfigureEvm<Primitives = ArbPrimitives> + Into<arb_reth_evm::ArbEvmConfig> + Clone,
         CB::Components: NodeComponents<T, Evm = arb_reth_evm::ArbEvmConfig>,
@@ -240,7 +240,6 @@ impl ArbLauncher {
             feed_messages,
             l1_messages,
             feed_latency,
-            rpc_addr,
             tx_log_stream,
         } = self;
 
@@ -252,7 +251,7 @@ impl ArbLauncher {
                 AddOns {
                     hooks,
                     exexs: _,
-                    add_ons: _,
+                    add_ons,
                 },
             config,
         } = target;
@@ -261,21 +260,10 @@ impl ArbLauncher {
             ..
         } = hooks;
 
-        // Drive RPC config from the explicit `rpc_addr`: canonical `RpcAddOns` reads addresses from
-        // `NodeConfig.rpc`, not an arg. Enable http+ws with the full module fleet; this node is
-        // self-driven from L1 derivation, so the auth/engine server is disabled.
+        // The native command owns public RPC configuration. This node is self-driven from L1
+        // derivation, so its authenticated Engine API server must always stay disabled.
         let mut config = config;
-        if let Some(addr) = rpc_addr {
-            config.rpc.http = true;
-            config.rpc.http_addr = addr.ip();
-            config.rpc.http_port = addr.port();
-            config.rpc.http_api = Some(reth_rpc_server_types::RpcModuleSelection::All);
-            config.rpc.ws = true;
-            config.rpc.ws_addr = addr.ip();
-            config.rpc.ws_port = addr.port();
-            config.rpc.ws_api = Some(reth_rpc_server_types::RpcModuleSelection::All);
-            config.rpc.disable_auth_server = true;
-        }
+        config.rpc.disable_auth_server = true;
 
         let overlay_manager = OverlayManager::<ArbPrimitives>::new(
             ctx.task_executor.state_trie_overlay_worker_pool(),
@@ -285,7 +273,15 @@ impl ArbLauncher {
         let ctx = ctx
             .with_configured_globals(0)
             .with_loaded_toml_config(config)?
-            .attach(database.clone())
+            .attach(database.clone());
+
+        // TOML is intentionally allowed to configure the public Reth RPC servers, but this
+        // standalone node has no beacon-engine service to back an authenticated Engine API.
+        // Apply this after TOML merging so no config file can inadvertently expose it.
+        let mut ctx = ctx;
+        ctx.node_config_mut().rpc.disable_auth_server = true;
+
+        let ctx = ctx
             .with_adjusted_configs()
             .with_provider_factory::<NodeTypesWithDBAdapter<N, DB>, <CB::Components as NodeComponents<T>>::Evm>(
                 overlay_manager.clone(),
@@ -326,6 +322,9 @@ impl ArbLauncher {
             })?
             .with_components(components_builder, on_component_initialized)
             .await?;
+
+        let rpc = &ctx.node_config().rpc;
+        let rpc_enabled = rpc.http || rpc.ws || !rpc.ipcdisable;
 
         let provider: BlockchainProvider<NodeTypesWithDBAdapter<N, DB>> =
             ctx.node_adapter().provider.clone();
@@ -487,7 +486,7 @@ impl ArbLauncher {
         // from L1 derivation, so the beacon-engine handle is a stub (dangling receiver: engine_*
         // calls would return `EngineUnavailable`), and the auth/engine server is disabled, so
         // nothing ever reaches it.
-        let rpc_handle = if rpc_addr.is_some() {
+        let rpc_handle = if rpc_enabled {
             let (engine_tx, _engine_rx) = tokio::sync::mpsc::unbounded_channel();
             let beacon_engine_handle =
                 reth_engine_primitives::ConsensusEngineHandle::new(engine_tx);
@@ -657,7 +656,6 @@ mod tests {
             feed_messages: feed_rx,
             l1_messages: l1_rx,
             feed_latency: None,
-            rpc_addr: None,
             tx_log_stream: None,
         };
 
@@ -756,19 +754,19 @@ mod tests {
             ctx: LaunchContext::new(task_executor, data_dir),
             chain_id: crate::ARB_ONE_CHAIN_ID,
             genesis_block: 0,
-            tuning: ArbEngineTuning {
-                persistence_threshold: 128,
-                memory_block_buffer_target: 0,
-                persistence_backpressure_threshold: 512,
-                execution_cache_size: 256 * 1024 * 1024,
-                share_execution_cache_with_payload_builder: true,
-                share_sparse_trie_with_payload_builder: false,
-            },
+            tuning: ArbEngineTuning::from_tree_config(
+                reth_engine_primitives::TreeConfig::default()
+                    .with_persistence_backpressure_threshold(512)
+                    .with_persistence_threshold(128)
+                    .with_memory_block_buffer_target(0)
+                    .with_cross_block_cache_size(256 * 1024 * 1024)
+                    .with_share_execution_cache_with_payload_builder(true)
+                    .with_share_sparse_trie_with_payload_builder(false),
+            ),
             prune_config: None,
             feed_messages: feed_rx,
             l1_messages: l1_rx,
             feed_latency: None,
-            rpc_addr: None,
             tx_log_stream: None,
         };
         let handle = launcher

--- a/crates/arb-reth-node/src/lib.rs
+++ b/crates/arb-reth-node/src/lib.rs
@@ -117,7 +117,7 @@ pub type ArbNetworkPrimitives =
 // except the executor (Arbitrum has no tx gossip, p2p, or fork-choice engine).
 // `ArbLauncher` reuses reth's `LaunchContext` for DB/provider/tasks but skips the sync
 // pipeline and consensus-engine orchestrator, spawning `ArbEngineDriver` to drive reth's
-// engine tree directly; AddOns = () (no engine-coupled RpcAddOns).
+// engine tree directly. Its RPC add-ons remain native Reth add-ons, with a noop Engine API.
 
 use reth_node_builder::components::{
     ComponentsBuilder, NoopConsensusBuilder, NoopNetworkBuilder, NoopPayloadBuilder,
@@ -138,7 +138,7 @@ where
         NoopConsensusBuilder,
     >;
 
-    type AddOns = ();
+    type AddOns = addons::ArbAddOns<reth_node_builder::NodeAdapter<N>>;
 
     fn components_builder(&self) -> Self::ComponentsBuilder {
         ComponentsBuilder::<(), (), (), (), (), ()>::default()
@@ -150,7 +150,9 @@ where
             .noop_consensus()
     }
 
-    fn add_ons(&self) -> Self::AddOns {}
+    fn add_ons(&self) -> Self::AddOns {
+        addons::arb_add_ons()
+    }
 }
 
 #[cfg(test)]

--- a/crates/arb-reth-node/tests/engine_tree_integration.rs
+++ b/crates/arb-reth-node/tests/engine_tree_integration.rs
@@ -65,8 +65,11 @@ mod tests {
     #[tokio::test(flavor = "multi_thread")]
     async fn engine_tree_tier1_replay_v2_hashed_sparse() {
         let factory = storage_v2_factory();
-        let mut tuning = ArbEngineTuning::reth_defaults();
-        tuning.share_sparse_trie_with_payload_builder = true;
+        let tuning = ArbEngineTuning::from_tree_config(
+            ArbEngineTuning::reth_defaults()
+                .to_tree_config()
+                .with_share_sparse_trie_with_payload_builder(true),
+        );
         drive_replay_native(factory, 412346, tuning).await;
     }
 

--- a/crates/arb-reth-node/tests/engine_tree_integration.rs
+++ b/crates/arb-reth-node/tests/engine_tree_integration.rs
@@ -126,6 +126,7 @@ mod tests {
             tuning,
             None,
             None,
+            reth_tokio_util::EventSender::default(),
         )
         .expect("spawn native payload driver");
 

--- a/crates/arb-reth-node/tests/rpc_integration.rs
+++ b/crates/arb-reth-node/tests/rpc_integration.rs
@@ -2,7 +2,7 @@
 //! layer was split into the `arb-reth-rpc` crate. Exercises `ArbLauncher` + RPC end-to-end,
 //! so it lives with the node crate (which owns the launcher/node types), not with the RPC crate.
 
-use std::net::{Ipv4Addr, SocketAddr};
+use std::net::Ipv4Addr;
 
 use alloy_primitives::{U256, address};
 use arbitrum_alloy_sequencer::sequencer::feed::BroadcastFeedMessage;
@@ -45,17 +45,21 @@ async fn rpc_serves_eth_queries() {
         reth_node_core::dirs::MaybePlatformPath::<reth_node_core::dirs::DataDirPath>::from(
             datadir.clone(),
         );
-    let config = NodeConfig::test()
+    let mut config = NodeConfig::test()
         .with_chain(MAINNET.clone())
         .with_datadir_args(reth_node_core::args::DatadirArgs {
             datadir: maybe_path.clone(),
             ..Default::default()
         });
+    config.rpc.http = true;
+    config.rpc.http_addr = Ipv4Addr::LOCALHOST.into();
+    config.rpc.http_port = 0;
+    config.rpc.http_api = Some(reth_rpc_server_types::RpcModuleSelection::All);
+    config.rpc.disable_auth_server = true;
     let data_dir = maybe_path.unwrap_or_chain_default(MAINNET.chain(), config.datadir.clone());
 
     let node_builder_with_components = NodeBuilder::new(config).with_database(db).node(ArbNode);
 
-    let rpc_addr = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), 0);
     let tx_log_stream = ArbTxLogBroadcaster::new();
     let mut tx_events = tx_log_stream.subscribe();
     let launcher = ArbLauncher {
@@ -67,7 +71,6 @@ async fn rpc_serves_eth_queries() {
         feed_messages: feed_rx,
         l1_messages: l1_rx,
         feed_latency: None,
-        rpc_addr: Some(rpc_addr),
         tx_log_stream: Some(tx_log_stream),
     };
 

--- a/crates/arb-reth-node/tests/rpc_integration.rs
+++ b/crates/arb-reth-node/tests/rpc_integration.rs
@@ -67,7 +67,6 @@ async fn rpc_serves_eth_queries() {
         chain_id: arb_reth_node::ARB_ONE_CHAIN_ID,
         genesis_block: 0,
         tuning: arb_reth_node::ArbEngineTuning::reth_defaults(),
-        prune_config: None,
         feed_messages: feed_rx,
         l1_messages: l1_rx,
         feed_latency: None,

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,7 @@ Use the release binary in the examples below. Replace paths and endpoints with v
 - [genesis](commands/genesis.md): verify state roots before import.
 - [rewind](commands/rewind.md): remove a bad local suffix.
 - [dump-blocks](commands/dump-blocks.md): inspect persisted blocks.
+- [CLI migration](cli-migration.md): update node invocations for the native Reth CLI.
 - [chains](chains/README.md): chain-specific operator notes.
 - [observability](observability/README.md): Prometheus metrics for the execute and persist loop.
 - [MEV transaction-log IPC](mev-tx-log-ipc.md): low-latency, pre-canonical transaction logs.

--- a/docs/chains/robinhood-mainnet.md
+++ b/docs/chains/robinhood-mainnet.md
@@ -51,11 +51,12 @@ The command below creates the datadir when absent and resumes from its stored L1
   --l1-getlogs-range 500 \
   --l1-prefetch 32 \
   --feed-url "$FEED_URL" \
-  --persistence-threshold 128 \
-  --memory-buffer-target 0 \
-  --persistence-backpressure 512 \
+  --engine.persistence-threshold 128 \
+  --engine.memory-block-buffer-target 0 \
+  --engine.persistence-backpressure-threshold 512 \
   --full \
-  --http --http.port 8547
+  --http --http.port 8547 \
+  --ws --ws.port 8548
 ```
 
 `--full` is the recommended local full-node profile: it retains the recent history and receipts

--- a/docs/cli-migration.md
+++ b/docs/cli-migration.md
@@ -1,0 +1,73 @@
+# CLI migration
+
+`arb-reth node` now uses Reth's native node command. Arbitrum-specific inputs remain available,
+while database, engine, RPC, metrics, pruning, and logging settings use Reth's flag names.
+
+Unknown commands and arguments print a link to this guide. The complete current interface is
+available through:
+
+```sh
+arb-reth node --help
+```
+
+## Changed arguments
+
+| Previous argument | Native CLI argument | Notes |
+| --- | --- | --- |
+| `--chain <chain-config.json>` | `--arb-chain-config <chain-config.json>` | `--chain` is now Reth's chain-spec selector. |
+| `--persistence-threshold <N>` | `--engine.persistence-threshold <N>` | The default remains 2 blocks. |
+| `--memory-buffer-target <N>` | `--engine.memory-block-buffer-target <N>` | The default remains 0 blocks. |
+| `--persistence-backpressure <N>` | `--engine.persistence-backpressure-threshold <N>` | The default remains 16 blocks. |
+| `--share-execution-cache-with-payload-builder true` | `--engine.share-execution-cache-with-payload-builder` | Sharing remains enabled by default, so the argument can normally be removed. |
+| `--share-sparse-trie-with-payload-builder` | `--engine.share-sparse-trie-with-payload-builder` | Sparse-trie sharing remains opt-in. |
+| `--no-fsync` | `--db.sync-mode safe-no-sync` | `--no-fsync` remains as a temporary compatibility alias. |
+
+`--datadir`, `--metrics`, `--http`, `--http.addr`, `--http.port`, pruning arguments, and the
+Arbitrum-specific L1, feed, genesis, snapshot, and MEV arguments keep their existing names.
+
+## RPC changes
+
+HTTP and WebSocket servers now use Reth's native settings. Enable them independently:
+
+```sh
+arb-reth node \
+  --http --http.addr 127.0.0.1 --http.port 8545 \
+  --ws --ws.addr 127.0.0.1 --ws.port 8546
+```
+
+Use `--http.api` and `--ws.api` to select namespaces. Local IPC follows Reth's default behavior;
+pass `--ipcdisable` when it is not wanted. Use `--rpc.gascap max` when RPC simulations must not be
+limited by Reth's default call gas cap.
+
+## Example
+
+Before:
+
+```sh
+arb-reth node \
+  --datadir /data/arb \
+  --chain chain-config.json \
+  --persistence-threshold 128 \
+  --memory-buffer-target 64 \
+  --persistence-backpressure 512 \
+  --share-sparse-trie-with-payload-builder \
+  --no-fsync \
+  --http
+```
+
+After:
+
+```sh
+arb-reth node \
+  --datadir /data/arb \
+  --arb-chain-config chain-config.json \
+  --engine.persistence-threshold 128 \
+  --engine.memory-block-buffer-target 64 \
+  --engine.persistence-backpressure-threshold 512 \
+  --engine.share-sparse-trie-with-payload-builder \
+  --db.sync-mode safe-no-sync \
+  --http
+```
+
+The non-node tools keep their command structure: `snapshot`, `genesis`, `rewind`, and
+`dump-blocks`.

--- a/docs/commands/node.md
+++ b/docs/commands/node.md
@@ -1,6 +1,12 @@
 # `arb-reth node`
 
-Runs the node, opens the database, derives L2 messages from L1, and optionally serves HTTP JSON-RPC.
+Runs the node, opens the database, derives L2 messages from L1, and optionally serves JSON-RPC.
+It uses Reth's native node command, so datadir, database, metrics, RPC, pruning, engine-tree,
+static-file, and storage arguments use their upstream Reth names.
+
+The command intentionally rejects native P2P, txpool, generic payload-builder, dev, ERA, debug-node,
+and JIT options. Those components do not exist in the standalone L1/feed-derived architecture, so
+accepting their settings would be misleading.
 
 ## Inputs
 
@@ -10,7 +16,10 @@ Runs the node, opens the database, derives L2 messages from L1, and optionally s
 - One boot mode:
   - `--snapshot-head <blocks.stream>` for a datadir created by `snapshot import --blocks`.
   - `--chain-info <chaininfo.json> --genesis <genesis.json>` for an Orbit chain booted from genesis.
-  - `--chain <chain-config.json>` for a chain-config boot.
+  - `--arb-chain-config <chain-config.json>` for a chain-config boot.
+
+`--chain` is now Reth's chain-spec option and currently accepts only the `arb-one` placeholder.
+It is not a substitute for an ArbOS bootstrap input.
 
 For a snapshot-seeded database:
 
@@ -20,7 +29,8 @@ arb-reth node \
   --snapshot-head /data/head.stream \
   --l1-rpc https://your-archive-rpc.example \
   --l1-beacon https://your-beacon-api.example \
-  --http --http.port 8545
+  --http --http.port 8545 \
+  --ws --ws.port 8546
 ```
 
 For an Orbit chain:
@@ -96,6 +106,11 @@ and credentials are excluded from logs and metric labels.
 
 Pass `--metrics 127.0.0.1:9001` to serve reth's Prometheus endpoint. See the [observability guide](../observability/README.md) for feed latency, engine-tree, persistence, and Prometheus scrape details.
 
+HTTP and WebSocket are separate native Reth servers. Enable each explicitly with `--http` and
+`--ws`; configure methods with `--http.api` and `--ws.api`. The authenticated Engine API is always
+disabled because ArbOS derives blocks locally rather than accepting beacon-client engine commands.
+Reth's local IPC server follows its normal native default; pass `--ipcdisable` when it is not wanted.
+
 ## MEV transaction-log IPC
 
 `--mev-tx-log-ipc /run/arb-reth/mev-logs.sock` opens a local Unix socket. Each connected client
@@ -121,9 +136,9 @@ connected. Frontier state deltas are retained whenever the feature is enabled.
 
 ## Payload execution
 
-- `--share-execution-cache-with-payload-builder <true|false>` shares Reth's cross-block account,
+- `--engine.share-execution-cache-with-payload-builder <true|false>` shares Reth's cross-block account,
   storage, and bytecode cache with the serial Arbitrum payload builder. It defaults to `true`.
-- `--share-sparse-trie-with-payload-builder` lets Reth compute the state root concurrently with
+- `--engine.share-sparse-trie-with-payload-builder` lets Reth compute the state root concurrently with
   ArbOS execution. It is opt-in and requires useful state-root worker parallelism.
 
 The node builds only one Arbitrum payload at a time. Do not reuse these settings in a node that can
@@ -131,10 +146,10 @@ run concurrent payload jobs without first reviewing Reth's cache and sparse-trie
 
 ## Persistence controls
 
-- `--persistence-threshold`: number of canonical blocks before a persistence batch.
-- `--memory-buffer-target`: recent blocks retained in memory before flushing.
-- `--persistence-backpressure`: maximum unpersisted gap before block production stalls.
-- `--no-fsync`: bulk-sync durability tradeoff. A crash can lose a recently produced suffix, which derivation can reproduce.
+- `--engine.persistence-threshold`: number of canonical blocks before a persistence batch.
+- `--engine.memory-block-buffer-target`: recent blocks retained in memory before flushing.
+- `--engine.persistence-backpressure-threshold`: maximum unpersisted gap before block production stalls.
+- `--db.sync-mode safe-no-sync`: bulk-sync durability tradeoff. A crash can lose a recently produced suffix, which derivation can reproduce. `--no-fsync` remains a compatibility alias.
 
 Start with the defaults unless a benchmark or recovery plan justifies changing them.
 

--- a/docs/commands/node.md
+++ b/docs/commands/node.md
@@ -139,8 +139,8 @@ connected. Frontier state deltas are retained whenever the feature is enabled.
 
 ## Payload execution
 
-- `--engine.share-execution-cache-with-payload-builder <true|false>` shares Reth's cross-block account,
-  storage, and bytecode cache with the serial Arbitrum payload builder. It defaults to `true`.
+- `--engine.share-execution-cache-with-payload-builder` shares Reth's cross-block account, storage,
+  and bytecode cache with the serial Arbitrum payload builder. It defaults to enabled.
 - `--engine.share-sparse-trie-with-payload-builder` lets Reth compute the state root concurrently with
   ArbOS execution. It is opt-in and requires useful state-root worker parallelism.
 

--- a/docs/commands/node.md
+++ b/docs/commands/node.md
@@ -111,6 +111,9 @@ HTTP and WebSocket are separate native Reth servers. Enable each explicitly with
 disabled because ArbOS derives blocks locally rather than accepting beacon-client engine commands.
 Reth's local IPC server follows its normal native default; pass `--ipcdisable` when it is not wanted.
 
+`--rpc.gascap` limits gas for `eth_call` and call tracing. Use `--rpc.gascap max` to remove Reth's
+default 50 million gas RPC cap. This does not change consensus block execution.
+
 ## MEV transaction-log IPC
 
 `--mev-tx-log-ipc /run/arb-reth/mev-logs.sock` opens a local Unix socket. Each connected client


### PR DESCRIPTION
## Summary

- replace the bespoke node parser with Reth's native `NodeCommand` and runner
- retain Arbitrum bootstrap, L1 derivation, sequencer feeds, MEV RPC/IPC, and the custom engine launcher
- apply native RPC, database, pruning, metrics, and engine settings after effective config resolution
- reject native component flags that this standalone node cannot honor
- preserve snapshot bootstrap and L1 resume behavior
- point unknown commands and removed flags to a native CLI migration guide

This exposes native RPC controls such as `--rpc.gascap max`, addressing the Reth-side cap in #43. The separate ArbOS `hold_gas` exemption still belongs in arbitrum-revm.

## Validation

- `cargo check --workspace --all-targets`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- native CLI help, `--rpc.gascap max`, and migration-error regression tests