### PR TITLE
fix(testnode): drop the forced delayed-message cursor in the parity harness

### DIFF
--- a/testnode/testnode-parity.sh
+++ b/testnode/testnode-parity.sh
@@ -116,7 +116,6 @@ cmd_run() {
     --l1-sequencer-inbox "$SEQUENCER_INBOX" \
     --l1-bridge "$BRIDGE" \
     --l1-start-block 0 \
-    --l1-start-delayed 0 \
     > "$ARB_LOG" 2>&1 &
   echo $! > "$ARB_PIDFILE"
   log "arb-reth pid $(cat "$ARB_PIDFILE"); logs at $ARB_LOG"


### PR DESCRIPTION
`testnode/testnode-parity.sh` always reports `DIVERGE 1` on current `main`.

Cause: the script passes `--l1-start-delayed 0`. Delayed message 0 is the chain's `Initialize` message, which genesis already applies, so the correct starting cursor is 1. Forcing 0 makes the first delayed messages land one block late — arb-reth's block 1 ends up holding only the ArbOS internal tx, and the retryable-submit tx Nitro puts in block 1 appears in block 2. Every later state root differs.

Dropping the flag lets the node work the cursor out itself (`L1 resume point: … delayed=1`).

Same binary, same chain, only the flag changed:

| flag | result |
| --- | --- |
| `--l1-start-delayed 0` | `DIVERGE 1` |
| removed | `OK: all 740 blocks match the testnode` |

The flag matched the old from-genesis default; #13 changed that default, so the script has been pinning the older behaviour since.

Tested against a stock nitro-testnode (`3c73bd8`, chain 412346, ArbOS 40) with a release build of `ae3f91f`. One note in case it helps: that testnode starts no beacon node, so I ran with `L1_BEACON=` empty.
