### PR TITLE
deps(arbitrum-revm): bump to 2ebb753 for root Stylus programs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ incremental = false
 [workspace.dependencies]
 # Keep the ArbOS implementation revision in one place. Individual crates opt into it with
 # `arb-revm.workspace = true`; only the EVM integration enables the Stylus runtime.
-arb-revm = { git = "https://github.com/nuntax/arbitrum-revm", rev = "81be7debab53b4f1053d63226a91773c68a8a89f" }
+arb-revm = { git = "https://github.com/nuntax/arbitrum-revm", rev = "2ebb753bea34be79950bebe1631461de7f079f59" }
 # Pinned to revm 42 to unify with arb_revm workspace.
 revm = { version = "42.0.1", features = ["optional_priority_fee_check", "optional_balance_check", "optional_eip7623", "optional_eip3541"] }
 alloy-rlp = "0.3.12"


### PR DESCRIPTION
Repins to arbitrum-revm main. Fixes issue #18: a root Stylus program (0xEFF002) was unrecognised, so activation reverted and the chain silently diverged at ArbOS >= 60. Also carries the Nitro runtime move to nitro-rust-runtime and Nitro's native stack overflow recovery.