### PR TITLE
Feat/export state history

### DIFF
--- a/crates/arb-reth-evm/src/block.rs
+++ b/crates/arb-reth-evm/src/block.rs
@@ -183,8 +183,9 @@ fn build_arb_receipt<H>(
     receipt_envelope_for_type(tx_type, rwb)
 }
 
+/// Wraps a receipt body in the envelope variant its transaction type calls for.
 #[inline]
-fn receipt_envelope_for_type(
+pub fn receipt_envelope_for_type(
     tx_type: u8,
     rwb: ReceiptWithBloom<ArbReceipt<Log>>,
 ) -> ArbReceiptEnvelope<Log> {

--- a/crates/arb-reth-genesis/examples/read_snapshot_stream.rs
+++ b/crates/arb-reth-genesis/examples/read_snapshot_stream.rs
@@ -77,6 +77,7 @@ fn main() -> eyre::Result<()> {
     stream.check_history_meets_state()?;
 
     println!("\nblocks   {headers} headers, {bodies} bodies, {receipts} receipt sets");
+    println!("         {tx_roots_checked} transactions roots verified against their header");
     println!("history  {histories} objects, {hist_accounts} accounts, {hist_slots} slots");
     println!("state    {accounts} accounts, {slots} slots, {codes} code blobs");
     println!("first history block: {first_history_block:?}");

--- a/crates/arb-reth-genesis/examples/read_snapshot_stream.rs
+++ b/crates/arb-reth-genesis/examples/read_snapshot_stream.rs
@@ -1,0 +1,48 @@
+//! Read a `reth-export --mode full-snapshot` stream and report what it contains.
+//!
+//! Usage: `read_snapshot_stream <stream-file>`. A truncated stream is expected to end in an error,
+//! which is the point: the reader should notice rather than stop quietly.
+
+use arb_reth_genesis::snapshot_stream::{Record, SnapshotStream};
+
+fn main() -> eyre::Result<()> {
+    let path = std::env::args().nth(1).ok_or_else(|| eyre::eyre!("usage: read_snapshot_stream <file>"))?;
+    let file = std::fs::File::open(&path)?;
+    let mut stream = SnapshotStream::open(std::io::BufReader::new(file))?;
+
+    let m = stream.manifest().clone();
+    println!("manifest: block {} state id {}", m.block, m.state_id);
+    println!("  root {:#x}", m.root);
+    println!("  hash {:#x}", m.hash);
+
+    let (mut headers, mut bodies, mut receipts, mut histories, mut accounts, mut slots, mut codes) =
+        (0u64, 0u64, 0u64, 0u64, 0u64, 0u64, 0u64);
+    loop {
+        match stream.next_record() {
+            Ok(None) => break,
+            Ok(Some(rec)) => match rec {
+                Record::Header { .. } => headers += 1,
+                Record::Body { .. } => bodies += 1,
+                Record::Receipts { .. } => receipts += 1,
+                Record::History(h) => {
+                    histories += 1;
+                    accounts += h.accounts.len() as u64;
+                    slots += h.accounts.iter().map(|a| a.storage.len() as u64).sum::<u64>();
+                }
+                Record::Account { .. } => accounts += 1,
+                Record::Storage { .. } => slots += 1,
+                Record::Code { .. } => codes += 1,
+            },
+            Err(e) => {
+                println!("\nstopped: {e}");
+                break;
+            }
+        }
+    }
+    println!(
+        "\nheaders {headers}, bodies {bodies}, receipt sets {receipts}, histories {histories}, \
+         accounts {accounts}, slots {slots}, code blobs {codes}"
+    );
+    println!("highest block seen: {:?}", stream.last_block());
+    Ok(())
+}

--- a/crates/arb-reth-genesis/examples/read_snapshot_stream.rs
+++ b/crates/arb-reth-genesis/examples/read_snapshot_stream.rs
@@ -8,7 +8,8 @@
 
 use std::time::Instant;
 
-use arb_reth_genesis::snapshot_stream::{Record, SnapshotStream};
+use alloy_primitives::B256;
+use arb_reth_genesis::snapshot_stream::{header_field, transactions_root, Record, SnapshotStream};
 
 fn main() -> eyre::Result<()> {
     let path = std::env::args()
@@ -28,11 +29,35 @@ fn main() -> eyre::Result<()> {
     let (mut histories, mut hist_accounts, mut hist_slots) = (0u64, 0u64, 0u64);
     let (mut accounts, mut slots, mut codes) = (0u64, 0u64, 0u64);
     let mut first_history_block = None;
+    // Header by block, so a body can be checked against the header that precedes it.
+    let mut pending_header: Option<(u64, B256)> = None;
+    let mut tx_roots_checked = 0u64;
 
     while let Some(rec) = stream.next_record()? {
         match rec {
-            Record::Header { .. } => headers += 1,
-            Record::Body { .. } => bodies += 1,
+            Record::Header { block, rlp, .. } => {
+                headers += 1;
+                pending_header = Some((block, B256::from_slice(header_field(&rlp, 4)?)));
+            }
+            Record::Body { block, rlp } => {
+                bodies += 1;
+                match pending_header {
+                    Some((n, want)) if n == block => {
+                        let got = transactions_root(&rlp)?;
+                        if got != want {
+                            return Err(eyre::eyre!(
+                                "block {block}: transactions root {got:#x}, header says {want:#x}"
+                            ));
+                        }
+                        tx_roots_checked += 1;
+                    }
+                    other => {
+                        return Err(eyre::eyre!(
+                            "block {block}: body without its header (pending {other:?})"
+                        ));
+                    }
+                }
+            }
             Record::Receipts { .. } => receipts += 1,
             Record::History(h) => {
                 first_history_block.get_or_insert(h.block);

--- a/crates/arb-reth-genesis/examples/read_snapshot_stream.rs
+++ b/crates/arb-reth-genesis/examples/read_snapshot_stream.rs
@@ -1,48 +1,65 @@
-//! Read a `reth-export --mode full-snapshot` stream and report what it contains.
+//! Validate a `reth-export --mode full-snapshot` stream.
 //!
-//! Usage: `read_snapshot_stream <stream-file>`. A truncated stream is expected to end in an error,
-//! which is the point: the reader should notice rather than stop quietly.
+//! Streams the whole file through [`SnapshotStream`], which enforces the invariants that need no
+//! database, then checks that the history reaches the exported state. Exits non-zero on any failure
+//! so this can gate an import.
+//!
+//! Usage: `read_snapshot_stream <stream-file>`
+
+use std::time::Instant;
 
 use arb_reth_genesis::snapshot_stream::{Record, SnapshotStream};
 
 fn main() -> eyre::Result<()> {
-    let path = std::env::args().nth(1).ok_or_else(|| eyre::eyre!("usage: read_snapshot_stream <file>"))?;
+    let path = std::env::args()
+        .nth(1)
+        .ok_or_else(|| eyre::eyre!("usage: read_snapshot_stream <file>"))?;
     let file = std::fs::File::open(&path)?;
-    let mut stream = SnapshotStream::open(std::io::BufReader::new(file))?;
+    let total = file.metadata()?.len();
+    let mut stream = SnapshotStream::open(std::io::BufReader::with_capacity(1 << 22, file))?;
 
     let m = stream.manifest().clone();
     println!("manifest: block {} state id {}", m.block, m.state_id);
     println!("  root {:#x}", m.root);
     println!("  hash {:#x}", m.hash);
 
-    let (mut headers, mut bodies, mut receipts, mut histories, mut accounts, mut slots, mut codes) =
-        (0u64, 0u64, 0u64, 0u64, 0u64, 0u64, 0u64);
-    loop {
-        match stream.next_record() {
-            Ok(None) => break,
-            Ok(Some(rec)) => match rec {
-                Record::Header { .. } => headers += 1,
-                Record::Body { .. } => bodies += 1,
-                Record::Receipts { .. } => receipts += 1,
-                Record::History(h) => {
-                    histories += 1;
-                    accounts += h.accounts.len() as u64;
-                    slots += h.accounts.iter().map(|a| a.storage.len() as u64).sum::<u64>();
+    let started = Instant::now();
+    let (mut headers, mut bodies, mut receipts) = (0u64, 0u64, 0u64);
+    let (mut histories, mut hist_accounts, mut hist_slots) = (0u64, 0u64, 0u64);
+    let (mut accounts, mut slots, mut codes) = (0u64, 0u64, 0u64);
+    let mut first_history_block = None;
+
+    while let Some(rec) = stream.next_record()? {
+        match rec {
+            Record::Header { .. } => headers += 1,
+            Record::Body { .. } => bodies += 1,
+            Record::Receipts { .. } => receipts += 1,
+            Record::History(h) => {
+                first_history_block.get_or_insert(h.block);
+                histories += 1;
+                hist_accounts += h.accounts.len() as u64;
+                hist_slots += h.accounts.iter().map(|a| a.storage.len() as u64).sum::<u64>();
+                if histories % 5_000_000 == 0 {
+                    println!("  .. {histories} history objects ({:?})", started.elapsed());
                 }
-                Record::Account { .. } => accounts += 1,
-                Record::Storage { .. } => slots += 1,
-                Record::Code { .. } => codes += 1,
-            },
-            Err(e) => {
-                println!("\nstopped: {e}");
-                break;
             }
+            Record::Account { .. } => accounts += 1,
+            Record::Storage { .. } => slots += 1,
+            Record::Code { .. } => codes += 1,
         }
     }
+
+    stream.check_history_meets_state()?;
+
+    println!("\nblocks   {headers} headers, {bodies} bodies, {receipts} receipt sets");
+    println!("history  {histories} objects, {hist_accounts} accounts, {hist_slots} slots");
+    println!("state    {accounts} accounts, {slots} slots, {codes} code blobs");
+    println!("first history block: {first_history_block:?}");
+    println!("highest block: {:?}", stream.last_block());
     println!(
-        "\nheaders {headers}, bodies {bodies}, receipt sets {receipts}, histories {histories}, \
-         accounts {accounts}, slots {slots}, code blobs {codes}"
+        "\nvalidated {:.1} GB in {:?}",
+        total as f64 / 1e9,
+        started.elapsed()
     );
-    println!("highest block seen: {:?}", stream.last_block());
     Ok(())
 }

--- a/crates/arb-reth-genesis/go-exporter/reth-export.go
+++ b/crates/arb-reth-genesis/go-exporter/reth-export.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"io"
 	"math/big"
 	"os"
 	"sync"
@@ -147,7 +148,7 @@ func main() {
 	// headroom. `--parallel N` splits the account-key space into N disjoint ranges walked
 	// concurrently, each writing `<outbase>.partNNN`; concatenating the parts in index order yields
 	// the same stream a serial walk would. `--outbase` is required when N > 1.
-	parallel := flag.Int("parallel", 1, "for --mode state: number of concurrent key-range walkers")
+	parallel := flag.Int("parallel", 1, "for --mode state and --mode full-snapshot: number of concurrent key-range walkers")
 	outbase := flag.String("outbase", "", "for --mode state --parallel N: output path prefix for part files")
 	flag.Parse()
 	if flag.NArg() < 1 {
@@ -337,7 +338,7 @@ func main() {
 		}
 		fmt.Fprintf(os.Stderr, "exported %d blocks [%d..%d]\n", nBlk, lo, hi)
 	case "full-snapshot":
-		fullSnapshot(db, anc, sdb, tdb)
+		fullSnapshot(db, anc, sdb, tdb, *parallel, dir)
 	case "diskroot":
 		// The path-scheme disk layer: the persisted trie, before any journalled diff layers.
 		// pathdb derives it the same way in loadLayers(). Its root is the post root of the most
@@ -665,7 +666,7 @@ func resolveConvertPoint(db ethdb.Database, ancientDir string, sdb state.Databas
 //
 // Sections are ordered so the importer can write append-only: blocks ascending, then history
 // ascending, then the state bulk load. Everything stops at P, so the three agree.
-func fullSnapshot(db ethdb.Database, ancientDir string, sdb state.Database, tdb *triedb.Database) {
+func fullSnapshot(db ethdb.Database, ancientDir string, sdb state.Database, tdb *triedb.Database, parallel int, tmpDir string) {
 	point := resolveConvertPoint(db, ancientDir, sdb)
 	fmt.Fprintf(os.Stderr, "convert point: block=%d root=%s stateID=%d\n",
 		point.block, point.root.Hex(), point.stateID)
@@ -677,7 +678,7 @@ func fullSnapshot(db ethdb.Database, ancientDir string, sdb state.Database, tdb 
 	writeManifestSection(w, db, point)
 	writeBlocksSection(w, db, point)
 	writeHistorySection(w, ancientDir, point)
-	writeStateSection(w, sdb, tdb, db, point)
+	writeStateSection(w, sdb, tdb, db, point, parallel, tmpDir)
 	w.WriteByte(snapSectionEnd)
 }
 
@@ -755,91 +756,174 @@ func writeHistorySection(w *bufio.Writer, ancientDir string, point convertPoint)
 
 // writeStateSection walks the account and storage tries at R_P.
 //
-// This is the same walk --mode state performs, at the persisted root rather than the head root, and
-// emitting binary rather than hex. Storage tries are opened by hashed owner, since a pruned snapshot
-// carries no address preimages.
-func writeStateSection(w *bufio.Writer, sdb state.Database, tdb *triedb.Database, db ethdb.Database, point convertPoint) {
+// The serial walk is random-read bound at iodepth 1 and measured at a few MB per minute on a real
+// snapshot, which is unusable. `--parallel N` splits the account key space into N disjoint ranges
+// walked concurrently, each into a temporary file, then appends them in index order. Records land in
+// key order either way, so the result is byte-identical to a serial walk.
+func writeStateSection(w *bufio.Writer, sdb state.Database, tdb *triedb.Database, db ethdb.Database, point convertPoint, parallel int, tmpDir string) {
 	w.WriteByte(snapSectionState)
-	accTrie, err := sdb.OpenTrie(point.root)
-	if err != nil {
-		fatal("open account trie at the persisted root", err)
+	var accounts, slots, codes uint64
+	started := time.Now()
+	// Code is shared across partitions: proxies mean one bytecode backs many accounts. Deduplicating
+	// globally keeps a partitioned run from emitting the same blob once per partition.
+	var seenCode sync.Map
+
+	if parallel <= 1 {
+		if err := walkStateRange(w, sdb, tdb, db, point.root, nil, nil, &seenCode, &accounts, &slots, &codes); err != nil {
+			fatal("walk state", err)
+		}
+	} else {
+		parts := make([]string, parallel)
+		errs := make([]error, parallel)
+		var wg sync.WaitGroup
+		for i := 0; i < parallel; i++ {
+			parts[i] = fmt.Sprintf("%s/state-part-%03d.bin", tmpDir, i)
+			wg.Add(1)
+			go func(i int) {
+				defer wg.Done()
+				f, err := os.Create(parts[i])
+				if err != nil {
+					errs[i] = err
+					return
+				}
+				defer f.Close()
+				pw := bufio.NewWriterSize(f, 1<<22)
+				var lo, hi []byte
+				if i > 0 {
+					lo = partitionBoundary(i, parallel)
+				}
+				if i < parallel-1 {
+					hi = partitionBoundary(i+1, parallel)
+				}
+				if err := walkStateRange(pw, sdb, tdb, db, point.root, lo, hi, &seenCode, &accounts, &slots, &codes); err != nil {
+					errs[i] = err
+					return
+				}
+				errs[i] = pw.Flush()
+			}(i)
+		}
+
+		done := make(chan struct{})
+		go func() {
+			ticker := time.NewTicker(30 * time.Second)
+			defer ticker.Stop()
+			for {
+				select {
+				case <-done:
+					return
+				case <-ticker.C:
+					fmt.Fprintf(os.Stderr, "state %d accounts, %d slots, %d code (%s)\n",
+						atomic.LoadUint64(&accounts), atomic.LoadUint64(&slots),
+						atomic.LoadUint64(&codes), time.Since(started).Truncate(time.Second))
+				}
+			}
+		}()
+		wg.Wait()
+		close(done)
+		for i, err := range errs {
+			if err != nil {
+				fatal(fmt.Sprintf("state partition %d", i), err)
+			}
+		}
+
+		// Append in index order. Partition boundaries are ascending key ranges, so this is the same
+		// sequence a serial walk would have produced.
+		for i, name := range parts {
+			f, err := os.Open(name)
+			if err != nil {
+				fatal(fmt.Sprintf("open state part %d", i), err)
+			}
+			if _, err := io.Copy(w, bufio.NewReaderSize(f, 1<<22)); err != nil {
+				fatal(fmt.Sprintf("append state part %d", i), err)
+			}
+			f.Close()
+			os.Remove(name)
+		}
 	}
-	nodeIt, err := accTrie.NodeIterator(nil)
+
+	w.WriteByte(snapRecEnd)
+	fmt.Fprintf(os.Stderr, "state section: %d accounts, %d slots, %d code blobs in %s\n",
+		accounts, slots, codes, time.Since(started).Truncate(time.Second))
+}
+
+// walkStateRange emits accounts in [lo, hi) with their storage and code.
+//
+// Storage tries open by hashed owner: a pruned snapshot carries no address preimages, so the owner
+// must come from the account iterator's key rather than from hashing an address.
+func walkStateRange(w *bufio.Writer, sdb state.Database, tdb *triedb.Database, db ethdb.Database,
+	root common.Hash, lo, hi []byte, seenCode *sync.Map, accounts, slots, codes *uint64) error {
+	accTrie, err := sdb.OpenTrie(root)
 	if err != nil {
-		fatal("account node iterator", err)
+		return fmt.Errorf("open account trie: %w", err)
+	}
+	nodeIt, err := accTrie.NodeIterator(lo)
+	if err != nil {
+		return fmt.Errorf("account node iterator: %w", err)
 	}
 	accIt := trie.NewIterator(nodeIt)
 
-	seenCode := make(map[common.Hash]struct{})
-	var accounts, slots, codes uint64
-	started := time.Now()
 	for accIt.Next() {
+		if hi != nil && bytes.Compare(accIt.Key, hi) >= 0 {
+			break
+		}
 		var acc types.StateAccount
 		if err := rlp.DecodeBytes(accIt.Value, &acc); err != nil {
-			fatal("decode account", err)
+			return fmt.Errorf("decode account %x: %w", accIt.Key, err)
 		}
 		owner := common.BytesToHash(accIt.Key)
 		w.WriteByte(snapRecAccount)
-		w.Write(owner.Bytes()) // hashed address; the source has no preimage for it
+		w.Write(owner.Bytes())
 		writeUvarint(w, acc.Nonce)
 		writeShortBytes(w, acc.Balance.Bytes())
-		if bytes.Equal(acc.CodeHash, types.EmptyCodeHash[:]) {
-			w.WriteByte(0)
-		} else {
+		hasCode := !bytes.Equal(acc.CodeHash, types.EmptyCodeHash[:])
+		if hasCode {
 			writeShortBytes(w, acc.CodeHash)
+		} else {
+			w.WriteByte(0)
 		}
-		accounts++
+		atomic.AddUint64(accounts, 1)
 
-		codeHash := common.BytesToHash(acc.CodeHash)
-		if !bytes.Equal(acc.CodeHash, types.EmptyCodeHash[:]) {
-			if _, ok := seenCode[codeHash]; !ok {
-				seenCode[codeHash] = struct{}{}
+		if hasCode {
+			codeHash := common.BytesToHash(acc.CodeHash)
+			if _, loaded := seenCode.LoadOrStore(codeHash, struct{}{}); !loaded {
 				code := rawdb.ReadCode(db, codeHash)
 				if len(code) == 0 {
-					fatal("read contract code", fmt.Errorf("no code for hash %s", codeHash.Hex()))
+					return fmt.Errorf("no code for hash %s", codeHash.Hex())
 				}
 				w.WriteByte(snapRecCode)
 				w.Write(codeHash.Bytes())
 				writeBlob(w, code)
-				codes++
+				atomic.AddUint64(codes, 1)
 			}
 		}
 
 		if acc.Root == types.EmptyRootHash {
 			continue
 		}
-		stTrie, err := trie.NewStateTrie(trie.StorageTrieID(point.root, owner, acc.Root), tdb)
+		stTrie, err := trie.NewStateTrie(trie.StorageTrieID(root, owner, acc.Root), tdb)
 		if err != nil {
-			fatal("open storage trie", err)
+			return fmt.Errorf("open storage trie for %x: %w", owner, err)
 		}
 		stNodeIt, err := stTrie.NodeIterator(nil)
 		if err != nil {
-			fatal("storage node iterator", err)
+			return fmt.Errorf("storage node iterator for %x: %w", owner, err)
 		}
 		stIt := trie.NewIterator(stNodeIt)
 		for stIt.Next() {
 			var val []byte
 			if err := rlp.DecodeBytes(stIt.Value, &val); err != nil {
-				fatal("decode storage value", err)
+				return fmt.Errorf("decode storage value for %x: %w", owner, err)
 			}
 			w.WriteByte(snapRecStorage)
-			w.Write(common.BytesToHash(stIt.Key).Bytes()) // hashed slot key
+			w.Write(common.BytesToHash(stIt.Key).Bytes())
 			writeShortBytes(w, val)
-			slots++
+			atomic.AddUint64(slots, 1)
 		}
 		if err := stIt.Err; err != nil {
-			fatal("storage iterator", err)
-		}
-		if accounts%1000000 == 0 {
-			fmt.Fprintf(os.Stderr, "state %d accounts, %d slots (%s)\n", accounts, slots, time.Since(started).Truncate(time.Second))
+			return fmt.Errorf("storage iterator for %x: %w", owner, err)
 		}
 	}
-	if err := accIt.Err; err != nil {
-		fatal("account iterator", err)
-	}
-	w.WriteByte(snapRecEnd)
-	fmt.Fprintf(os.Stderr, "state section: %d accounts, %d slots, %d code blobs in %s\n",
-		accounts, slots, codes, time.Since(started).Truncate(time.Second))
+	return accIt.Err
 }
 
 // writeBlob writes a varint-prefixed byte slice, for payloads that exceed 255 bytes.

--- a/crates/arb-reth-genesis/go-exporter/reth-export.go
+++ b/crates/arb-reth-genesis/go-exporter/reth-export.go
@@ -134,7 +134,7 @@ func walkRange(w *bufio.Writer, sdb state.Database, tdb *triedb.Database, root c
 
 func main() {
 	ancient := flag.String("ancient", "", "ancients/freezer directory (default <dir>/ancient)")
-	mode := flag.String("mode", "diag", "diag|state|blocks|history|full-snapshot|diskroot|accounts|addr")
+	mode := flag.String("mode", "diag", "diag|state|blocks|history|full-snapshot|diskroot|accounts|addr|resume-point")
 	max := flag.Uint64("max", 0, "max accounts to dump (0 = all)")
 	addr := flag.String("addr", "", "for --mode addr: a 0x address to dump (storage key form check)")
 	from := flag.Int64("from", -1, "for --mode blocks: first block; for --mode history: first state id (default = earliest)")
@@ -153,6 +153,9 @@ func main() {
 	// Never defaults to the source directory: that is a live pebble database, and scattering part
 	// files through it risks confusing a later open.
 	tmpdir := flag.String("tmpdir", os.TempDir(), "for --mode full-snapshot --parallel N: scratch directory for state part files")
+	arbitrumdata := flag.String("arbitrumdata", "", "for --mode resume-point: the snapshot's arbitrumdata directory")
+	l2Block := flag.Int64("l2-block", -1, "for --mode resume-point: the converted head (P)")
+	genesisBlock := flag.Uint64("genesis-block", 0, "for --mode resume-point: the chain's ArbOS GenesisBlockNum")
 	flag.Parse()
 	if flag.NArg() < 1 {
 		fmt.Fprintln(os.Stderr, "usage: reth-export <l2chaindata-dir> [--ancient DIR] [--mode diag|accounts] [--max N]")
@@ -341,7 +344,12 @@ func main() {
 		}
 		fmt.Fprintf(os.Stderr, "exported %d blocks [%d..%d]\n", nBlk, lo, hi)
 	case "full-snapshot":
-		fullSnapshot(db, anc, sdb, tdb, *parallel, *tmpdir)
+		fullSnapshot(db, anc, sdb, tdb, *parallel, *tmpdir, *arbitrumdata, *genesisBlock, *cacheMB, *handles)
+	case "resume-point":
+		if *arbitrumdata == "" {
+			fatal("resume-point", fmt.Errorf("--arbitrumdata is required"))
+		}
+		resumePoint(*arbitrumdata, uint64(*l2Block), *genesisBlock, *cacheMB, *handles)
 	case "diskroot":
 		// The path-scheme disk layer: the persisted trie, before any journalled diff layers.
 		// pathdb derives it the same way in loadLayers(). Its root is the post root of the most
@@ -669,23 +677,39 @@ func resolveConvertPoint(db ethdb.Database, ancientDir string, sdb state.Databas
 //
 // Sections are ordered so the importer can write append-only: blocks ascending, then history
 // ascending, then the state bulk load. Everything stops at P, so the three agree.
-func fullSnapshot(db ethdb.Database, ancientDir string, sdb state.Database, tdb *triedb.Database, parallel int, tmpDir string) {
+func fullSnapshot(db ethdb.Database, ancientDir string, sdb state.Database, tdb *triedb.Database, parallel int, tmpDir string, arbitrumdata string, genesisBlock uint64, cacheMB, handles int) {
 	point := resolveConvertPoint(db, ancientDir, sdb)
 	fmt.Fprintf(os.Stderr, "convert point: block=%d root=%s stateID=%d\n",
 		point.block, point.root.Hex(), point.stateID)
+
+	// The derivation cursor is not recoverable from L2 state, so without it an importer's node can
+	// only re-derive from batch 0: on this chain that was 685,718 parent-chain blocks of getLogs and
+	// blob fetches, all discarded, before a single new block. Nitro already knows the answer, so
+	// carry it in the stream rather than making the operator run a second tool.
+	var resume *resumeCheckpoint
+	if arbitrumdata != "" {
+		if cp, ok := computeResumePoint(arbitrumdata, point.block, genesisBlock, cacheMB, handles); ok {
+			resume = &cp
+			fmt.Fprintf(os.Stderr, "resume point: l1_block=%d delayed=%d l2_block=%d\n",
+				cp.L1Block, cp.DelayedCount, cp.L2Block)
+		}
+	} else {
+		fmt.Fprintln(os.Stderr,
+			"note: no --arbitrumdata, so the stream carries no resume point; the importing node will re-derive from batch 0")
+	}
 
 	w := bufio.NewWriterSize(os.Stdout, 1<<22)
 	defer w.Flush()
 	w.WriteString(snapStreamMagic)
 
-	writeManifestSection(w, db, point)
+	writeManifestSection(w, db, point, resume)
 	writeBlocksSection(w, db, point)
 	writeHistorySection(w, ancientDir, point)
 	writeStateSection(w, sdb, tdb, db, point, parallel, tmpDir)
 	w.WriteByte(snapSectionEnd)
 }
 
-func writeManifestSection(w *bufio.Writer, db ethdb.Database, point convertPoint) {
+func writeManifestSection(w *bufio.Writer, db ethdb.Database, point convertPoint, resume *resumeCheckpoint) {
 	w.WriteByte(snapSectionManifest)
 	writeUvarint(w, point.block)
 	w.Write(point.root.Bytes())
@@ -695,6 +719,17 @@ func writeManifestSection(w *bufio.Writer, db ethdb.Database, point convertPoint
 		fatal("read convert-point hash", fmt.Errorf("no canonical hash at block %d", point.block))
 	}
 	w.Write(hash.Bytes())
+
+	// Optional, because a snapshot without its arbitrumdata can still be converted; the importer
+	// just cannot write a derivation cursor for it.
+	if resume == nil {
+		w.WriteByte(0)
+		return
+	}
+	w.WriteByte(1)
+	writeUvarint(w, resume.L1Block)
+	writeUvarint(w, resume.DelayedCount)
+	writeUvarint(w, resume.L2Block)
 }
 
 // writeBlocksSection streams headers, bodies and receipts for [0, P] as raw RLP.
@@ -970,4 +1005,135 @@ func streamHistoryRange(w *bufio.Writer, store ethdb.AncientStore, first, last u
 		}
 	}
 	return emitted, skipped, accounts, slots
+}
+
+// ---------------------------------------------------------------------------
+// --mode resume-point: where L1 derivation should restart for a converted datadir
+// ---------------------------------------------------------------------------
+
+// A converted datadir has no derivation cursor, so the node falls back to re-deriving from batch 0.
+// On a real chain that scans the whole parent-chain range and refetches every historical blob only to
+// drop the results, before producing a single new block.
+//
+// Nitro already knows the answer. `arbitrumdata` maps each batch sequence number to its
+// BatchMetadata, which carries the message count reached, the delayed cursor, and the parent-chain
+// block the batch was posted in. The batch boundary at or below the convert point is exactly the
+// resume checkpoint the node's persisted-checkpoint path wants.
+type batchMetadata struct {
+	Accumulator         common.Hash
+	MessageCount        uint64
+	DelayedMessageCount uint64
+	ParentChainBlock    uint64
+}
+
+// Matches arb-reth's `L1ResumeCheckpoint`: after consuming every batch up to and including L1 block
+// `l1_block - 1`, the delayed cursor is `delayed_count` and the chain has reached `l2_block`.
+type resumeCheckpoint struct {
+	L1Block      uint64 `json:"l1_block"`
+	DelayedCount uint64 `json:"delayed_count"`
+	L2Block      uint64 `json:"l2_block"`
+}
+
+type resumeLog struct {
+	Checkpoints []resumeCheckpoint `json:"checkpoints"`
+}
+
+func resumePoint(arbitrumdata string, convertPoint uint64, genesisBlock uint64, cacheMB, handles int) {
+	cp, ok := computeResumePoint(arbitrumdata, convertPoint, genesisBlock, cacheMB, handles)
+	if !ok {
+		fatal("resume-point", fmt.Errorf("no batch boundary at or below block %d", convertPoint))
+	}
+	out, err := json.Marshal(resumeLog{Checkpoints: []resumeCheckpoint{cp}})
+	if err != nil {
+		fatal("encode resume log", err)
+	}
+	fmt.Println(string(out))
+}
+
+func computeResumePoint(arbitrumdata string, convertPoint uint64, genesisBlock uint64, cacheMB, handles int) (resumeCheckpoint, bool) {
+	if convertPoint == 0 {
+		fatal("resume-point", fmt.Errorf("--l2-block is required"))
+	}
+	db, err := node.OpenDatabase(node.InternalOpenOptions{
+		DbEngine:  "pebble",
+		Directory: arbitrumdata,
+		DatabaseOptions: node.DatabaseOptions{
+			MetricsNamespace: "rethexport/",
+			ReadOnly:         true,
+			Cache:            cacheMB,
+			Handles:          handles,
+		},
+	})
+	if err != nil {
+		fatal("open arbitrumdata", err)
+	}
+	defer db.Close()
+
+	countBytes, err := db.Get([]byte("_sequencerBatchCount"))
+	if err != nil {
+		fatal("read _sequencerBatchCount", err)
+	}
+	var batchCount uint64
+	if err := rlp.DecodeBytes(countBytes, &batchCount); err != nil {
+		fatal("decode _sequencerBatchCount", err)
+	}
+	if batchCount == 0 {
+		fatal("resume-point", fmt.Errorf("arbitrumdata holds no batches"))
+	}
+
+	read := func(seq uint64) batchMetadata {
+		key := append([]byte("s"), encodeBE(seq)...)
+		raw, err := db.Get(key)
+		if err != nil {
+			fatal(fmt.Sprintf("read batch meta %d", seq), err)
+		}
+		var meta batchMetadata
+		if err := rlp.DecodeBytes(raw, &meta); err != nil {
+			fatal(fmt.Sprintf("decode batch meta %d", seq), err)
+		}
+		return meta
+	}
+	// The last L2 block a batch produced. Message index n is block genesisBlock+n.
+	lastBlock := func(seq uint64) uint64 { return genesisBlock + read(seq).MessageCount - 1 }
+
+	// Largest batch whose blocks are all at or below the convert point.
+	lo, hi := uint64(0), batchCount-1
+	if lastBlock(lo) > convertPoint {
+		fatal("resume-point", fmt.Errorf("even batch 0 ends at block %d, above the convert point %d", lastBlock(lo), convertPoint))
+	}
+	for lo < hi {
+		mid := (lo + hi + 1) / 2
+		if lastBlock(mid) <= convertPoint {
+			lo = mid
+		} else {
+			hi = mid - 1
+		}
+	}
+
+	// Several batches can share one parent-chain block. Resuming at ParentChainBlock+1 would then
+	// skip the siblings posted in the same block, leaving a gap that nothing later detects. Step
+	// back until the chosen batch is the last one in its parent-chain block.
+	chosen := lo
+	for chosen > 0 && chosen+1 < batchCount && read(chosen+1).ParentChainBlock == read(chosen).ParentChainBlock {
+		chosen--
+	}
+	meta := read(chosen)
+	cp := resumeCheckpoint{
+		L1Block:      meta.ParentChainBlock + 1,
+		DelayedCount: meta.DelayedMessageCount,
+		L2Block:      genesisBlock + meta.MessageCount - 1,
+	}
+	fmt.Fprintf(os.Stderr,
+		"batches=%d convert_point=%d chosen_batch=%d (stepped back %d) parent_chain_block=%d\n",
+		batchCount, convertPoint, chosen, lo-chosen, meta.ParentChainBlock)
+	fmt.Fprintf(os.Stderr,
+		"resuming at L1 %d skips %d parent-chain blocks of re-derivation\n",
+		cp.L1Block, cp.L1Block-read(0).ParentChainBlock)
+	return cp, true
+}
+
+func encodeBE(v uint64) []byte {
+	b := make([]byte, 8)
+	binary.BigEndian.PutUint64(b, v)
+	return b
 }

--- a/crates/arb-reth-genesis/go-exporter/reth-export.go
+++ b/crates/arb-reth-genesis/go-exporter/reth-export.go
@@ -133,7 +133,7 @@ func walkRange(w *bufio.Writer, sdb state.Database, tdb *triedb.Database, root c
 
 func main() {
 	ancient := flag.String("ancient", "", "ancients/freezer directory (default <dir>/ancient)")
-	mode := flag.String("mode", "diag", "diag|state|blocks|history|accounts|addr")
+	mode := flag.String("mode", "diag", "diag|state|blocks|history|full-snapshot|diskroot|accounts|addr")
 	max := flag.Uint64("max", 0, "max accounts to dump (0 = all)")
 	addr := flag.String("addr", "", "for --mode addr: a 0x address to dump (storage key form check)")
 	from := flag.Int64("from", -1, "for --mode blocks: first block; for --mode history: first state id (default = earliest)")
@@ -336,6 +336,19 @@ func main() {
 			nBlk++
 		}
 		fmt.Fprintf(os.Stderr, "exported %d blocks [%d..%d]\n", nBlk, lo, hi)
+	case "full-snapshot":
+		fullSnapshot(db, anc, sdb, tdb)
+	case "diskroot":
+		// The path-scheme disk layer: the persisted trie, before any journalled diff layers.
+		// pathdb derives it the same way in loadLayers(). Its root is the post root of the most
+		// recent state history object, which is what makes it the point where state and history
+		// agree.
+		node := rawdb.ReadAccountTrieNode(db, nil)
+		if len(node) == 0 {
+			fatal("read disk-layer root node", fmt.Errorf("no account trie node at the empty path"))
+		}
+		fmt.Printf("diskRoot=%s persistentStateID=%d\n",
+			crypto.Keccak256Hash(node).Hex(), rawdb.ReadPersistentStateID(db))
 	case "history":
 		exportHistory(anc, uint64Flag(*from), uint64Flag(*to))
 	case "addr":
@@ -360,8 +373,8 @@ func main() {
 // Encoded sizes of the fixed-width records inside a state history object.
 // Mirrors triedb/pathdb/history_state.go, which keeps these unexported.
 const (
-	histMetaSize     = 73 // version(1) parentRoot(32) postRoot(32) block(8)
-	histAccIndexSize = 33 // address(20) len(1) offset(4) storageOffset(4) storageSlots(4)
+	histMetaSize      = 73 // version(1) parentRoot(32) postRoot(32) block(8)
+	histAccIndexSize  = 33 // address(20) len(1) offset(4) storageOffset(4) storageSlots(4)
 	histSlotIndexSize = 37 // slotKey(32) len(1) offset(4)
 
 	histVersionHashedSlots = 0 // storage slot keys are hashed
@@ -572,5 +585,286 @@ func writeUvarint(w *bufio.Writer, v uint64) {
 // (balance, code hash, slot value) is bounded at 32.
 func writeShortBytes(w *bufio.Writer, b []byte) {
 	w.WriteByte(byte(len(b)))
+	w.Write(b)
+}
+
+// ---------------------------------------------------------------------------
+// --mode full-snapshot: one stream holding state, blocks and history up to P
+// ---------------------------------------------------------------------------
+
+// Stream framing. Sections appear in this order and each is self-terminating.
+const (
+	snapStreamMagic = "ARBSNAP1"
+
+	snapSectionManifest = 0x01
+	snapSectionBlocks   = 0x02
+	snapSectionHistory  = 0x03
+	snapSectionState    = 0x04
+	snapSectionEnd      = 0xff
+
+	snapRecEnd     = 0x00
+	snapRecHeader  = 0x01 // block header
+	snapRecBody    = 0x02 // block body
+	snapRecReceipt = 0x03 // block receipts
+	snapRecAccount = 0x04 // account, at the exported state root
+	snapRecStorage = 0x05 // storage slot, belongs to the preceding account
+	snapRecCode    = 0x06 // contract code, keyed by hash
+)
+
+// convertPoint is where state, blocks and history all agree: the block of the persisted state trie.
+//
+// State above it lives only in the pathdb journal (the disk layer's unflushed write buffer, and diff
+// layers on top), so it is not in the trie on disk. Converting up to this point and letting the node
+// re-derive the rest avoids needing any of that, and avoids a range whose state we would have to
+// reconstruct in order to generate its own changesets.
+type convertPoint struct {
+	block   uint64      // P
+	root    common.Hash // R_P
+	stateID uint64      // persistent state id, which is P's history object
+}
+
+// resolveConvertPoint reads P two independent ways and requires them to agree (ADR-004 P3).
+//
+// The root comes from hashing the persisted root account trie node. The block comes from the history
+// object at the persistent state id. If a snapshot were captured mid-write these would disagree, and
+// the resulting conversion would silently pair one block's state with another block's history.
+func resolveConvertPoint(db ethdb.Database, ancientDir string) convertPoint {
+	node := rawdb.ReadAccountTrieNode(db, nil)
+	if len(node) == 0 {
+		fatal("read persisted state root", fmt.Errorf("no account trie node at the empty path; is this a path-scheme database?"))
+	}
+	root := crypto.Keccak256Hash(node)
+	id := rawdb.ReadPersistentStateID(db)
+	if id == 0 {
+		fatal("read persistent state id", fmt.Errorf("no persistent state id; nothing has been flattened to disk"))
+	}
+
+	store, err := rawdb.NewStateFreezer(ancientDir, false, true)
+	if err != nil {
+		fatal("open state freezer", err)
+	}
+	defer store.Close()
+
+	meta, _, _, _, _, err := rawdb.ReadStateHistory(store, id)
+	if err != nil {
+		fatal(fmt.Sprintf("read state history %d", id), err)
+	}
+	if len(meta) != histMetaSize {
+		fatal("decode state history meta", fmt.Errorf("meta is %d bytes, want %d", len(meta), histMetaSize))
+	}
+	postRoot := common.BytesToHash(meta[33:65])
+	if postRoot != root {
+		fatal("resolve convert point", fmt.Errorf(
+			"persisted trie root %s does not match the post root %s of history %d; snapshot looks torn",
+			root.Hex(), postRoot.Hex(), id))
+	}
+	return convertPoint{
+		block:   binary.BigEndian.Uint64(meta[65:histMetaSize]),
+		root:    root,
+		stateID: id,
+	}
+}
+
+// fullSnapshot writes one stream that an importer can turn into a complete reth datadir.
+//
+// Sections are ordered so the importer can write append-only: blocks ascending, then history
+// ascending, then the state bulk load. Everything stops at P, so the three agree.
+func fullSnapshot(db ethdb.Database, ancientDir string, sdb state.Database, tdb *triedb.Database) {
+	point := resolveConvertPoint(db, ancientDir)
+	fmt.Fprintf(os.Stderr, "convert point: block=%d root=%s stateID=%d\n",
+		point.block, point.root.Hex(), point.stateID)
+
+	w := bufio.NewWriterSize(os.Stdout, 1<<22)
+	defer w.Flush()
+	w.WriteString(snapStreamMagic)
+
+	writeManifestSection(w, db, point)
+	writeBlocksSection(w, db, point)
+	writeHistorySection(w, ancientDir, point)
+	writeStateSection(w, sdb, tdb, db, point)
+	w.WriteByte(snapSectionEnd)
+}
+
+func writeManifestSection(w *bufio.Writer, db ethdb.Database, point convertPoint) {
+	w.WriteByte(snapSectionManifest)
+	writeUvarint(w, point.block)
+	w.Write(point.root.Bytes())
+	writeUvarint(w, point.stateID)
+	hash := rawdb.ReadCanonicalHash(db, point.block)
+	if hash == (common.Hash{}) {
+		fatal("read convert-point hash", fmt.Errorf("no canonical hash at block %d", point.block))
+	}
+	w.Write(hash.Bytes())
+}
+
+// writeBlocksSection streams headers, bodies and receipts for [0, P] as raw RLP.
+//
+// The importer recomputes transactionsRoot and receiptsRoot from these and compares them against the
+// header, so a truncated or misaligned body is caught per block rather than at the end (ADR-004 B2).
+func writeBlocksSection(w *bufio.Writer, db ethdb.Database, point convertPoint) {
+	w.WriteByte(snapSectionBlocks)
+	var blocks, bodies, receipts uint64
+	started := time.Now()
+	for n := uint64(0); n <= point.block; n++ {
+		hash := rawdb.ReadCanonicalHash(db, n)
+		if hash == (common.Hash{}) {
+			fatal("read canonical hash", fmt.Errorf("gap at block %d", n))
+		}
+		header := rawdb.ReadHeaderRLP(db, hash, n)
+		if len(header) == 0 {
+			fatal("read header", fmt.Errorf("missing header at block %d", n))
+		}
+		w.WriteByte(snapRecHeader)
+		writeUvarint(w, n)
+		w.Write(hash.Bytes())
+		writeBlob(w, header)
+		blocks++
+
+		if body := rawdb.ReadBodyRLP(db, hash, n); len(body) > 0 {
+			w.WriteByte(snapRecBody)
+			writeUvarint(w, n)
+			writeBlob(w, body)
+			bodies++
+		}
+		if r := rawdb.ReadReceiptsRLP(db, hash, n); len(r) > 0 {
+			w.WriteByte(snapRecReceipt)
+			writeUvarint(w, n)
+			writeBlob(w, r)
+			receipts++
+		}
+		if n%1000000 == 0 {
+			fmt.Fprintf(os.Stderr, "blocks %d/%d (%s)\n", n, point.block, time.Since(started).Truncate(time.Second))
+		}
+	}
+	w.WriteByte(snapRecEnd)
+	fmt.Fprintf(os.Stderr, "blocks section: %d headers, %d bodies, %d receipt sets in %s\n",
+		blocks, bodies, receipts, time.Since(started).Truncate(time.Second))
+}
+
+// writeHistorySection streams every state history object up to and including P's.
+func writeHistorySection(w *bufio.Writer, ancientDir string, point convertPoint) {
+	w.WriteByte(snapSectionHistory)
+	store, err := rawdb.NewStateFreezer(ancientDir, false, true)
+	if err != nil {
+		fatal("open state freezer", err)
+	}
+	defer store.Close()
+
+	var accounts, slots uint64
+	started := time.Now()
+	// State history ids are 1-based. Ids below the freezer tail have been pruned away; the importer
+	// records whatever range it receives rather than assuming full coverage.
+	for id := uint64(1); id <= point.stateID; id++ {
+		meta, accIndex, slotIndex, accData, slotData, err := rawdb.ReadStateHistory(store, id)
+		if err != nil {
+			fatal(fmt.Sprintf("read state history %d", id), err)
+		}
+		na, ns, err := writeHistoryObject(w, id, meta, accIndex, slotIndex, accData, slotData)
+		if err != nil {
+			fatal(fmt.Sprintf("encode state history %d", id), err)
+		}
+		accounts += na
+		slots += ns
+		if id%1000000 == 0 {
+			fmt.Fprintf(os.Stderr, "history %d/%d (%s)\n", id, point.stateID, time.Since(started).Truncate(time.Second))
+		}
+	}
+	w.WriteByte(snapRecEnd)
+	fmt.Fprintf(os.Stderr, "history section: %d objects, %d accounts, %d slots in %s\n",
+		point.stateID, accounts, slots, time.Since(started).Truncate(time.Second))
+}
+
+// writeStateSection walks the account and storage tries at R_P.
+//
+// This is the same walk --mode state performs, at the persisted root rather than the head root, and
+// emitting binary rather than hex. Storage tries are opened by hashed owner, since a pruned snapshot
+// carries no address preimages.
+func writeStateSection(w *bufio.Writer, sdb state.Database, tdb *triedb.Database, db ethdb.Database, point convertPoint) {
+	w.WriteByte(snapSectionState)
+	accTrie, err := sdb.OpenTrie(point.root)
+	if err != nil {
+		fatal("open account trie at the persisted root", err)
+	}
+	nodeIt, err := accTrie.NodeIterator(nil)
+	if err != nil {
+		fatal("account node iterator", err)
+	}
+	accIt := trie.NewIterator(nodeIt)
+
+	seenCode := make(map[common.Hash]struct{})
+	var accounts, slots, codes uint64
+	started := time.Now()
+	for accIt.Next() {
+		var acc types.StateAccount
+		if err := rlp.DecodeBytes(accIt.Value, &acc); err != nil {
+			fatal("decode account", err)
+		}
+		owner := common.BytesToHash(accIt.Key)
+		w.WriteByte(snapRecAccount)
+		w.Write(owner.Bytes()) // hashed address; the source has no preimage for it
+		writeUvarint(w, acc.Nonce)
+		writeShortBytes(w, acc.Balance.Bytes())
+		if bytes.Equal(acc.CodeHash, types.EmptyCodeHash[:]) {
+			w.WriteByte(0)
+		} else {
+			writeShortBytes(w, acc.CodeHash)
+		}
+		accounts++
+
+		codeHash := common.BytesToHash(acc.CodeHash)
+		if !bytes.Equal(acc.CodeHash, types.EmptyCodeHash[:]) {
+			if _, ok := seenCode[codeHash]; !ok {
+				seenCode[codeHash] = struct{}{}
+				code := rawdb.ReadCode(db, codeHash)
+				if len(code) == 0 {
+					fatal("read contract code", fmt.Errorf("no code for hash %s", codeHash.Hex()))
+				}
+				w.WriteByte(snapRecCode)
+				w.Write(codeHash.Bytes())
+				writeBlob(w, code)
+				codes++
+			}
+		}
+
+		if acc.Root == types.EmptyRootHash {
+			continue
+		}
+		stTrie, err := trie.NewStateTrie(trie.StorageTrieID(point.root, owner, acc.Root), tdb)
+		if err != nil {
+			fatal("open storage trie", err)
+		}
+		stNodeIt, err := stTrie.NodeIterator(nil)
+		if err != nil {
+			fatal("storage node iterator", err)
+		}
+		stIt := trie.NewIterator(stNodeIt)
+		for stIt.Next() {
+			var val []byte
+			if err := rlp.DecodeBytes(stIt.Value, &val); err != nil {
+				fatal("decode storage value", err)
+			}
+			w.WriteByte(snapRecStorage)
+			w.Write(common.BytesToHash(stIt.Key).Bytes()) // hashed slot key
+			writeShortBytes(w, val)
+			slots++
+		}
+		if err := stIt.Err; err != nil {
+			fatal("storage iterator", err)
+		}
+		if accounts%1000000 == 0 {
+			fmt.Fprintf(os.Stderr, "state %d accounts, %d slots (%s)\n", accounts, slots, time.Since(started).Truncate(time.Second))
+		}
+	}
+	if err := accIt.Err; err != nil {
+		fatal("account iterator", err)
+	}
+	w.WriteByte(snapRecEnd)
+	fmt.Fprintf(os.Stderr, "state section: %d accounts, %d slots, %d code blobs in %s\n",
+		accounts, slots, codes, time.Since(started).Truncate(time.Second))
+}
+
+// writeBlob writes a varint-prefixed byte slice, for payloads that exceed 255 bytes.
+func writeBlob(w *bufio.Writer, b []byte) {
+	writeUvarint(w, uint64(len(b)))
 	w.Write(b)
 }

--- a/crates/arb-reth-genesis/go-exporter/reth-export.go
+++ b/crates/arb-reth-genesis/go-exporter/reth-export.go
@@ -595,58 +595,70 @@ const (
 	snapRecCode    = 0x06 // contract code, keyed by hash
 )
 
-// convertPoint is where state, blocks and history all agree: the block of the persisted state trie.
+// convertPoint is where state, blocks and history all agree: the deepest state the trie database can
+// still serve, which is pathdb's disk layer.
 //
-// State above it lives only in the pathdb journal (the disk layer's unflushed write buffer, and diff
-// layers on top), so it is not in the trie on disk. Converting up to this point and letting the node
-// re-derive the rest avoids needing any of that, and avoids a range whose state we would have to
-// reconstruct in order to generate its own changesets.
+// It is not the persisted state id. That tracks how far trie node writes have been flushed, while
+// the disk layer aggregates further transitions in its journal buffer, so the persisted root is not
+// a root the layer tree can serve. Asking for it fails with "state is not available".
+//
+// The disk layer's root is the post root of the most recently flattened history object, because
+// history is written at flatten time. Diff layers above it have no history yet, which is why the
+// conversion stops here and lets the node re-derive the rest.
 type convertPoint struct {
 	block   uint64      // P
 	root    common.Hash // R_P
-	stateID uint64      // persistent state id, which is P's history object
+	stateID uint64      // P's history object
 }
 
-// resolveConvertPoint reads P two independent ways and requires them to agree (ADR-004 P3).
+// resolveConvertPoint finds the deepest servable state that also has history.
 //
-// The root comes from hashing the persisted root account trie node. The block comes from the history
-// object at the persistent state id. If a snapshot were captured mid-write these would disagree, and
-// the resulting conversion would silently pair one block's state with another block's history.
-func resolveConvertPoint(db ethdb.Database, ancientDir string) convertPoint {
-	node := rawdb.ReadAccountTrieNode(db, nil)
-	if len(node) == 0 {
-		fatal("read persisted state root", fmt.Errorf("no account trie node at the empty path; is this a path-scheme database?"))
-	}
-	root := crypto.Keccak256Hash(node)
-	id := rawdb.ReadPersistentStateID(db)
-	if id == 0 {
-		fatal("read persistent state id", fmt.Errorf("no persistent state id; nothing has been flattened to disk"))
-	}
-
+// Rather than deriving the disk layer's identity from pathdb internals, it walks history objects
+// back from the newest and takes the first whose post root the trie database can actually open.
+// That is the property the exporter needs, checked directly, and it self-corrects if the disk layer
+// sits a few transitions below the newest history.
+func resolveConvertPoint(db ethdb.Database, ancientDir string, sdb state.Database) convertPoint {
 	store, err := rawdb.NewStateFreezer(ancientDir, false, true)
 	if err != nil {
 		fatal("open state freezer", err)
 	}
 	defer store.Close()
 
-	meta, _, _, _, _, err := rawdb.ReadStateHistory(store, id)
+	count, err := store.Ancients()
 	if err != nil {
-		fatal(fmt.Sprintf("read state history %d", id), err)
+		fatal("read state history count", err)
 	}
-	if len(meta) != histMetaSize {
-		fatal("decode state history meta", fmt.Errorf("meta is %d bytes, want %d", len(meta), histMetaSize))
+	if count == 0 {
+		fatal("resolve convert point", fmt.Errorf("state freezer holds no history"))
 	}
-	postRoot := common.BytesToHash(meta[33:65])
-	if postRoot != root {
-		fatal("resolve convert point", fmt.Errorf(
-			"persisted trie root %s does not match the post root %s of history %d; snapshot looks torn",
-			root.Hex(), postRoot.Hex(), id))
+
+	// Bounded: the disk layer is at most maxDiffLayers behind the newest history in a healthy
+	// database. Scanning far past that would mean something is wrong, and silently converting an
+	// ancient state is worse than stopping.
+	const maxProbe = 512
+	for probe := uint64(0); probe < maxProbe && probe < count; probe++ {
+		id := count - probe
+		meta, _, _, _, _, err := rawdb.ReadStateHistory(store, id)
+		if err != nil {
+			fatal(fmt.Sprintf("read state history %d", id), err)
+		}
+		if len(meta) != histMetaSize {
+			fatal("decode state history meta", fmt.Errorf("meta is %d bytes, want %d", len(meta), histMetaSize))
+		}
+		root := common.BytesToHash(meta[33:65])
+		if _, err := sdb.OpenTrie(root); err != nil {
+			continue
+		}
+		block := binary.BigEndian.Uint64(meta[65:histMetaSize])
+		if probe > 0 {
+			fmt.Fprintf(os.Stderr,
+				"note: newest history is %d ids above the servable state; converting at id %d\n", probe, id)
+		}
+		return convertPoint{block: block, root: root, stateID: id}
 	}
-	return convertPoint{
-		block:   binary.BigEndian.Uint64(meta[65:histMetaSize]),
-		root:    root,
-		stateID: id,
-	}
+	fatal("resolve convert point", fmt.Errorf(
+		"no state root among the newest %d history objects can be opened; the snapshot's trie and its history do not meet", maxProbe))
+	panic("unreachable")
 }
 
 // fullSnapshot writes one stream that an importer can turn into a complete reth datadir.
@@ -654,7 +666,7 @@ func resolveConvertPoint(db ethdb.Database, ancientDir string) convertPoint {
 // Sections are ordered so the importer can write append-only: blocks ascending, then history
 // ascending, then the state bulk load. Everything stops at P, so the three agree.
 func fullSnapshot(db ethdb.Database, ancientDir string, sdb state.Database, tdb *triedb.Database) {
-	point := resolveConvertPoint(db, ancientDir)
+	point := resolveConvertPoint(db, ancientDir, sdb)
 	fmt.Fprintf(os.Stderr, "convert point: block=%d root=%s stateID=%d\n",
 		point.block, point.root.Hex(), point.stateID)
 

--- a/crates/arb-reth-genesis/go-exporter/reth-export.go
+++ b/crates/arb-reth-genesis/go-exporter/reth-export.go
@@ -596,10 +596,13 @@ func writeShortBytes(w *bufio.Writer, b []byte) {
 const (
 	snapStreamMagic = "ARBSNAP1"
 
-	snapSectionManifest = 0x01
-	snapSectionBlocks   = 0x02
-	snapSectionHistory  = 0x03
-	snapSectionState    = 0x04
+	// Section tags live above the record tags on purpose. They shared a range in the first draft,
+	// which made a receipts record inside the blocks section indistinguishable from the start of
+	// the history section.
+	snapSectionManifest = 0xf1
+	snapSectionBlocks   = 0xf2
+	snapSectionHistory  = 0xf3
+	snapSectionState    = 0xf4
 	snapSectionEnd      = 0xff
 
 	snapRecEnd     = 0x00

--- a/crates/arb-reth-genesis/go-exporter/reth-export.go
+++ b/crates/arb-reth-genesis/go-exporter/reth-export.go
@@ -14,6 +14,7 @@ package main
 import (
 	"bufio"
 	"bytes"
+	"encoding/binary"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -132,11 +133,11 @@ func walkRange(w *bufio.Writer, sdb state.Database, tdb *triedb.Database, root c
 
 func main() {
 	ancient := flag.String("ancient", "", "ancients/freezer directory (default <dir>/ancient)")
-	mode := flag.String("mode", "diag", "diag|state|blocks|accounts|addr")
+	mode := flag.String("mode", "diag", "diag|state|blocks|history|accounts|addr")
 	max := flag.Uint64("max", 0, "max accounts to dump (0 = all)")
 	addr := flag.String("addr", "", "for --mode addr: a 0x address to dump (storage key form check)")
-	from := flag.Int64("from", -1, "for --mode blocks: first block (default = head)")
-	to := flag.Int64("to", -1, "for --mode blocks: last block (default = head)")
+	from := flag.Int64("from", -1, "for --mode blocks: first block; for --mode history: first state id (default = earliest)")
+	to := flag.Int64("to", -1, "for --mode blocks: last block; for --mode history: last state id (default = latest)")
 	// A large pebble block cache is critical for `--mode state`: the trie walk is random-read
 	// bound, and the default 16 MiB cache makes almost every node a cold disk read. Sizing this
 	// to hold the hot upper-trie nodes turns most reads into RAM hits (orders of magnitude faster).
@@ -335,6 +336,8 @@ func main() {
 			nBlk++
 		}
 		fmt.Fprintf(os.Stderr, "exported %d blocks [%d..%d]\n", nBlk, lo, hi)
+	case "history":
+		exportHistory(anc, uint64Flag(*from), uint64Flag(*to))
 	case "addr":
 		a := common.HexToAddress(*addr)
 		h := crypto.Keccak256Hash(a.Bytes())
@@ -348,4 +351,226 @@ func main() {
 	default:
 		fatal("mode", fmt.Errorf("unknown mode %q", *mode))
 	}
+}
+
+// ---------------------------------------------------------------------------
+// --mode history: geth pathdb state history -> neutral change records
+// ---------------------------------------------------------------------------
+
+// Encoded sizes of the fixed-width records inside a state history object.
+// Mirrors triedb/pathdb/history_state.go, which keeps these unexported.
+const (
+	histMetaSize     = 73 // version(1) parentRoot(32) postRoot(32) block(8)
+	histAccIndexSize = 33 // address(20) len(1) offset(4) storageOffset(4) storageSlots(4)
+	histSlotIndexSize = 37 // slotKey(32) len(1) offset(4)
+
+	histVersionHashedSlots = 0 // storage slot keys are hashed
+	histVersionRawSlots    = 1 // storage slot keys are raw
+
+	// Stream framing. The importer rejects anything else.
+	histStreamMagic  = "ARBHIST1"
+	histTagObject    = 0x01
+	histTagStreamEnd = 0x00
+)
+
+func uint64Flag(v int64) uint64 {
+	if v < 0 {
+		return 0
+	}
+	return uint64(v)
+}
+
+// exportHistory streams pathdb state history as neutral pre-state records.
+//
+// Each history object holds the values a block overwrote, which is what reth changesets store, so
+// the conversion needs no re-execution. Output is binary rather than the hex-per-line form the
+// state and block modes use: this chain has 27M objects and roughly 1.6B slot entries, where hex
+// would more than double an already 100 GB stream.
+//
+// `from` and `to` are state ids, not block numbers, because that is how the freezer is addressed.
+// Zero means "the whole available range". Each record carries its block number, so the importer
+// never has to infer the mapping (ids 0 and 1 are both block 0 on a chain built from genesis).
+func exportHistory(ancientDir string, from, to uint64) {
+	store, err := rawdb.NewStateFreezer(ancientDir, false, true)
+	if err != nil {
+		fatal("open state freezer", err)
+	}
+	defer store.Close()
+
+	// Ancients() counts items; state history ids are 1-based, so id i lives at position i-1.
+	count, err := store.Ancients()
+	if err != nil {
+		fatal("read state history count", err)
+	}
+	if count == 0 {
+		fatal("state freezer holds no history", fmt.Errorf("nothing to export from %s", ancientDir))
+	}
+	first, last := uint64(1), count
+	if from != 0 {
+		first = from
+	}
+	if to != 0 && to < last {
+		last = to
+	}
+	if first > last {
+		fatal("empty history range", fmt.Errorf("from %d > to %d", first, last))
+	}
+
+	w := bufio.NewWriterSize(os.Stdout, 1<<22)
+	defer w.Flush()
+	w.WriteString(histStreamMagic)
+
+	var (
+		accounts uint64
+		slots    uint64
+		started  = time.Now()
+	)
+	for id := first; id <= last; id++ {
+		meta, accIndex, slotIndex, accData, slotData, err := rawdb.ReadStateHistory(store, id)
+		if err != nil {
+			fatal(fmt.Sprintf("read state history %d", id), err)
+		}
+		na, ns, err := writeHistoryObject(w, id, meta, accIndex, slotIndex, accData, slotData)
+		if err != nil {
+			fatal(fmt.Sprintf("encode state history %d", id), err)
+		}
+		accounts += na
+		slots += ns
+		if (id-first)%500000 == 0 {
+			fmt.Fprintf(os.Stderr, "history id %d/%d (%d accounts, %d slots, %s)\n",
+				id, last, accounts, slots, time.Since(started).Truncate(time.Second))
+		}
+	}
+	w.WriteByte(histTagStreamEnd)
+	fmt.Fprintf(os.Stderr, "exported history ids [%d..%d]: %d accounts, %d slots in %s\n",
+		first, last, accounts, slots, time.Since(started).Truncate(time.Second))
+}
+
+// writeHistoryObject decodes one history object and writes its neutral form.
+//
+// Record layout, all integers unsigned varint unless stated:
+//
+//	tag(1)=0x01 stateID block version(1) parentRoot(32) postRoot(32) accountCount
+//	  per account: address(20) present(1)
+//	               if present: nonce, balanceLen(1) balance, codeHashLen(1) codeHash
+//	               slotCount
+//	    per slot:  key(32) valueLen(1) value
+//
+// A zero-length value means the slot was unset, and present=0 means the account did not exist
+// before the block. Balances and slot values are minimal big-endian, so they cost a byte each when
+// small, which most are.
+func writeHistoryObject(w *bufio.Writer, id uint64, meta, accIndex, slotIndex, accData, slotData []byte) (uint64, uint64, error) {
+	if len(meta) != histMetaSize {
+		return 0, 0, fmt.Errorf("meta is %d bytes, want %d", len(meta), histMetaSize)
+	}
+	version := meta[0]
+	if version > histVersionRawSlots {
+		return 0, 0, fmt.Errorf("unknown state history version %d", version)
+	}
+	// A v0 object identifies storage slots by hash. Converting those to reth changesets needs a
+	// preimage source the importer does not have, so refuse rather than emit unusable keys.
+	// Chains built under a v1 geth carry at most a couple of v0 objects at genesis.
+	if version == histVersionHashedSlots {
+		return 0, 0, fmt.Errorf("state history %d uses hashed slot keys (v0); re-export from a range that excludes it", id)
+	}
+	if len(accIndex)%histAccIndexSize != 0 {
+		return 0, 0, fmt.Errorf("account index is %d bytes, not a multiple of %d", len(accIndex), histAccIndexSize)
+	}
+	if len(slotIndex)%histSlotIndexSize != 0 {
+		return 0, 0, fmt.Errorf("storage index is %d bytes, not a multiple of %d", len(slotIndex), histSlotIndexSize)
+	}
+
+	block := binary.BigEndian.Uint64(meta[65:histMetaSize])
+	nAccounts := uint64(len(accIndex) / histAccIndexSize)
+
+	w.WriteByte(histTagObject)
+	writeUvarint(w, id)
+	writeUvarint(w, block)
+	w.WriteByte(version)
+	w.Write(meta[1:33])  // parent root
+	w.Write(meta[33:65]) // post root
+	writeUvarint(w, nAccounts)
+
+	var slotTotal uint64
+	for i := uint64(0); i < nAccounts; i++ {
+		rec := accIndex[i*histAccIndexSize : (i+1)*histAccIndexSize]
+		addr := rec[0:20]
+		length := int(rec[20])
+		offset := int(binary.BigEndian.Uint32(rec[21:25]))
+		storageOffset := int(binary.BigEndian.Uint32(rec[25:29]))
+		storageSlots := int(binary.BigEndian.Uint32(rec[29:33]))
+
+		if offset+length > len(accData) {
+			return 0, 0, fmt.Errorf("account data range [%d,%d) exceeds %d bytes", offset, offset+length, len(accData))
+		}
+		w.Write(addr)
+
+		blob := accData[offset : offset+length]
+		if len(blob) == 0 {
+			w.WriteByte(0) // did not exist before this block
+		} else {
+			acct, err := types.FullAccount(blob)
+			if err != nil {
+				return 0, 0, fmt.Errorf("decode previous account %x: %w", addr, err)
+			}
+			w.WriteByte(1)
+			writeUvarint(w, acct.Nonce)
+			writeShortBytes(w, acct.Balance.Bytes())
+			// The storage root is a trie artefact reth recomputes, so it is not emitted. An empty
+			// code hash is emitted as zero bytes rather than the empty-hash constant.
+			if bytes.Equal(acct.CodeHash, types.EmptyCodeHash[:]) {
+				w.WriteByte(0)
+			} else {
+				writeShortBytes(w, acct.CodeHash)
+			}
+		}
+
+		writeUvarint(w, uint64(storageSlots))
+		for s := 0; s < storageSlots; s++ {
+			at := (storageOffset + s) * histSlotIndexSize
+			if at+histSlotIndexSize > len(slotIndex) {
+				return 0, 0, fmt.Errorf("storage index entry %d for %x out of range", storageOffset+s, addr)
+			}
+			entry := slotIndex[at : at+histSlotIndexSize]
+			vlen := int(entry[32])
+			voff := int(binary.BigEndian.Uint32(entry[33:37]))
+			if voff+vlen > len(slotData) {
+				return 0, 0, fmt.Errorf("storage data range [%d,%d) exceeds %d bytes", voff, voff+vlen, len(slotData))
+			}
+			w.Write(entry[0:32]) // raw slot key, guaranteed by the v1 check above
+			// Stored values are RLP byte strings; strip the header so the importer gets the
+			// integer bytes directly.
+			val, err := rlpStringPayload(slotData[voff : voff+vlen])
+			if err != nil {
+				return 0, 0, fmt.Errorf("decode slot value for %x: %w", addr, err)
+			}
+			writeShortBytes(w, val)
+		}
+		slotTotal += uint64(storageSlots)
+	}
+	return nAccounts, slotTotal, nil
+}
+
+// rlpStringPayload strips the RLP header from a storage value. An empty input is a zero slot.
+func rlpStringPayload(b []byte) ([]byte, error) {
+	if len(b) == 0 {
+		return nil, nil
+	}
+	var out []byte
+	if err := rlp.DecodeBytes(b, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func writeUvarint(w *bufio.Writer, v uint64) {
+	var buf [binary.MaxVarintLen64]byte
+	w.Write(buf[:binary.PutUvarint(buf[:], v)])
+}
+
+// writeShortBytes writes a length-prefixed blob of at most 255 bytes. Every field using it
+// (balance, code hash, slot value) is bounded at 32.
+func writeShortBytes(w *bufio.Writer, b []byte) {
+	w.WriteByte(byte(len(b)))
+	w.Write(b)
 }

--- a/crates/arb-reth-genesis/go-exporter/reth-export.go
+++ b/crates/arb-reth-genesis/go-exporter/reth-export.go
@@ -150,6 +150,9 @@ func main() {
 	// the same stream a serial walk would. `--outbase` is required when N > 1.
 	parallel := flag.Int("parallel", 1, "for --mode state and --mode full-snapshot: number of concurrent key-range walkers")
 	outbase := flag.String("outbase", "", "for --mode state --parallel N: output path prefix for part files")
+	// Never defaults to the source directory: that is a live pebble database, and scattering part
+	// files through it risks confusing a later open.
+	tmpdir := flag.String("tmpdir", os.TempDir(), "for --mode full-snapshot --parallel N: scratch directory for state part files")
 	flag.Parse()
 	if flag.NArg() < 1 {
 		fmt.Fprintln(os.Stderr, "usage: reth-export <l2chaindata-dir> [--ancient DIR] [--mode diag|accounts] [--max N]")
@@ -338,7 +341,7 @@ func main() {
 		}
 		fmt.Fprintf(os.Stderr, "exported %d blocks [%d..%d]\n", nBlk, lo, hi)
 	case "full-snapshot":
-		fullSnapshot(db, anc, sdb, tdb, *parallel, dir)
+		fullSnapshot(db, anc, sdb, tdb, *parallel, *tmpdir)
 	case "diskroot":
 		// The path-scheme disk layer: the persisted trie, before any journalled diff layers.
 		// pathdb derives it the same way in loadLayers(). Its root is the post root of the most

--- a/crates/arb-reth-genesis/go-exporter/reth-export.go
+++ b/crates/arb-reth-genesis/go-exporter/reth-export.go
@@ -433,30 +433,11 @@ func exportHistory(ancientDir string, from, to uint64) {
 	defer w.Flush()
 	w.WriteString(histStreamMagic)
 
-	var (
-		accounts uint64
-		slots    uint64
-		started  = time.Now()
-	)
-	for id := first; id <= last; id++ {
-		meta, accIndex, slotIndex, accData, slotData, err := rawdb.ReadStateHistory(store, id)
-		if err != nil {
-			fatal(fmt.Sprintf("read state history %d", id), err)
-		}
-		na, ns, err := writeHistoryObject(w, id, meta, accIndex, slotIndex, accData, slotData)
-		if err != nil {
-			fatal(fmt.Sprintf("encode state history %d", id), err)
-		}
-		accounts += na
-		slots += ns
-		if (id-first)%500000 == 0 {
-			fmt.Fprintf(os.Stderr, "history id %d/%d (%d accounts, %d slots, %s)\n",
-				id, last, accounts, slots, time.Since(started).Truncate(time.Second))
-		}
-	}
+	started := time.Now()
+	emitted, skipped, accounts, slots := streamHistoryRange(w, store, first, last, "history id")
 	w.WriteByte(histTagStreamEnd)
-	fmt.Fprintf(os.Stderr, "exported history ids [%d..%d]: %d accounts, %d slots in %s\n",
-		first, last, accounts, slots, time.Since(started).Truncate(time.Second))
+	fmt.Fprintf(os.Stderr, "exported history ids [%d..%d]: %d objects (%d genesis v0 skipped), %d accounts, %d slots in %s\n",
+		first, last, emitted, skipped, accounts, slots, time.Since(started).Truncate(time.Second))
 }
 
 // writeHistoryObject decodes one history object and writes its neutral form.
@@ -753,28 +734,11 @@ func writeHistorySection(w *bufio.Writer, ancientDir string, point convertPoint)
 	}
 	defer store.Close()
 
-	var accounts, slots uint64
 	started := time.Now()
-	// State history ids are 1-based. Ids below the freezer tail have been pruned away; the importer
-	// records whatever range it receives rather than assuming full coverage.
-	for id := uint64(1); id <= point.stateID; id++ {
-		meta, accIndex, slotIndex, accData, slotData, err := rawdb.ReadStateHistory(store, id)
-		if err != nil {
-			fatal(fmt.Sprintf("read state history %d", id), err)
-		}
-		na, ns, err := writeHistoryObject(w, id, meta, accIndex, slotIndex, accData, slotData)
-		if err != nil {
-			fatal(fmt.Sprintf("encode state history %d", id), err)
-		}
-		accounts += na
-		slots += ns
-		if id%1000000 == 0 {
-			fmt.Fprintf(os.Stderr, "history %d/%d (%s)\n", id, point.stateID, time.Since(started).Truncate(time.Second))
-		}
-	}
+	emitted, skipped, accounts, slots := streamHistoryRange(w, store, 1, point.stateID, "history")
 	w.WriteByte(snapRecEnd)
-	fmt.Fprintf(os.Stderr, "history section: %d objects, %d accounts, %d slots in %s\n",
-		point.stateID, accounts, slots, time.Since(started).Truncate(time.Second))
+	fmt.Fprintf(os.Stderr, "history section: %d objects (%d genesis v0 skipped), %d accounts, %d slots in %s\n",
+		emitted, skipped, accounts, slots, time.Since(started).Truncate(time.Second))
 }
 
 // writeStateSection walks the account and storage tries at R_P.
@@ -870,4 +834,41 @@ func writeStateSection(w *bufio.Writer, sdb state.Database, tdb *triedb.Database
 func writeBlob(w *bufio.Writer, b []byte) {
 	writeUvarint(w, uint64(len(b)))
 	w.Write(b)
+}
+
+// streamHistoryRange writes history objects [first, last] and reports what it emitted.
+//
+// A leading run of v0 objects is the genesis state materialisation, which identifies slots by hash.
+// It is skipped rather than refused: block 0 needs no changeset, since there is nothing below it to
+// unwind into, and the first v1 object still chains to the genesis state root. A v0 object after
+// real history has started is a different thing and is fatal.
+func streamHistoryRange(w *bufio.Writer, store ethdb.AncientStore, first, last uint64, label string) (emitted, skipped, accounts, slots uint64) {
+	started := time.Now()
+	for id := first; id <= last; id++ {
+		meta, accIndex, slotIndex, accData, slotData, err := rawdb.ReadStateHistory(store, id)
+		if err != nil {
+			fatal(fmt.Sprintf("read state history %d", id), err)
+		}
+		if len(meta) == histMetaSize && meta[0] == histVersionHashedSlots && emitted == 0 {
+			block := binary.BigEndian.Uint64(meta[65:histMetaSize])
+			if block != 0 {
+				fatal("export history", fmt.Errorf(
+					"state history %d uses hashed slot keys at block %d; only a genesis-block v0 object can be skipped", id, block))
+			}
+			skipped++
+			continue
+		}
+		na, ns, err := writeHistoryObject(w, id, meta, accIndex, slotIndex, accData, slotData)
+		if err != nil {
+			fatal(fmt.Sprintf("encode state history %d", id), err)
+		}
+		emitted++
+		accounts += na
+		slots += ns
+		if emitted%1000000 == 0 {
+			fmt.Fprintf(os.Stderr, "%s %d/%d (%d accounts, %d slots, %s)\n",
+				label, id, last, accounts, slots, time.Since(started).Truncate(time.Second))
+		}
+	}
+	return emitted, skipped, accounts, slots
 }

--- a/crates/arb-reth-genesis/src/lib.rs
+++ b/crates/arb-reth-genesis/src/lib.rs
@@ -7,4 +7,5 @@
 pub mod arbitrum_one;
 pub mod preimages;
 pub mod readers;
+pub mod snapshot_stream;
 pub mod verify;

--- a/crates/arb-reth-genesis/src/snapshot_stream.rs
+++ b/crates/arb-reth-genesis/src/snapshot_stream.rs
@@ -13,9 +13,8 @@ use std::io::Read;
 use alloy_primitives::{B256, U256, keccak256};
 use eyre::{Context as _, eyre};
 
-// Bumped when the manifest gained the resume point. An older stream would otherwise parse its first
-// section tag as the resume-present flag and desynchronise silently, which is the one failure mode
-// worth spending a magic byte to avoid.
+// Bumped when the manifest gained the resume point: an older stream would parse its first section
+// tag as the resume-present flag and desynchronise silently rather than fail.
 const MAGIC: &[u8; 8] = b"ARBSNAP2";
 
 // Section tags live above the record tags on purpose. They shared a range in the first draft, which

--- a/crates/arb-reth-genesis/src/snapshot_stream.rs
+++ b/crates/arb-reth-genesis/src/snapshot_stream.rs
@@ -365,6 +365,40 @@ impl<R: Read> SnapshotStream<R> {
     }
 }
 
+/// Transactions trie root over a block body, for checking against `header.transactionsRoot`.
+///
+/// The body is `[transactions, uncles, ...]`. A leaf's value is the transaction's encoded form: the
+/// full RLP list for a legacy transaction, and the bare `type || payload` for a typed one, which the
+/// body carries wrapped in an RLP byte string. So a list item contributes its whole encoding and a
+/// string item contributes only its payload.
+pub fn transactions_root(body_rlp: &[u8]) -> eyre::Result<B256> {
+    let (body, rest) = rlp_split(body_rlp, true)?;
+    if !rest.is_empty() {
+        return Err(eyre!("trailing bytes after the body"));
+    }
+    let (txs, _) = rlp_split(body, true).wrap_err("body has no transactions list")?;
+
+    let mut encoded: Vec<&[u8]> = Vec::new();
+    let mut cursor = txs;
+    while !cursor.is_empty() {
+        let is_list = cursor[0] >= 0xc0;
+        let consumed_before = cursor.len();
+        let (payload, next) = rlp_split(cursor, is_list)?;
+        if is_list {
+            // Legacy: the leaf is the entire RLP list, header included.
+            encoded.push(&cursor[..consumed_before - next.len()]);
+        } else {
+            // Typed: the leaf is the envelope the string wraps, without the string header.
+            encoded.push(payload);
+        }
+        cursor = next;
+    }
+    Ok(alloy_trie::root::ordered_trie_root_with_encoder(
+        &encoded,
+        |item, out| out.extend_from_slice(item),
+    ))
+}
+
 /// Payload of the `i`th top-level field of an RLP-encoded header.
 ///
 /// Avoids decoding the whole header, which lets this work regardless of any chain-specific trailing
@@ -742,6 +776,49 @@ mod tests {
         let mut s = SnapshotStream::open(bytes.as_slice()).unwrap();
         let err = s.next_record().unwrap_err().to_string();
         assert!(err.contains("does not hash to"), "{err}");
+    }
+
+    /// An empty body must produce the empty trie root, which is what a header with no transactions
+    /// commits to.
+    #[test]
+    fn empty_body_has_the_empty_transactions_root() {
+        // [[], []] : no transactions, no uncles.
+        let body = [0xc2u8, 0xc0, 0xc0];
+        assert_eq!(
+            transactions_root(&body).unwrap(),
+            alloy_trie::EMPTY_ROOT_HASH,
+        );
+    }
+
+    /// A legacy transaction contributes its whole RLP list; a typed one contributes only the
+    /// envelope the body wraps in a string. Getting that backwards yields a wrong but plausible
+    /// root, so the two shapes must produce different results.
+    #[test]
+    fn legacy_and_typed_transactions_encode_differently() {
+        let legacy: &[u8] = &[0xc3, 0x01, 0x02, 0x03]; // list [1,2,3]
+        let typed_payload: &[u8] = &[0x02, 0x01, 0x02, 0x03]; // type 2 envelope
+        let mut typed = vec![0x80 + typed_payload.len() as u8];
+        typed.extend_from_slice(typed_payload);
+
+        let mut body_a = vec![];
+        body_a.extend_from_slice(legacy);
+        let mut body_b = vec![];
+        body_b.extend_from_slice(&typed);
+
+        let wrap = |txs: &[u8]| {
+            let mut inner = vec![0xc0 + txs.len() as u8];
+            inner.extend_from_slice(txs);
+            inner.push(0xc0); // empty uncles
+            let mut out = vec![0xc0 + inner.len() as u8];
+            out.extend_from_slice(&inner);
+            out
+        };
+
+        let root_a = transactions_root(&wrap(&body_a)).unwrap();
+        let root_b = transactions_root(&wrap(&body_b)).unwrap();
+        assert_ne!(root_a, root_b);
+        assert_ne!(root_a, alloy_trie::EMPTY_ROOT_HASH);
+        assert_ne!(root_b, alloy_trie::EMPTY_ROOT_HASH);
     }
 
     #[test]

--- a/crates/arb-reth-genesis/src/snapshot_stream.rs
+++ b/crates/arb-reth-genesis/src/snapshot_stream.rs
@@ -13,7 +13,10 @@ use std::io::Read;
 use alloy_primitives::{B256, U256, keccak256};
 use eyre::{Context as _, eyre};
 
-const MAGIC: &[u8; 8] = b"ARBSNAP1";
+// Bumped when the manifest gained the resume point. An older stream would otherwise parse its first
+// section tag as the resume-present flag and desynchronise silently, which is the one failure mode
+// worth spending a magic byte to avoid.
+const MAGIC: &[u8; 8] = b"ARBSNAP2";
 
 // Section tags live above the record tags on purpose. They shared a range in the first draft, which
 // made a receipts record inside the blocks section indistinguishable from the start of the history
@@ -35,6 +38,17 @@ const REC_CODE: u8 = 0x06;
 /// History objects identify storage slots by raw key from this version on.
 const HISTORY_VERSION_RAW_SLOTS: u8 = 1;
 
+/// Where L1 derivation should restart, so a converted datadir does not re-derive from batch 0.
+///
+/// Mirrors arb-reth's `L1ResumeCheckpoint`: after consuming every batch up to and including L1 block
+/// `l1_block - 1`, the delayed cursor is `delayed_count` and the chain has reached `l2_block`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ResumePoint {
+    pub l1_block: u64,
+    pub delayed_count: u64,
+    pub l2_block: u64,
+}
+
 /// Where the conversion stops: state, blocks and history all end here.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Manifest {
@@ -46,6 +60,9 @@ pub struct Manifest {
     pub state_id: u64,
     /// Canonical hash of block `P`.
     pub hash: B256,
+    /// Present when the exporter was given the snapshot's `arbitrumdata`. Absent means the importer
+    /// cannot write a derivation cursor and the node will re-derive from batch 0.
+    pub resume: Option<ResumePoint>,
 }
 
 /// One account's pre-block state, and the slots the block overwrote.
@@ -134,12 +151,20 @@ impl<R: Read> SnapshotStream<R> {
         if tag != SECTION_MANIFEST {
             return Err(eyre!("expected the manifest section, found tag {tag:#04x}"));
         }
-        let manifest = Manifest {
+        let mut manifest = Manifest {
             block: read_uvarint(&mut inner)?,
             root: read_b256(&mut inner)?,
             state_id: read_uvarint(&mut inner)?,
             hash: read_b256(&mut inner)?,
+            resume: None,
         };
+        if read_u8(&mut inner)? == 1 {
+            manifest.resume = Some(ResumePoint {
+                l1_block: read_uvarint(&mut inner)?,
+                delayed_count: read_uvarint(&mut inner)?,
+                l2_block: read_uvarint(&mut inner)?,
+            });
+        }
         Ok(Self {
             inner,
             manifest,
@@ -259,7 +284,8 @@ impl<R: Read> SnapshotStream<R> {
                 self.manifest.block
             ));
         }
-        let parent = header_field(rlp, 0).wrap_err_with(|| format!("block {block}: parent hash"))?;
+        let parent =
+            header_field(rlp, 0).wrap_err_with(|| format!("block {block}: parent hash"))?;
         if let Some((last_number, last_hash)) = self.last_block {
             if block != last_number + 1 {
                 return Err(eyre!("blocks jump from {last_number} to {block}"));
@@ -438,12 +464,18 @@ fn rlp_split(blob: &[u8], want_list: bool) -> eyre::Result<(&[u8], &[u8])> {
         0x80..=0xb7 => (1, (prefix - 0x80) as usize),
         0xb8..=0xbf => {
             let n = (prefix - 0xb7) as usize;
-            (1 + n, be_usize(blob.get(1..1 + n).ok_or_else(|| eyre!("short RLP"))?))
+            (
+                1 + n,
+                be_usize(blob.get(1..1 + n).ok_or_else(|| eyre!("short RLP"))?),
+            )
         }
         0xc0..=0xf7 => (1, (prefix - 0xc0) as usize),
         0xf8..=0xff => {
             let n = (prefix - 0xf7) as usize;
-            (1 + n, be_usize(blob.get(1..1 + n).ok_or_else(|| eyre!("short RLP"))?))
+            (
+                1 + n,
+                be_usize(blob.get(1..1 + n).ok_or_else(|| eyre!("short RLP"))?),
+            )
         }
     };
     if (prefix >= 0xc0) != want_list {
@@ -533,6 +565,15 @@ impl StreamBuilder {
         out.extend_from_slice(manifest.root.as_slice());
         put_uvarint(&mut out, manifest.state_id);
         out.extend_from_slice(manifest.hash.as_slice());
+        match manifest.resume {
+            None => out.push(0),
+            Some(r) => {
+                out.push(1);
+                put_uvarint(&mut out, r.l1_block);
+                put_uvarint(&mut out, r.delayed_count);
+                put_uvarint(&mut out, r.l2_block);
+            }
+        }
         Self { out }
     }
 
@@ -710,6 +751,7 @@ mod tests {
             root: B256::repeat_byte(0xee),
             state_id: 12,
             hash: B256::repeat_byte(0xaa),
+            resume: None,
         }
     }
 
@@ -727,7 +769,10 @@ mod tests {
                 HistoryAccount {
                     address: address!("00000000000000000000000000000000000000aa"),
                     previous: Some((7, U256::from(1234u64), Some(B256::repeat_byte(0x9)))),
-                    storage: vec![(B256::repeat_byte(1), U256::from(5u64)), (B256::repeat_byte(2), U256::ZERO)],
+                    storage: vec![
+                        (B256::repeat_byte(1), U256::from(5u64)),
+                        (B256::repeat_byte(2), U256::ZERO),
+                    ],
                 },
                 HistoryAccount {
                     address: Address::ZERO,

--- a/crates/arb-reth-genesis/src/snapshot_stream.rs
+++ b/crates/arb-reth-genesis/src/snapshot_stream.rs
@@ -114,6 +114,8 @@ pub struct SnapshotStream<R> {
     last_block: Option<(u64, B256)>,
     /// Last history object seen, for root chaining.
     last_history: Option<(u64, B256)>,
+    /// Set by [`SnapshotStream::unread`]; returned before anything is read from `inner`.
+    held: Option<Record>,
     finished: bool,
 }
 
@@ -144,6 +146,7 @@ impl<R: Read> SnapshotStream<R> {
             section: SECTION_MANIFEST,
             last_block: None,
             last_history: None,
+            held: None,
             finished: false,
         })
     }
@@ -153,8 +156,20 @@ impl<R: Read> SnapshotStream<R> {
         &self.manifest
     }
 
+    /// Hand a record back, so the next [`Self::next_record`] returns it again.
+    ///
+    /// Sections are only delimited by the record that follows them, so a per-section reader has to
+    /// read one record too far to learn it is done. This gives that record to the next reader.
+    pub fn unread(&mut self, record: Record) {
+        debug_assert!(self.held.is_none(), "only one record can be held back");
+        self.held = Some(record);
+    }
+
     /// Next record, or `None` at the end of the stream.
     pub fn next_record(&mut self) -> eyre::Result<Option<Record>> {
+        if let Some(record) = self.held.take() {
+            return Ok(Some(record));
+        }
         if self.finished {
             return Ok(None);
         }
@@ -498,94 +513,181 @@ fn read_blob(r: &mut impl Read) -> eyre::Result<Vec<u8>> {
     Ok(buf)
 }
 
+/// Builds a full-snapshot stream in memory, mirroring the exporter's framing.
+///
+/// This exists so tests can produce streams without a second copy of the format. It is not how real
+/// snapshots are made: those come from `reth-export --mode full-snapshot`, which reads a Nitro
+/// database. Nothing here enforces the invariants the reader checks, on purpose, so a test can build
+/// a deliberately broken stream.
+#[derive(Debug, Default)]
+pub struct StreamBuilder {
+    out: Vec<u8>,
+}
+
+impl StreamBuilder {
+    /// Start a stream with its magic and manifest.
+    pub fn new(manifest: &Manifest) -> Self {
+        let mut out = MAGIC.to_vec();
+        out.push(SECTION_MANIFEST);
+        put_uvarint(&mut out, manifest.block);
+        out.extend_from_slice(manifest.root.as_slice());
+        put_uvarint(&mut out, manifest.state_id);
+        out.extend_from_slice(manifest.hash.as_slice());
+        Self { out }
+    }
+
+    /// Open the blocks section.
+    pub fn blocks(self) -> Self {
+        self.section(SECTION_BLOCKS)
+    }
+
+    /// Open the state-history section.
+    pub fn history_section(self) -> Self {
+        self.section(SECTION_HISTORY)
+    }
+
+    /// Open the state section.
+    pub fn state(self) -> Self {
+        self.section(SECTION_STATE)
+    }
+
+    fn section(mut self, tag: u8) -> Self {
+        self.out.push(tag);
+        self
+    }
+
+    /// Close the current section.
+    pub fn end_section(mut self) -> Self {
+        self.out.push(REC_END);
+        self
+    }
+
+    /// A block header. Its hash is derived from the bytes, so headers are self-consistent.
+    pub fn header(mut self, block: u64, rlp: &[u8]) -> Self {
+        self.out.push(REC_HEADER);
+        put_uvarint(&mut self.out, block);
+        self.out.extend_from_slice(keccak256(rlp).as_slice());
+        put_uvarint(&mut self.out, rlp.len() as u64);
+        self.out.extend_from_slice(rlp);
+        self
+    }
+
+    /// A block body, as geth's `ReadBodyRLP` returns it.
+    pub fn body(mut self, block: u64, rlp: &[u8]) -> Self {
+        self.out.push(REC_BODY);
+        put_uvarint(&mut self.out, block);
+        put_uvarint(&mut self.out, rlp.len() as u64);
+        self.out.extend_from_slice(rlp);
+        self
+    }
+
+    /// A block's receipts, as geth's `ReadReceiptsRLP` returns them: the storage form.
+    pub fn receipts(mut self, block: u64, rlp: &[u8]) -> Self {
+        self.out.push(REC_RECEIPTS);
+        put_uvarint(&mut self.out, block);
+        put_uvarint(&mut self.out, rlp.len() as u64);
+        self.out.extend_from_slice(rlp);
+        self
+    }
+
+    /// One state-history object.
+    pub fn history(mut self, o: &HistoryObject) -> Self {
+        self.out.push(REC_HEADER);
+        put_uvarint(&mut self.out, o.state_id);
+        put_uvarint(&mut self.out, o.block);
+        self.out.push(HISTORY_VERSION_RAW_SLOTS);
+        self.out.extend_from_slice(o.parent_root.as_slice());
+        self.out.extend_from_slice(o.post_root.as_slice());
+        put_uvarint(&mut self.out, o.accounts.len() as u64);
+        for a in &o.accounts {
+            self.out.extend_from_slice(a.address.as_slice());
+            match &a.previous {
+                None => self.out.push(0),
+                Some((nonce, balance, code)) => {
+                    self.out.push(1);
+                    put_uvarint(&mut self.out, *nonce);
+                    put_short(&mut self.out, &trim(balance.to_be_bytes::<32>()));
+                    put_short(
+                        &mut self.out,
+                        code.map(|c| c.to_vec()).unwrap_or_default().as_slice(),
+                    );
+                }
+            }
+            put_uvarint(&mut self.out, a.storage.len() as u64);
+            for (k, v) in &a.storage {
+                self.out.extend_from_slice(k.as_slice());
+                put_short(&mut self.out, &trim(v.to_be_bytes::<32>()));
+            }
+        }
+        self
+    }
+
+    /// An account at the exported state root, keyed by the hash of its address.
+    pub fn account(
+        mut self,
+        hashed_address: B256,
+        nonce: u64,
+        balance: U256,
+        code_hash: Option<B256>,
+    ) -> Self {
+        self.out.push(REC_ACCOUNT);
+        self.out.extend_from_slice(hashed_address.as_slice());
+        put_uvarint(&mut self.out, nonce);
+        put_short(&mut self.out, &trim(balance.to_be_bytes::<32>()));
+        put_short(
+            &mut self.out,
+            code_hash.map(|c| c.to_vec()).unwrap_or_default().as_slice(),
+        );
+        self
+    }
+
+    /// A storage slot belonging to the preceding account.
+    pub fn storage(mut self, hashed_slot: B256, value: U256) -> Self {
+        self.out.push(REC_STORAGE);
+        self.out.extend_from_slice(hashed_slot.as_slice());
+        put_short(&mut self.out, &trim(value.to_be_bytes::<32>()));
+        self
+    }
+
+    /// Contract code, keyed by its hash.
+    pub fn code(mut self, code: &[u8]) -> Self {
+        self.out.push(REC_CODE);
+        self.out.extend_from_slice(keccak256(code).as_slice());
+        put_uvarint(&mut self.out, code.len() as u64);
+        self.out.extend_from_slice(code);
+        self
+    }
+
+    /// Close the stream and return its bytes.
+    pub fn finish(mut self) -> Vec<u8> {
+        self.out.push(SECTION_END);
+        self.out
+    }
+}
+
+fn trim(bytes: [u8; 32]) -> Vec<u8> {
+    let first = bytes.iter().position(|b| *b != 0).unwrap_or(32);
+    bytes[first..].to_vec()
+}
+
+fn put_uvarint(out: &mut Vec<u8>, mut v: u64) {
+    while v >= 0x80 {
+        out.push((v as u8) | 0x80);
+        v >>= 7;
+    }
+    out.push(v as u8);
+}
+
+fn put_short(out: &mut Vec<u8>, b: &[u8]) {
+    out.push(b.len() as u8);
+    out.extend_from_slice(b);
+}
+
 #[cfg(test)]
 mod tests {
     use alloy_primitives::{Address, address};
 
     use super::*;
-
-    /// Mirrors the exporter's framing, so the tests exercise the same bytes it writes.
-    #[derive(Default)]
-    struct StreamBuilder {
-        out: Vec<u8>,
-    }
-
-    impl StreamBuilder {
-        fn new(manifest: &Manifest) -> Self {
-            let mut out = MAGIC.to_vec();
-            out.push(SECTION_MANIFEST);
-            put_uvarint(&mut out, manifest.block);
-            out.extend_from_slice(manifest.root.as_slice());
-            put_uvarint(&mut out, manifest.state_id);
-            out.extend_from_slice(manifest.hash.as_slice());
-            Self { out }
-        }
-        fn section(mut self, tag: u8) -> Self {
-            self.out.push(tag);
-            self
-        }
-        fn end_section(mut self) -> Self {
-            self.out.push(REC_END);
-            self
-        }
-        fn header(mut self, block: u64, rlp: &[u8]) -> Self {
-            self.out.push(REC_HEADER);
-            put_uvarint(&mut self.out, block);
-            self.out.extend_from_slice(keccak256(rlp).as_slice());
-            put_uvarint(&mut self.out, rlp.len() as u64);
-            self.out.extend_from_slice(rlp);
-            self
-        }
-        fn history(mut self, o: &HistoryObject) -> Self {
-            self.out.push(REC_HEADER);
-            put_uvarint(&mut self.out, o.state_id);
-            put_uvarint(&mut self.out, o.block);
-            self.out.push(HISTORY_VERSION_RAW_SLOTS);
-            self.out.extend_from_slice(o.parent_root.as_slice());
-            self.out.extend_from_slice(o.post_root.as_slice());
-            put_uvarint(&mut self.out, o.accounts.len() as u64);
-            for a in &o.accounts {
-                self.out.extend_from_slice(a.address.as_slice());
-                match &a.previous {
-                    None => self.out.push(0),
-                    Some((nonce, balance, code)) => {
-                        self.out.push(1);
-                        put_uvarint(&mut self.out, *nonce);
-                        put_short(&mut self.out, &trim(balance.to_be_bytes::<32>()));
-                        put_short(&mut self.out, code.map(|c| c.to_vec()).unwrap_or_default().as_slice());
-                    }
-                }
-                put_uvarint(&mut self.out, a.storage.len() as u64);
-                for (k, v) in &a.storage {
-                    self.out.extend_from_slice(k.as_slice());
-                    put_short(&mut self.out, &trim(v.to_be_bytes::<32>()));
-                }
-            }
-            self
-        }
-        fn finish(mut self) -> Vec<u8> {
-            self.out.push(SECTION_END);
-            self.out
-        }
-    }
-
-    fn trim(bytes: [u8; 32]) -> Vec<u8> {
-        let first = bytes.iter().position(|b| *b != 0).unwrap_or(32);
-        bytes[first..].to_vec()
-    }
-
-    fn put_uvarint(out: &mut Vec<u8>, mut v: u64) {
-        while v >= 0x80 {
-            out.push((v as u8) | 0x80);
-            v >>= 7;
-        }
-        out.push(v as u8);
-    }
-
-    fn put_short(out: &mut Vec<u8>, b: &[u8]) {
-        out.push(b.len() as u8);
-        out.extend_from_slice(b);
-    }
 
     /// A header RLP whose first field is `parent` and whose remaining fields are placeholders, so
     /// `header_field` and the linkage check have something real to walk.
@@ -635,14 +737,14 @@ mod tests {
             ],
         };
         let bytes = StreamBuilder::new(&m)
-            .section(SECTION_BLOCKS)
+            .blocks()
             .header(0, &h0)
             .header(1, &h1)
             .end_section()
-            .section(SECTION_HISTORY)
+            .history_section()
             .history(&obj)
             .end_section()
-            .section(SECTION_STATE)
+            .state()
             .end_section()
             .finish();
 
@@ -670,7 +772,7 @@ mod tests {
         let h0 = header_rlp(B256::ZERO);
         let h2 = header_rlp(keccak256(&h0));
         let bytes = StreamBuilder::new(&m)
-            .section(SECTION_BLOCKS)
+            .blocks()
             .header(0, &h0)
             .header(2, &h2)
             .end_section()
@@ -688,7 +790,7 @@ mod tests {
         let h0 = header_rlp(B256::ZERO);
         let h1 = header_rlp(B256::repeat_byte(0x77)); // wrong parent
         let bytes = StreamBuilder::new(&m)
-            .section(SECTION_BLOCKS)
+            .blocks()
             .header(0, &h0)
             .header(1, &h1)
             .end_section()
@@ -719,9 +821,9 @@ mod tests {
             accounts: vec![],
         };
         let bytes = StreamBuilder::new(&m)
-            .section(SECTION_BLOCKS)
+            .blocks()
             .end_section()
-            .section(SECTION_HISTORY)
+            .history_section()
             .history(&first)
             .history(&second)
             .end_section()
@@ -744,12 +846,12 @@ mod tests {
             accounts: vec![],
         };
         let bytes = StreamBuilder::new(&m)
-            .section(SECTION_BLOCKS)
+            .blocks()
             .end_section()
-            .section(SECTION_HISTORY)
+            .history_section()
             .history(&short)
             .end_section()
-            .section(SECTION_STATE)
+            .state()
             .end_section()
             .finish();
 
@@ -765,7 +867,7 @@ mod tests {
 
         let m = manifest();
         let mut bytes = StreamBuilder::new(&m)
-            .section(SECTION_BLOCKS)
+            .blocks()
             .header(0, &header_rlp(B256::ZERO))
             .end_section()
             .finish();

--- a/crates/arb-reth-genesis/src/snapshot_stream.rs
+++ b/crates/arb-reth-genesis/src/snapshot_stream.rs
@@ -1,0 +1,754 @@
+//! Reader for the `reth-export --mode full-snapshot` stream.
+//!
+//! The stream holds a manifest, then blocks, then state history, then the state trie, all ending at
+//! the same block: the one whose state is in the persisted trie. See
+//! `arb-kb/decisions/ADR-004-snapshot-conversion-invariants.md`.
+//!
+//! Records arrive in one pass and are yielded one at a time, because the stream is far larger than
+//! memory. Structural invariants that need no database are enforced here as records go past, so a
+//! malformed stream fails before anything is written.
+
+use std::io::Read;
+
+use alloy_primitives::{B256, U256, keccak256};
+use eyre::{Context as _, eyre};
+
+const MAGIC: &[u8; 8] = b"ARBSNAP1";
+
+// Section tags live above the record tags on purpose. They shared a range in the first draft, which
+// made a receipts record inside the blocks section indistinguishable from the start of the history
+// section, since both were 0x03.
+const SECTION_MANIFEST: u8 = 0xf1;
+const SECTION_BLOCKS: u8 = 0xf2;
+const SECTION_HISTORY: u8 = 0xf3;
+const SECTION_STATE: u8 = 0xf4;
+const SECTION_END: u8 = 0xff;
+
+const REC_END: u8 = 0x00;
+const REC_HEADER: u8 = 0x01;
+const REC_BODY: u8 = 0x02;
+const REC_RECEIPTS: u8 = 0x03;
+const REC_ACCOUNT: u8 = 0x04;
+const REC_STORAGE: u8 = 0x05;
+const REC_CODE: u8 = 0x06;
+
+/// History objects identify storage slots by raw key from this version on.
+const HISTORY_VERSION_RAW_SLOTS: u8 = 1;
+
+/// Where the conversion stops: state, blocks and history all end here.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Manifest {
+    /// `P`, the block of the persisted state trie.
+    pub block: u64,
+    /// `R_P`, the state root at `P`.
+    pub root: B256,
+    /// The pathdb persistent state id, which is `P`'s history object.
+    pub state_id: u64,
+    /// Canonical hash of block `P`.
+    pub hash: B256,
+}
+
+/// One account's pre-block state, and the slots the block overwrote.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HistoryAccount {
+    pub address: alloy_primitives::Address,
+    /// `None` when the account did not exist before the block.
+    pub previous: Option<(u64, U256, Option<B256>)>,
+    /// Raw slot key and its pre-block value.
+    pub storage: Vec<(B256, U256)>,
+}
+
+/// One state history object: the state before `block`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HistoryObject {
+    pub state_id: u64,
+    pub block: u64,
+    pub parent_root: B256,
+    pub post_root: B256,
+    pub accounts: Vec<HistoryAccount>,
+}
+
+/// A record from the stream, in the order the exporter wrote it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Record {
+    Header {
+        block: u64,
+        hash: B256,
+        rlp: Vec<u8>,
+    },
+    Body {
+        block: u64,
+        rlp: Vec<u8>,
+    },
+    Receipts {
+        block: u64,
+        rlp: Vec<u8>,
+    },
+    History(HistoryObject),
+    /// An account at the exported state root. The address is hashed: a pruned snapshot carries no
+    /// preimage for it.
+    Account {
+        hashed_address: B256,
+        nonce: u64,
+        balance: U256,
+        code_hash: Option<B256>,
+    },
+    /// A storage slot belonging to the most recent [`Record::Account`]. The key is hashed.
+    Storage {
+        hashed_slot: B256,
+        value: U256,
+    },
+    Code {
+        hash: B256,
+        code: Vec<u8>,
+    },
+}
+
+/// Streaming reader over a full-snapshot export.
+#[derive(Debug)]
+pub struct SnapshotStream<R> {
+    inner: R,
+    manifest: Manifest,
+    section: u8,
+    /// Last block seen in the blocks section, for contiguity and parent linkage.
+    last_block: Option<(u64, B256)>,
+    /// Last history object seen, for root chaining.
+    last_history: Option<(u64, B256)>,
+    finished: bool,
+}
+
+impl<R: Read> SnapshotStream<R> {
+    /// Read the magic and manifest, leaving the reader positioned at the first section.
+    pub fn open(mut inner: R) -> eyre::Result<Self> {
+        let mut magic = [0u8; 8];
+        inner.read_exact(&mut magic).wrap_err("read stream magic")?;
+        if &magic != MAGIC {
+            return Err(eyre!(
+                "not a full-snapshot stream: magic {:?}",
+                String::from_utf8_lossy(&magic)
+            ));
+        }
+        let tag = read_u8(&mut inner)?;
+        if tag != SECTION_MANIFEST {
+            return Err(eyre!("expected the manifest section, found tag {tag:#04x}"));
+        }
+        let manifest = Manifest {
+            block: read_uvarint(&mut inner)?,
+            root: read_b256(&mut inner)?,
+            state_id: read_uvarint(&mut inner)?,
+            hash: read_b256(&mut inner)?,
+        };
+        Ok(Self {
+            inner,
+            manifest,
+            section: SECTION_MANIFEST,
+            last_block: None,
+            last_history: None,
+            finished: false,
+        })
+    }
+
+    /// The convert point this stream was produced at.
+    pub const fn manifest(&self) -> &Manifest {
+        &self.manifest
+    }
+
+    /// Next record, or `None` at the end of the stream.
+    pub fn next_record(&mut self) -> eyre::Result<Option<Record>> {
+        if self.finished {
+            return Ok(None);
+        }
+        loop {
+            let tag = read_u8(&mut self.inner)?;
+            match (self.section, tag) {
+                // Section transitions. Order is fixed so the importer can write append-only.
+                (SECTION_MANIFEST, SECTION_BLOCKS)
+                | (SECTION_BLOCKS, SECTION_HISTORY)
+                | (SECTION_HISTORY, SECTION_STATE) => {
+                    self.section = tag;
+                }
+                (SECTION_STATE, SECTION_END) => {
+                    self.finished = true;
+                    return Ok(None);
+                }
+                (SECTION_MANIFEST, _) => {
+                    return Err(eyre!("expected the blocks section, found tag {tag:#04x}"));
+                }
+                (_, REC_END) => {
+                    // End of the current section; the next byte names the next one.
+                    continue;
+                }
+                (SECTION_BLOCKS, REC_HEADER) => {
+                    let block = read_uvarint(&mut self.inner)?;
+                    let hash = read_b256(&mut self.inner)?;
+                    let rlp = read_blob(&mut self.inner)?;
+                    self.check_header(block, hash, &rlp)?;
+                    return Ok(Some(Record::Header { block, hash, rlp }));
+                }
+                (SECTION_BLOCKS, REC_BODY) => {
+                    let block = read_uvarint(&mut self.inner)?;
+                    let rlp = read_blob(&mut self.inner)?;
+                    return Ok(Some(Record::Body { block, rlp }));
+                }
+                (SECTION_BLOCKS, REC_RECEIPTS) => {
+                    let block = read_uvarint(&mut self.inner)?;
+                    let rlp = read_blob(&mut self.inner)?;
+                    return Ok(Some(Record::Receipts { block, rlp }));
+                }
+                (SECTION_HISTORY, REC_HEADER) => {
+                    let object = self.read_history()?;
+                    return Ok(Some(Record::History(object)));
+                }
+                (SECTION_STATE, REC_ACCOUNT) => {
+                    let hashed_address = read_b256(&mut self.inner)?;
+                    let nonce = read_uvarint(&mut self.inner)?;
+                    let balance = read_short_u256(&mut self.inner)?;
+                    let code_hash = read_short_bytes(&mut self.inner)?;
+                    return Ok(Some(Record::Account {
+                        hashed_address,
+                        nonce,
+                        balance,
+                        code_hash: (!code_hash.is_empty()).then(|| B256::from_slice(&code_hash)),
+                    }));
+                }
+                (SECTION_STATE, REC_STORAGE) => {
+                    let hashed_slot = read_b256(&mut self.inner)?;
+                    let value = read_short_u256(&mut self.inner)?;
+                    return Ok(Some(Record::Storage { hashed_slot, value }));
+                }
+                (SECTION_STATE, REC_CODE) => {
+                    let hash = read_b256(&mut self.inner)?;
+                    let code = read_blob(&mut self.inner)?;
+                    if keccak256(&code) != hash {
+                        return Err(eyre!("code blob does not hash to {hash:#x}"));
+                    }
+                    return Ok(Some(Record::Code { hash, code }));
+                }
+                (section, tag) => {
+                    return Err(eyre!(
+                        "record tag {tag:#04x} is not valid in section {section:#04x}"
+                    ));
+                }
+            }
+        }
+    }
+
+    /// ADR-004 B1, B2 (header hash) and B3.
+    fn check_header(&mut self, block: u64, hash: B256, rlp: &[u8]) -> eyre::Result<()> {
+        if keccak256(rlp) != hash {
+            return Err(eyre!("block {block}: header does not hash to {hash:#x}"));
+        }
+        if block > self.manifest.block {
+            return Err(eyre!(
+                "block {block} is above the convert point {}",
+                self.manifest.block
+            ));
+        }
+        let parent = header_field(rlp, 0).wrap_err_with(|| format!("block {block}: parent hash"))?;
+        if let Some((last_number, last_hash)) = self.last_block {
+            if block != last_number + 1 {
+                return Err(eyre!("blocks jump from {last_number} to {block}"));
+            }
+            if parent != last_hash.as_slice() {
+                return Err(eyre!(
+                    "block {block} does not build on {last_number}: parent is {}",
+                    B256::from_slice(parent),
+                ));
+            }
+        }
+        self.last_block = Some((block, hash));
+        Ok(())
+    }
+
+    /// ADR-004 S1, S2, S4 and S5.
+    fn read_history(&mut self) -> eyre::Result<HistoryObject> {
+        let state_id = read_uvarint(&mut self.inner)?;
+        let block = read_uvarint(&mut self.inner)?;
+        let version = read_u8(&mut self.inner)?;
+        let parent_root = read_b256(&mut self.inner)?;
+        let post_root = read_b256(&mut self.inner)?;
+
+        if version != HISTORY_VERSION_RAW_SLOTS {
+            return Err(eyre!(
+                "history {state_id} has version {version}; only raw slot keys are supported"
+            ));
+        }
+        if block > self.manifest.block {
+            return Err(eyre!(
+                "history {state_id} names block {block}, above the convert point {}",
+                self.manifest.block
+            ));
+        }
+        if let Some((last_block, last_post)) = self.last_history {
+            if block <= last_block {
+                return Err(eyre!(
+                    "history {state_id} block {block} does not advance past {last_block}"
+                ));
+            }
+            // The strong structural check: a gap, a reordering or a truncation all break the chain.
+            if parent_root != last_post {
+                return Err(eyre!(
+                    "history {state_id} at block {block} starts from {parent_root:#x}, but the \
+                     previous object ended at {last_post:#x}"
+                ));
+            }
+        }
+        self.last_history = Some((block, post_root));
+
+        let count = read_uvarint(&mut self.inner)?;
+        let mut accounts = Vec::with_capacity(count.min(4096) as usize);
+        for _ in 0..count {
+            let mut address = [0u8; 20];
+            self.inner.read_exact(&mut address)?;
+            let present = read_u8(&mut self.inner)?;
+            let previous = if present == 0 {
+                None
+            } else {
+                let nonce = read_uvarint(&mut self.inner)?;
+                let balance = read_short_u256(&mut self.inner)?;
+                let code_hash = read_short_bytes(&mut self.inner)?;
+                Some((
+                    nonce,
+                    balance,
+                    (!code_hash.is_empty()).then(|| B256::from_slice(&code_hash)),
+                ))
+            };
+            let slots = read_uvarint(&mut self.inner)?;
+            let mut storage = Vec::with_capacity(slots.min(4096) as usize);
+            for _ in 0..slots {
+                let key = read_b256(&mut self.inner)?;
+                storage.push((key, read_short_u256(&mut self.inner)?));
+            }
+            accounts.push(HistoryAccount {
+                address: alloy_primitives::Address::from(address),
+                previous,
+                storage,
+            });
+        }
+        Ok(HistoryObject {
+            state_id,
+            block,
+            parent_root,
+            post_root,
+            accounts,
+        })
+    }
+
+    /// The last history object must end at the exported state root (ADR-004 S3).
+    pub fn check_history_meets_state(&self) -> eyre::Result<()> {
+        match self.last_history {
+            None => Err(eyre!("stream carried no state history")),
+            Some((block, post_root)) => {
+                if block != self.manifest.block {
+                    return Err(eyre!(
+                        "history ends at block {block}, but the convert point is {}",
+                        self.manifest.block
+                    ));
+                }
+                if post_root != self.manifest.root {
+                    return Err(eyre!(
+                        "history ends at {post_root:#x}, but the exported state root is {:#x}",
+                        self.manifest.root
+                    ));
+                }
+                Ok(())
+            }
+        }
+    }
+
+    /// The highest block seen in the blocks section, if any.
+    pub const fn last_block(&self) -> Option<u64> {
+        match self.last_block {
+            Some((n, _)) => Some(n),
+            None => None,
+        }
+    }
+}
+
+/// Payload of the `i`th top-level field of an RLP-encoded header.
+///
+/// Avoids decoding the whole header, which lets this work regardless of any chain-specific trailing
+/// fields. Field order is fixed by the Ethereum header encoding: 0 parentHash, 3 stateRoot,
+/// 4 transactionsRoot, 5 receiptsRoot.
+pub fn header_field(rlp: &[u8], index: usize) -> eyre::Result<&[u8]> {
+    let (mut cursor, rest) = rlp_split(rlp, true)?;
+    if !rest.is_empty() {
+        return Err(eyre!("trailing bytes after the header"));
+    }
+    for _ in 0..index {
+        let (_, next) = rlp_split(cursor, false)?;
+        cursor = next;
+    }
+    Ok(rlp_split(cursor, false)?.0)
+}
+
+fn rlp_split(blob: &[u8], want_list: bool) -> eyre::Result<(&[u8], &[u8])> {
+    let &prefix = blob.first().ok_or_else(|| eyre!("empty RLP input"))?;
+    let (header, len) = match prefix {
+        0x00..=0x7f => (0, 1),
+        0x80..=0xb7 => (1, (prefix - 0x80) as usize),
+        0xb8..=0xbf => {
+            let n = (prefix - 0xb7) as usize;
+            (1 + n, be_usize(blob.get(1..1 + n).ok_or_else(|| eyre!("short RLP"))?))
+        }
+        0xc0..=0xf7 => (1, (prefix - 0xc0) as usize),
+        0xf8..=0xff => {
+            let n = (prefix - 0xf7) as usize;
+            (1 + n, be_usize(blob.get(1..1 + n).ok_or_else(|| eyre!("short RLP"))?))
+        }
+    };
+    if (prefix >= 0xc0) != want_list {
+        return Err(eyre!("RLP item is not the expected kind"));
+    }
+    let end = header + len;
+    let payload = blob
+        .get(header..end)
+        .ok_or_else(|| eyre!("RLP item claims {len} bytes, only {} available", blob.len()))?;
+    Ok((payload, &blob[end..]))
+}
+
+fn be_usize(bytes: &[u8]) -> usize {
+    bytes.iter().fold(0usize, |n, &b| (n << 8) | b as usize)
+}
+
+fn read_u8(r: &mut impl Read) -> eyre::Result<u8> {
+    let mut b = [0u8; 1];
+    r.read_exact(&mut b)?;
+    Ok(b[0])
+}
+
+fn read_b256(r: &mut impl Read) -> eyre::Result<B256> {
+    let mut b = [0u8; 32];
+    r.read_exact(&mut b)?;
+    Ok(B256::from(b))
+}
+
+fn read_uvarint(r: &mut impl Read) -> eyre::Result<u64> {
+    let mut value = 0u64;
+    let mut shift = 0u32;
+    loop {
+        let byte = read_u8(r)?;
+        value |= u64::from(byte & 0x7f)
+            .checked_shl(shift)
+            .ok_or_else(|| eyre!("varint overflows u64"))?;
+        if byte & 0x80 == 0 {
+            return Ok(value);
+        }
+        shift += 7;
+        if shift >= 64 {
+            return Err(eyre!("varint overflows u64"));
+        }
+    }
+}
+
+/// A blob whose length is at most 255 bytes: balance, code hash, slot value.
+fn read_short_bytes(r: &mut impl Read) -> eyre::Result<Vec<u8>> {
+    let len = read_u8(r)? as usize;
+    let mut buf = vec![0u8; len];
+    r.read_exact(&mut buf)?;
+    Ok(buf)
+}
+
+fn read_short_u256(r: &mut impl Read) -> eyre::Result<U256> {
+    let bytes = read_short_bytes(r)?;
+    if bytes.len() > 32 {
+        return Err(eyre!("integer is {} bytes, too wide for U256", bytes.len()));
+    }
+    Ok(U256::from_be_slice(&bytes))
+}
+
+fn read_blob(r: &mut impl Read) -> eyre::Result<Vec<u8>> {
+    let len = read_uvarint(r)? as usize;
+    let mut buf = vec![0u8; len];
+    r.read_exact(&mut buf)?;
+    Ok(buf)
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::{Address, address};
+
+    use super::*;
+
+    /// Mirrors the exporter's framing, so the tests exercise the same bytes it writes.
+    #[derive(Default)]
+    struct StreamBuilder {
+        out: Vec<u8>,
+    }
+
+    impl StreamBuilder {
+        fn new(manifest: &Manifest) -> Self {
+            let mut out = MAGIC.to_vec();
+            out.push(SECTION_MANIFEST);
+            put_uvarint(&mut out, manifest.block);
+            out.extend_from_slice(manifest.root.as_slice());
+            put_uvarint(&mut out, manifest.state_id);
+            out.extend_from_slice(manifest.hash.as_slice());
+            Self { out }
+        }
+        fn section(mut self, tag: u8) -> Self {
+            self.out.push(tag);
+            self
+        }
+        fn end_section(mut self) -> Self {
+            self.out.push(REC_END);
+            self
+        }
+        fn header(mut self, block: u64, rlp: &[u8]) -> Self {
+            self.out.push(REC_HEADER);
+            put_uvarint(&mut self.out, block);
+            self.out.extend_from_slice(keccak256(rlp).as_slice());
+            put_uvarint(&mut self.out, rlp.len() as u64);
+            self.out.extend_from_slice(rlp);
+            self
+        }
+        fn history(mut self, o: &HistoryObject) -> Self {
+            self.out.push(REC_HEADER);
+            put_uvarint(&mut self.out, o.state_id);
+            put_uvarint(&mut self.out, o.block);
+            self.out.push(HISTORY_VERSION_RAW_SLOTS);
+            self.out.extend_from_slice(o.parent_root.as_slice());
+            self.out.extend_from_slice(o.post_root.as_slice());
+            put_uvarint(&mut self.out, o.accounts.len() as u64);
+            for a in &o.accounts {
+                self.out.extend_from_slice(a.address.as_slice());
+                match &a.previous {
+                    None => self.out.push(0),
+                    Some((nonce, balance, code)) => {
+                        self.out.push(1);
+                        put_uvarint(&mut self.out, *nonce);
+                        put_short(&mut self.out, &trim(balance.to_be_bytes::<32>()));
+                        put_short(&mut self.out, code.map(|c| c.to_vec()).unwrap_or_default().as_slice());
+                    }
+                }
+                put_uvarint(&mut self.out, a.storage.len() as u64);
+                for (k, v) in &a.storage {
+                    self.out.extend_from_slice(k.as_slice());
+                    put_short(&mut self.out, &trim(v.to_be_bytes::<32>()));
+                }
+            }
+            self
+        }
+        fn finish(mut self) -> Vec<u8> {
+            self.out.push(SECTION_END);
+            self.out
+        }
+    }
+
+    fn trim(bytes: [u8; 32]) -> Vec<u8> {
+        let first = bytes.iter().position(|b| *b != 0).unwrap_or(32);
+        bytes[first..].to_vec()
+    }
+
+    fn put_uvarint(out: &mut Vec<u8>, mut v: u64) {
+        while v >= 0x80 {
+            out.push((v as u8) | 0x80);
+            v >>= 7;
+        }
+        out.push(v as u8);
+    }
+
+    fn put_short(out: &mut Vec<u8>, b: &[u8]) {
+        out.push(b.len() as u8);
+        out.extend_from_slice(b);
+    }
+
+    /// A header RLP whose first field is `parent` and whose remaining fields are placeholders, so
+    /// `header_field` and the linkage check have something real to walk.
+    fn header_rlp(parent: B256) -> Vec<u8> {
+        let mut fields = Vec::new();
+        fields.push(0xa0);
+        fields.extend_from_slice(parent.as_slice());
+        for _ in 0..5 {
+            fields.push(0xa0);
+            fields.extend_from_slice(&[0x11u8; 32]);
+        }
+        let mut out = vec![0xf8, fields.len() as u8];
+        out.extend_from_slice(&fields);
+        out
+    }
+
+    fn manifest() -> Manifest {
+        Manifest {
+            block: 10,
+            root: B256::repeat_byte(0xee),
+            state_id: 12,
+            hash: B256::repeat_byte(0xaa),
+        }
+    }
+
+    #[test]
+    fn reads_manifest_blocks_and_history() {
+        let m = manifest();
+        let h0 = header_rlp(B256::ZERO);
+        let h1 = header_rlp(keccak256(&h0));
+        let obj = HistoryObject {
+            state_id: 12,
+            block: 10,
+            parent_root: B256::repeat_byte(0xcc),
+            post_root: m.root,
+            accounts: vec![
+                HistoryAccount {
+                    address: address!("00000000000000000000000000000000000000aa"),
+                    previous: Some((7, U256::from(1234u64), Some(B256::repeat_byte(0x9)))),
+                    storage: vec![(B256::repeat_byte(1), U256::from(5u64)), (B256::repeat_byte(2), U256::ZERO)],
+                },
+                HistoryAccount {
+                    address: Address::ZERO,
+                    previous: None,
+                    storage: vec![],
+                },
+            ],
+        };
+        let bytes = StreamBuilder::new(&m)
+            .section(SECTION_BLOCKS)
+            .header(0, &h0)
+            .header(1, &h1)
+            .end_section()
+            .section(SECTION_HISTORY)
+            .history(&obj)
+            .end_section()
+            .section(SECTION_STATE)
+            .end_section()
+            .finish();
+
+        let mut s = SnapshotStream::open(bytes.as_slice()).unwrap();
+        assert_eq!(s.manifest(), &m);
+
+        let mut headers = 0;
+        let mut got = None;
+        while let Some(rec) = s.next_record().unwrap() {
+            match rec {
+                Record::Header { .. } => headers += 1,
+                Record::History(o) => got = Some(o),
+                other => panic!("unexpected {other:?}"),
+            }
+        }
+        assert_eq!(headers, 2);
+        assert_eq!(got.as_ref(), Some(&obj));
+        assert_eq!(s.last_block(), Some(1));
+        s.check_history_meets_state().unwrap();
+    }
+
+    #[test]
+    fn rejects_a_gap_in_blocks() {
+        let m = manifest();
+        let h0 = header_rlp(B256::ZERO);
+        let h2 = header_rlp(keccak256(&h0));
+        let bytes = StreamBuilder::new(&m)
+            .section(SECTION_BLOCKS)
+            .header(0, &h0)
+            .header(2, &h2)
+            .end_section()
+            .finish();
+
+        let mut s = SnapshotStream::open(bytes.as_slice()).unwrap();
+        s.next_record().unwrap();
+        let err = s.next_record().unwrap_err().to_string();
+        assert!(err.contains("blocks jump from 0 to 2"), "{err}");
+    }
+
+    #[test]
+    fn rejects_a_header_that_does_not_build_on_its_predecessor() {
+        let m = manifest();
+        let h0 = header_rlp(B256::ZERO);
+        let h1 = header_rlp(B256::repeat_byte(0x77)); // wrong parent
+        let bytes = StreamBuilder::new(&m)
+            .section(SECTION_BLOCKS)
+            .header(0, &h0)
+            .header(1, &h1)
+            .end_section()
+            .finish();
+
+        let mut s = SnapshotStream::open(bytes.as_slice()).unwrap();
+        s.next_record().unwrap();
+        let err = s.next_record().unwrap_err().to_string();
+        assert!(err.contains("does not build on 0"), "{err}");
+    }
+
+    /// The check that catches a gap, a reordering, or a truncated history section.
+    #[test]
+    fn rejects_a_break_in_the_history_root_chain() {
+        let m = manifest();
+        let first = HistoryObject {
+            state_id: 1,
+            block: 1,
+            parent_root: B256::repeat_byte(1),
+            post_root: B256::repeat_byte(2),
+            accounts: vec![],
+        };
+        let second = HistoryObject {
+            state_id: 2,
+            block: 2,
+            parent_root: B256::repeat_byte(0x99), // should be first.post_root
+            post_root: m.root,
+            accounts: vec![],
+        };
+        let bytes = StreamBuilder::new(&m)
+            .section(SECTION_BLOCKS)
+            .end_section()
+            .section(SECTION_HISTORY)
+            .history(&first)
+            .history(&second)
+            .end_section()
+            .finish();
+
+        let mut s = SnapshotStream::open(bytes.as_slice()).unwrap();
+        s.next_record().unwrap();
+        let err = s.next_record().unwrap_err().to_string();
+        assert!(err.contains("previous object ended at"), "{err}");
+    }
+
+    #[test]
+    fn rejects_history_that_does_not_reach_the_exported_state() {
+        let m = manifest();
+        let short = HistoryObject {
+            state_id: 1,
+            block: 9, // one below the convert point
+            parent_root: B256::repeat_byte(1),
+            post_root: B256::repeat_byte(2),
+            accounts: vec![],
+        };
+        let bytes = StreamBuilder::new(&m)
+            .section(SECTION_BLOCKS)
+            .end_section()
+            .section(SECTION_HISTORY)
+            .history(&short)
+            .end_section()
+            .section(SECTION_STATE)
+            .end_section()
+            .finish();
+
+        let mut s = SnapshotStream::open(bytes.as_slice()).unwrap();
+        while s.next_record().unwrap().is_some() {}
+        let err = s.check_history_meets_state().unwrap_err().to_string();
+        assert!(err.contains("history ends at block 9"), "{err}");
+    }
+
+    #[test]
+    fn rejects_a_bad_magic_and_a_corrupt_header_hash() {
+        assert!(SnapshotStream::open(b"NOPE0000".as_slice()).is_err());
+
+        let m = manifest();
+        let mut bytes = StreamBuilder::new(&m)
+            .section(SECTION_BLOCKS)
+            .header(0, &header_rlp(B256::ZERO))
+            .end_section()
+            .finish();
+        // Corrupt one byte of the header payload, leaving its recorded hash stale.
+        let last = bytes.len() - 3;
+        bytes[last] ^= 0xff;
+
+        let mut s = SnapshotStream::open(bytes.as_slice()).unwrap();
+        let err = s.next_record().unwrap_err().to_string();
+        assert!(err.contains("does not hash to"), "{err}");
+    }
+
+    #[test]
+    fn extracts_header_fields_without_decoding_the_whole_header() {
+        let parent = B256::repeat_byte(0x42);
+        let rlp = header_rlp(parent);
+        assert_eq!(header_field(&rlp, 0).unwrap(), parent.as_slice());
+        assert_eq!(header_field(&rlp, 3).unwrap(), [0x11u8; 32]);
+    }
+}

--- a/crates/arb-reth-node/src/bin/arb-reth.rs
+++ b/crates/arb-reth-node/src/bin/arb-reth.rs
@@ -5,6 +5,7 @@
 //!
 //! - `node`             the standalone no-engine node (feed / L1-derivation block producer + RPC)
 //! - `snapshot import`  import a Nitro genesis-state stream into reth MDBX
+//! - `snapshot import-full`  convert a full-snapshot stream (blocks + history + state)
 //! - `snapshot read`    read hashed-state from a converted snapshot
 //! - `genesis verify`   verify the Arbitrum One Nitro-genesis state root from the classic export
 //! - `genesis verify-export`  verify a `reth-export --mode state` stream (stdin)
@@ -23,6 +24,7 @@ use arb_reth_node::commands::{
         SnapshotBuildPreimagesArgs, SnapshotImportArgs, SnapshotReadArgs,
         SnapshotRepairHistoryArgs,
     },
+    snapshot_full::SnapshotImportFullArgs,
 };
 use clap::{Args, Parser, Subcommand};
 use reth_cli_runner::CliRunner;
@@ -72,6 +74,8 @@ enum SnapshotSub {
     BuildPreimages(SnapshotBuildPreimagesArgs),
     /// Import a Nitro genesis state stream into reth MDBX and verify the state root.
     Import(SnapshotImportArgs),
+    /// Convert a `reth-export --mode full-snapshot` stream into a reth datadir.
+    ImportFull(SnapshotImportFullArgs),
     /// Read hashed-state from a converted Arbitrum reth MDBX snapshot.
     Read(SnapshotReadArgs),
     /// Add missing history-boundary metadata to an existing snapshot import.
@@ -112,6 +116,7 @@ fn main() -> eyre::Result<()> {
         Command::Snapshot(cmd) => match cmd.command {
             SnapshotSub::BuildPreimages(args) => commands::snapshot::build_preimages(args),
             SnapshotSub::Import(args) => commands::snapshot::import(args),
+            SnapshotSub::ImportFull(args) => commands::snapshot_full::import_full(args),
             SnapshotSub::Read(args) => commands::snapshot::read(args),
             SnapshotSub::RepairHistory(args) => commands::snapshot::repair_history(args),
         },

--- a/crates/arb-reth-node/src/bin/arb-reth.rs
+++ b/crates/arb-reth-node/src/bin/arb-reth.rs
@@ -24,7 +24,7 @@ use arb_reth_node::commands::{
         SnapshotBuildPreimagesArgs, SnapshotImportArgs, SnapshotReadArgs,
         SnapshotRepairHistoryArgs,
     },
-    snapshot_full::SnapshotImportFullArgs,
+    snapshot_full::{SnapshotFinalizeArgs, SnapshotImportFullArgs},
 };
 use clap::{Args, Parser, Subcommand};
 use reth_cli_runner::CliRunner;
@@ -76,6 +76,8 @@ enum SnapshotSub {
     Import(SnapshotImportArgs),
     /// Convert a `reth-export --mode full-snapshot` stream into a reth datadir.
     ImportFull(SnapshotImportFullArgs),
+    /// Finish a converted datadir that stopped after its state root.
+    Finalize(SnapshotFinalizeArgs),
     /// Read hashed-state from a converted Arbitrum reth MDBX snapshot.
     Read(SnapshotReadArgs),
     /// Add missing history-boundary metadata to an existing snapshot import.
@@ -117,6 +119,7 @@ fn main() -> eyre::Result<()> {
             SnapshotSub::BuildPreimages(args) => commands::snapshot::build_preimages(args),
             SnapshotSub::Import(args) => commands::snapshot::import(args),
             SnapshotSub::ImportFull(args) => commands::snapshot_full::import_full(args),
+            SnapshotSub::Finalize(args) => commands::snapshot_full::finalize_datadir(args),
             SnapshotSub::Read(args) => commands::snapshot::read(args),
             SnapshotSub::RepairHistory(args) => commands::snapshot::repair_history(args),
         },

--- a/crates/arb-reth-node/src/commands/mod.rs
+++ b/crates/arb-reth-node/src/commands/mod.rs
@@ -7,3 +7,4 @@ pub mod genesis;
 pub mod node;
 pub mod rewind;
 pub mod snapshot;
+pub mod snapshot_full;

--- a/crates/arb-reth-node/src/commands/snapshot.rs
+++ b/crates/arb-reth-node/src/commands/snapshot.rs
@@ -1376,7 +1376,7 @@ fn require_slot_preimage(preimages: &SlotPreimagesReader, hashed_slot: B256) -> 
     Ok(plain_slot)
 }
 
-fn compute_state_root_chunked<PF>(factory: &PF) -> eyre::Result<B256>
+pub(crate) fn compute_state_root_chunked<PF>(factory: &PF) -> eyre::Result<B256>
 where
     PF: reth_provider::DatabaseProviderFactory<
             ProviderRW: DBProvider<Tx: DbTxMut> + TrieWriter + StorageSettingsCache,

--- a/crates/arb-reth-node/src/commands/snapshot.rs
+++ b/crates/arb-reth-node/src/commands/snapshot.rs
@@ -636,7 +636,7 @@ pub(crate) fn validate_snapshot_import_for_launch(
     Ok(())
 }
 
-fn ensure_fresh_import_target(out: &Path) -> eyre::Result<()> {
+pub(crate) fn ensure_fresh_import_target(out: &Path) -> eyre::Result<()> {
     let import_manifest = out.join(SNAPSHOT_IMPORT_MANIFEST_FILE);
     if import_manifest.exists() {
         eyre::bail!(

--- a/crates/arb-reth-node/src/commands/snapshot.rs
+++ b/crates/arb-reth-node/src/commands/snapshot.rs
@@ -735,8 +735,7 @@ pub fn repair_history(args: SnapshotRepairHistoryArgs) -> eyre::Result<()> {
 /// Rename the changeset static-file segments so their on-disk name matches the
 /// `expected_block_range` recorded in their header, which is what reth resolves their path from.
 ///
-/// Shared with the full-snapshot importer, which hit the same hazard over ~55 files per segment
-/// rather than one. That implementation checks every file, so it covers this caller too.
+/// Shared with the full-snapshot importer; it checks every segment file, not just the first.
 use super::snapshot_full::rename_changeset_files_to_header;
 
 /// Arbitrum One chain id.
@@ -804,9 +803,7 @@ fn parse_header_record(
             .next()
             .ok_or_else(|| eyre::eyre!("{tag}: missing number at line {line_number}"))?
             .parse()
-            .map_err(|error| {
-                eyre::eyre!("{tag}: bad number at line {line_number}: {error}")
-            })?;
+            .map_err(|error| eyre::eyre!("{tag}: bad number at line {line_number}: {error}"))?;
         let encoded = hex::decode(
             parts
                 .next()
@@ -1721,11 +1718,8 @@ mod tests {
     fn snapshot_identity_binds_export_header_and_state_root() {
         let head = canonical_test_head();
         assert_eq!(
-            validate_snapshot_identity(
-                arb_reth_genesis::arbitrum_one::GENESIS_STATE_ROOT,
-                &head,
-            )
-            .unwrap(),
+            validate_snapshot_identity(arb_reth_genesis::arbitrum_one::GENESIS_STATE_ROOT, &head,)
+                .unwrap(),
             SnapshotPreimagePolicy::CanonicalGenesisRequired
         );
 

--- a/crates/arb-reth-node/src/commands/snapshot.rs
+++ b/crates/arb-reth-node/src/commands/snapshot.rs
@@ -134,7 +134,7 @@ type ArbNodeTypesWithDB = NodeTypesWithDBAdapter<ArbNode, reth_db::DatabaseEnv>;
 /// Number of preimages sorted and inserted in one auxiliary MDBX transaction.
 const PREIMAGE_BATCH_SIZE: usize = 250_000;
 
-const SNAPSHOT_IMPORT_MANIFEST_FILE: &str = "snapshot-import.json";
+pub(crate) const SNAPSHOT_IMPORT_MANIFEST_FILE: &str = "snapshot-import.json";
 const SNAPSHOT_IMPORT_MANIFEST_VERSION: u64 = 1;
 
 #[derive(Clone, Copy, Debug, serde::Deserialize, serde::Serialize)]

--- a/crates/arb-reth-node/src/commands/snapshot.rs
+++ b/crates/arb-reth-node/src/commands/snapshot.rs
@@ -556,7 +556,7 @@ fn validate_snapshot_identity(
     Ok(SnapshotPreimagePolicy::CanonicalGenesisRequired)
 }
 
-fn write_snapshot_import_manifest(
+pub(crate) fn write_snapshot_import_manifest(
     out: &Path,
     head: &(u64, B256, Header),
 ) -> eyre::Result<()> {

--- a/crates/arb-reth-node/src/commands/snapshot.rs
+++ b/crates/arb-reth-node/src/commands/snapshot.rs
@@ -732,40 +732,12 @@ pub fn repair_history(args: SnapshotRepairHistoryArgs) -> eyre::Result<()> {
     Ok(())
 }
 
-/// Rename the changeset static-file segments so their on-disk name matches the `expected_block_range`
-/// recorded in their header. The import creates them in the fixed 500k slot (e.g. `_22000000_…`) and
-/// then `set_expected_block_start(head)` shifts the header's expected start to `head`; reth resolves
-/// the file path from the header's expected range, so the name must agree or reads miss the file.
-/// Idempotent: only renames when the name doesn't already match the header.
-fn rename_changeset_files_to_header(static_files: &std::path::Path) -> eyre::Result<()> {
-    for seg in ["account-change-sets", "storage-change-sets"] {
-        let prefix = format!("static_file_{seg}_");
-        let data_name = std::fs::read_dir(static_files)?
-            .filter_map(|e| e.ok())
-            .map(|e| e.file_name().to_string_lossy().into_owned())
-            .find(|n| n.starts_with(&prefix) && !n.contains('.'));
-        let Some(data_name) = data_name else { continue };
-        let conf = std::fs::read(static_files.join(format!("{data_name}.conf")))?;
-        if conf.len() < 24 {
-            continue;
-        }
-        let exp_start = u64::from_le_bytes(conf[8..16].try_into().unwrap());
-        let exp_end = u64::from_le_bytes(conf[16..24].try_into().unwrap());
-        let want = format!("static_file_{seg}_{exp_start}_{exp_end}");
-        if data_name == want {
-            continue; // already matches header
-        }
-        for ext in ["", ".conf", ".off", ".csoff"] {
-            let src = static_files.join(format!("{data_name}{ext}"));
-            let dst = static_files.join(format!("{want}{ext}"));
-            if src.exists() && src != dst {
-                std::fs::rename(&src, &dst)?;
-            }
-        }
-        tracing::info!(seg, from = %data_name, to = %want, "renamed changeset file to match header expected range");
-    }
-    Ok(())
-}
+/// Rename the changeset static-file segments so their on-disk name matches the
+/// `expected_block_range` recorded in their header, which is what reth resolves their path from.
+///
+/// Shared with the full-snapshot importer, which hit the same hazard over ~55 files per segment
+/// rather than one. That implementation checks every file, so it covers this caller too.
+use super::snapshot_full::rename_changeset_files_to_header;
 
 /// Arbitrum One chain id.
 const ARB_ONE_CHAIN_ID: u64 = 42161;

--- a/crates/arb-reth-node/src/commands/snapshot_full.rs
+++ b/crates/arb-reth-node/src/commands/snapshot_full.rs
@@ -55,7 +55,7 @@ use reth_storage_api::{BlockBodyIndicesProvider, StageCheckpointWriter};
 use reth_tasks::Runtime;
 use reth_tracing::tracing::info;
 
-use crate::{ArbNode, stored_receipt::decode_stored_receipts};
+use crate::{ArbNode, L1ResumeCheckpoint, L1ResumeLog, stored_receipt::decode_stored_receipts};
 
 type ArbNodeTypesWithDB = NodeTypesWithDBAdapter<ArbNode, reth_db::DatabaseEnv>;
 
@@ -183,6 +183,7 @@ pub fn finalize_datadir(args: SnapshotFinalizeArgs) -> eyre::Result<()> {
         root: head.state_root,
         state_id: 0,
         hash: head.hash(),
+        resume: None,
     };
     drop(provider);
 
@@ -411,6 +412,8 @@ fn finalize<DB: SnapshotDb>(
         .commit()
         .map_err(|error| eyre::eyre!("commit finalisation: {error}"))?;
 
+    write_resume_log(manifest, out)?;
+
     // Last, and only once everything above held. Without it the node refuses to boot, so a run that
     // dies anywhere earlier leaves a datadir that cannot be mistaken for a finished one.
     super::snapshot::write_snapshot_import_manifest(
@@ -463,6 +466,50 @@ where
         info!(target: "arb-snapshot", stage = what, at = output.checkpoint.block_number, "building index");
     }
     info!(target: "arb-snapshot", stage = what, elapsed = ?started.elapsed(), "index built");
+    Ok(())
+}
+
+/// Give the node its L1-derivation cursor, so it does not re-derive from batch 0.
+///
+/// Nothing in the L2 state says where derivation left off, so without this the node falls back to
+/// re-deriving the whole chain: on Robinhood that was 685,718 parent-chain blocks of `getLogs` and
+/// blob fetches, every result discarded, before a single new block. The exporter reads the answer
+/// out of the snapshot's own `arbitrumdata` and carries it in the manifest.
+fn write_resume_log(manifest: &Manifest, out: &std::path::Path) -> eyre::Result<()> {
+    let Some(resume) = manifest.resume else {
+        info!(
+            target: "arb-snapshot",
+            "the stream carries no resume point, so the node will re-derive from batch 0; \
+             re-export with --arbitrumdata to avoid that"
+        );
+        return Ok(());
+    };
+    // The boundary sits at or below the convert point, never above it: derivation would otherwise
+    // start after blocks the datadir does not have and leave a gap.
+    if resume.l2_block > manifest.block {
+        return Err(eyre::eyre!(
+            "resume point names L2 block {}, above the convert point {}",
+            resume.l2_block,
+            manifest.block
+        ));
+    }
+    let log = L1ResumeLog {
+        checkpoints: vec![L1ResumeCheckpoint {
+            l1_block: resume.l1_block,
+            delayed_count: resume.delayed_count,
+            l2_block: resume.l2_block,
+        }],
+    };
+    let path = L1ResumeLog::path_in(out);
+    std::fs::write(&path, serde_json::to_vec(&log)?)
+        .map_err(|error| eyre::eyre!("write {}: {error}", path.display()))?;
+    info!(
+        target: "arb-snapshot",
+        l1_block = resume.l1_block,
+        delayed = resume.delayed_count,
+        l2_block = resume.l2_block,
+        "wrote the L1 derivation resume point"
+    );
     Ok(())
 }
 
@@ -1359,6 +1406,7 @@ mod tests {
             root: B256::repeat_byte(0xee),
             state_id: 3,
             hash: hash2,
+            resume: None,
         };
         let bytes = StreamBuilder::new(&manifest)
             .blocks()
@@ -1452,6 +1500,7 @@ mod tests {
             root,
             state_id: 5,
             hash: B256::repeat_byte(0xaa),
+            resume: None,
         })
         .blocks();
         let mut parent = B256::ZERO;
@@ -1467,6 +1516,7 @@ mod tests {
             root,
             state_id: 5,
             hash: parent,
+            resume: None,
         };
 
         let objects = vec![
@@ -1619,6 +1669,76 @@ mod tests {
         (bytes, manifest)
     }
 
+    /// A stream carrying a resume point must leave the node able to skip re-deriving the whole
+    /// chain. Without this the conversion is correct but unusable: the node re-derives from batch 0,
+    /// which on a real chain is hundreds of thousands of L1 blocks fetched and discarded.
+    #[test]
+    fn a_resume_point_in_the_stream_becomes_the_node_s_derivation_cursor() {
+        let factory = v2_factory();
+        let root = B256::repeat_byte(0xee);
+        let (bytes, mut manifest) = full_stream(root);
+        // Rebuild the stream with a resume point in its manifest.
+        manifest.resume = Some(arb_reth_genesis::snapshot_stream::ResumePoint {
+            l1_block: 25_679_956,
+            delayed_count: 91_588,
+            l2_block: 3,
+        });
+        let _ = bytes;
+        let mut rebuilt = StreamBuilder::new(&manifest).blocks();
+        let mut parent = B256::ZERO;
+        for number in 0..=4u64 {
+            let h = header(number, parent, &[], &[]);
+            parent = h.hash_slow();
+            rebuilt = rebuilt
+                .header(number, &alloy_rlp::encode(&h))
+                .body(number, &body_rlp(&[]));
+        }
+        let bytes = rebuilt
+            .end_section()
+            .history_section()
+            .end_section()
+            .state()
+            .account(keccak256(ACCOUNT_A), 1, U256::from(1u64), None)
+            .end_section()
+            .finish();
+
+        let mut stream = SnapshotStream::open(bytes.as_slice()).unwrap();
+        assert_eq!(stream.manifest().resume, manifest.resume);
+        write_blocks(&factory, &mut stream, &manifest).unwrap();
+
+        let out = tempfile::tempdir().unwrap();
+        write_resume_log(&manifest, out.path()).unwrap();
+
+        let log = L1ResumeLog::load(&L1ResumeLog::path_in(out.path())).expect("resume log");
+        assert_eq!(log.checkpoints.len(), 1);
+        assert_eq!(log.checkpoints[0].l1_block, 25_679_956);
+        assert_eq!(log.checkpoints[0].delayed_count, 91_588);
+        // The node resolves it for its own tip, which is what makes a non-boundary convert point work.
+        assert_eq!(log.resume_for(4).map(|c| c.l2_block), Some(3));
+    }
+
+    /// A cursor above the convert point would start derivation after blocks the datadir does not
+    /// have, leaving a gap that nothing downstream detects.
+    #[test]
+    fn rejects_a_resume_point_above_the_convert_point() {
+        let out = tempfile::tempdir().unwrap();
+        let manifest = Manifest {
+            block: 100,
+            root: B256::repeat_byte(0xee),
+            state_id: 1,
+            hash: B256::repeat_byte(0xaa),
+            resume: Some(arb_reth_genesis::snapshot_stream::ResumePoint {
+                l1_block: 5,
+                delayed_count: 0,
+                l2_block: 101,
+            }),
+        };
+        let error = write_resume_log(&manifest, out.path())
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("above the convert point"), "{error}");
+    }
+
     /// `S_lo` has to come back out of the datadir for finalisation to be re-runnable on its own,
     /// and the sidecars share the segment prefix, so they must not be mistaken for segments.
     #[test]
@@ -1719,6 +1839,9 @@ mod tests {
 
         // The completion manifest is written last and only on success.
         assert!(out.path().join("snapshot-import.json").is_file());
+
+        // Absent from this stream, so no cursor is written and the node falls back to batch 0.
+        assert!(!out.path().join("arb-l1-resume.json").is_file());
     }
 
     /// The whole conversion, end to end: every section written, then the trie built over the
@@ -1787,6 +1910,7 @@ mod tests {
             root: B256::repeat_byte(0xee),
             state_id: 1,
             hash: B256::repeat_byte(0xaa),
+            resume: None,
         };
         let bytes = StreamBuilder::new(&manifest)
             .blocks()
@@ -1909,6 +2033,7 @@ mod tests {
             root: B256::repeat_byte(0xee),
             state_id: 1,
             hash: h0.hash_slow(),
+            resume: None,
         };
         // The header commits to no transactions; the body carries two.
         let bytes = StreamBuilder::new(&manifest)
@@ -1943,6 +2068,7 @@ mod tests {
             root: B256::repeat_byte(0xee),
             state_id: 1,
             hash: h0.hash_slow(),
+            resume: None,
         };
         let bytes = StreamBuilder::new(&manifest)
             .blocks()
@@ -1979,6 +2105,7 @@ mod tests {
             root: B256::repeat_byte(0xee),
             state_id: 8,
             hash: B256::repeat_byte(0xaa),
+            resume: None,
         };
         let bytes = StreamBuilder::new(&manifest)
             .blocks()

--- a/crates/arb-reth-node/src/commands/snapshot_full.rs
+++ b/crates/arb-reth-node/src/commands/snapshot_full.rs
@@ -114,6 +114,128 @@ pub struct SnapshotImportFullArgs {
     genesis_json: PathBuf,
 }
 
+/// Finish a datadir whose sections were imported but which never reached finalisation.
+#[derive(Debug, Parser)]
+#[command(
+    name = "arb-snapshot-finalize",
+    about = "Finish a converted datadir that stopped after its state root"
+)]
+pub struct SnapshotFinalizeArgs {
+    /// Datadir produced by an `import-full` run that did not complete.
+    #[arg(long, value_name = "DIR")]
+    datadir: PathBuf,
+
+    /// Nitro `chaininfo.json` for the chain the snapshot came from.
+    #[arg(long = "chain-info", value_name = "PATH")]
+    chain_info: PathBuf,
+
+    /// Nitro `genesis.json` for the same chain.
+    #[arg(long = "genesis", value_name = "PATH")]
+    genesis_json: PathBuf,
+}
+
+/// Finish a datadir that was imported up to its state root but never finalised.
+///
+/// The sections take most of an hour on a real chain and finalisation is the last and longest step,
+/// so making it re-runnable on its own is the difference between losing an afternoon and losing a
+/// few minutes. Everything it needs is recoverable from the datadir: the convert point is the
+/// highest header, its root and hash come from that header, and `S_lo` is where the changeset
+/// segments begin.
+pub fn finalize_datadir(args: SnapshotFinalizeArgs) -> eyre::Result<()> {
+    let manifest_path = args
+        .datadir
+        .join(super::snapshot::SNAPSHOT_IMPORT_MANIFEST_FILE);
+    if manifest_path.exists() {
+        return Err(eyre::eyre!(
+            "{} is already finished; its completion manifest is at {}",
+            args.datadir.display(),
+            manifest_path.display()
+        ));
+    }
+
+    let static_files_path = args.datadir.join("static_files");
+    let history_from = lowest_changeset_block(&static_files_path)?;
+
+    let chain_info = std::fs::read(&args.chain_info)
+        .map_err(|error| eyre::eyre!("read {}: {error}", args.chain_info.display()))?;
+    let genesis = std::fs::read(&args.genesis_json)
+        .map_err(|error| eyre::eyre!("read {}: {error}", args.genesis_json.display()))?;
+    let (chain_spec, _init, _info) = crate::orbit_chain_from_files(&chain_info, &genesis)?;
+
+    let factory = open_factory(
+        &args.datadir.join("db"),
+        &static_files_path,
+        &args.datadir.join("rocksdb"),
+        Arc::new(chain_spec),
+    )?;
+
+    // The convert point is wherever the blocks section stopped, and its header carries the root the
+    // trie was already checked against.
+    let provider = factory.provider()?;
+    let block = provider
+        .static_file_provider()
+        .get_highest_static_file_block(StaticFileSegment::Headers)
+        .ok_or_else(|| eyre::eyre!("no headers in {}", args.datadir.display()))?;
+    let head = reth_storage_api::HeaderProvider::sealed_header(&provider, block)?
+        .ok_or_else(|| eyre::eyre!("block {block} is missing its header"))?;
+    let manifest = Manifest {
+        block,
+        root: head.state_root,
+        state_id: 0,
+        hash: head.hash(),
+    };
+    drop(provider);
+
+    info!(
+        target: "arb-snapshot",
+        block,
+        root = %manifest.root,
+        history_from,
+        "finishing a datadir that stopped after its state root"
+    );
+
+    finalize(&factory, &manifest, history_from, &args.datadir)?;
+    println!(
+        "finished {} at block {block} root {:#x}",
+        args.datadir.display(),
+        manifest.root
+    );
+    Ok(())
+}
+
+/// `S_lo`, read from where the account-changeset segments begin.
+///
+/// reth resolves a segment's path from the block range in its name, and the import renames those
+/// files to agree with their headers, so the lowest name is the lowest block with history.
+fn lowest_changeset_block(static_files: &std::path::Path) -> eyre::Result<u64> {
+    const PREFIX: &str = "static_file_account-change-sets_";
+    let mut lowest: Option<u64> = None;
+    for entry in std::fs::read_dir(static_files)
+        .map_err(|error| eyre::eyre!("read {}: {error}", static_files.display()))?
+    {
+        let name = entry?.file_name().to_string_lossy().into_owned();
+        let Some(range) = name.strip_prefix(PREFIX) else {
+            continue;
+        };
+        // Skip the sidecars, which share the prefix but carry an extension.
+        if range.contains('.') {
+            continue;
+        }
+        let Some((start, _)) = range.split_once('_') else {
+            continue;
+        };
+        if let Ok(start) = start.parse::<u64>() {
+            lowest = Some(lowest.map_or(start, |current: u64| current.min(start)));
+        }
+    }
+    lowest.ok_or_else(|| {
+        eyre::eyre!(
+            "no account-changeset segments in {}; this datadir has no state history to finish",
+            static_files.display()
+        )
+    })
+}
+
 /// What a section wrote, for the run's summary and for cross-checking against the exporter's own
 /// counts.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
@@ -1495,6 +1617,30 @@ mod tests {
             .end_section()
             .finish();
         (bytes, manifest)
+    }
+
+    /// `S_lo` has to come back out of the datadir for finalisation to be re-runnable on its own,
+    /// and the sidecars share the segment prefix, so they must not be mistaken for segments.
+    #[test]
+    fn reads_the_history_floor_back_from_the_changeset_segments() {
+        let dir = tempfile::tempdir().unwrap();
+        for name in [
+            "static_file_account-change-sets_1_499999",
+            "static_file_account-change-sets_1_499999.conf",
+            "static_file_account-change-sets_1_499999.csoff",
+            "static_file_account-change-sets_500000_999999",
+            "static_file_storage-change-sets_1_499999",
+            "static_file_headers_0_499999",
+        ] {
+            std::fs::write(dir.path().join(name), []).unwrap();
+        }
+        assert_eq!(lowest_changeset_block(dir.path()).unwrap(), 1);
+
+        let empty = tempfile::tempdir().unwrap();
+        let error = lowest_changeset_block(empty.path())
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("no state history to finish"), "{error}");
     }
 
     /// Finalisation on top of a converted datadir: reth's own stages build the indices from what

--- a/crates/arb-reth-node/src/commands/snapshot_full.rs
+++ b/crates/arb-reth-node/src/commands/snapshot_full.rs
@@ -24,13 +24,19 @@ use alloy_consensus::{
 };
 use alloy_primitives::B256;
 use alloy_rlp::Decodable;
-use arb_reth_genesis::snapshot_stream::{Manifest, Record, SnapshotStream};
+use arb_reth_genesis::snapshot_stream::{HistoryObject, Manifest, Record, SnapshotStream};
 use arbitrum_alloy_consensus::reth::ArbBlockBody;
 use clap::Parser;
 use reth_chainspec::ChainSpec;
 use reth_db::{ClientVersion, init_db, mdbx::DatabaseArguments};
-use reth_db_api::{database::Database, models::StorageSettings, tables, transaction::DbTxMut};
+use reth_db_api::{
+    database::Database,
+    models::{AccountBeforeTx, StorageBeforeTx, StorageSettings},
+    tables,
+    transaction::DbTxMut,
+};
 use reth_node_types::NodeTypesWithDBAdapter;
+use reth_primitives_traits::Account;
 use reth_provider::{
     BlockWriter, DBProvider, DatabaseProviderFactory, EitherWriter, MetadataWriter,
     ProviderFactory, StaticFileProviderFactory, StaticFileWriter, StorageSettingsCache,
@@ -68,6 +74,10 @@ const BLOCK_BATCH: usize = 4_000;
 /// Transactions accumulated before committing early, for chains whose blocks are much fuller than
 /// Arbitrum's average of roughly one transaction each.
 const TX_BATCH: usize = 50_000;
+
+/// Changeset entries (accounts plus slots) accumulated before a commit. Blocks are batched by
+/// entries rather than by count because a single block's diff can be very large.
+const CHANGESET_BATCH: usize = 250_000;
 
 /// Convert a full-snapshot stream into a reth datadir.
 #[derive(Debug, Parser)]
@@ -146,10 +156,33 @@ pub fn import_full(args: SnapshotImportFullArgs) -> eyre::Result<()> {
         "blocks section imported"
     );
 
+    let history = write_history(&factory, &mut stream, &manifest)?;
+    info!(
+        target: "arb-snapshot",
+        objects = history.objects,
+        accounts = history.accounts,
+        slots = history.slots,
+        range = format!("{}..={}", history.first_block, history.last_block),
+        "state history imported"
+    );
+
+    if history.first_block < blocks.first_block {
+        return Err(eyre::eyre!(
+            "history starts at {} but blocks start at {}; there would be changesets for blocks the \
+             datadir has no header for",
+            history.first_block,
+            blocks.first_block
+        ));
+    }
+
+    drop(factory);
+    rename_changeset_files_to_header(&static_files_path)?;
+
     Err(eyre::eyre!(
-        "the history and state sections are not implemented yet; {} blocks were written but the \
-         datadir is incomplete and has no completion manifest, so it will not boot",
-        blocks.blocks
+        "the state section is not implemented yet; {} blocks and {} history objects were written \
+         but the datadir is incomplete and has no completion manifest, so it will not boot",
+        blocks.blocks,
+        history.objects
     ))
 }
 
@@ -380,7 +413,8 @@ fn flush_blocks<DB: SnapshotDb>(
             }
             *first = false;
         }
-        writer.commit()?;
+        // Not committed here: dropping the writer returns it to the pool, and `provider.commit()`
+        // finalizes static files before RocksDB and MDBX, which is the order reth recovers from.
     }
 
     for block in batch.iter() {
@@ -460,6 +494,218 @@ fn flush_blocks<DB: SnapshotDb>(
     Ok(())
 }
 
+/// What the history section wrote.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct HistorySectionStats {
+    /// History objects, which is the number of blocks that actually changed state.
+    pub objects: u64,
+    /// Blocks given a changeset entry, including the empty ones for blocks that changed nothing.
+    pub blocks: u64,
+    pub accounts: u64,
+    pub slots: u64,
+    /// `S_lo`, the first block with history. Below it, historical state is unavailable.
+    pub first_block: u64,
+    pub last_block: u64,
+}
+
+/// Write the state-history section as reth changesets.
+///
+/// geth's reverse diffs and reth's changesets mean the same thing, the values from before the block,
+/// and this snapshot's history identifies both accounts and storage slots by raw key, so the mapping
+/// is direct.
+///
+/// A block that changed nothing produces no history object, but the changeset segments are indexed
+/// by `block - block_range.start()`, so every block from `S_lo` to `P` still needs an entry. Those
+/// blocks get an empty one, which is also what they mean (ADR-004 D1, S6).
+fn write_history<R: Read, DB: SnapshotDb>(
+    factory: &ProviderFactory<NodeTypesWithDBAdapter<ArbNode, DB>>,
+    stream: &mut SnapshotStream<R>,
+    manifest: &Manifest,
+) -> eyre::Result<HistorySectionStats> {
+    let mut stats = HistorySectionStats::default();
+    let mut batch: Vec<HistoryObject> = Vec::new();
+    let mut batch_entries = 0usize;
+    // The next block the changeset segments expect, so gaps can be filled across batches.
+    let mut cursor: Option<u64> = None;
+
+    loop {
+        match stream.next_record()? {
+            Some(Record::History(object)) => {
+                batch_entries += object
+                    .accounts
+                    .iter()
+                    .map(|a| 1 + a.storage.len())
+                    .sum::<usize>();
+                batch.push(object);
+                if batch_entries >= CHANGESET_BATCH {
+                    flush_history(factory, &mut batch, &mut cursor, &mut stats)?;
+                    batch_entries = 0;
+                }
+            }
+            other => {
+                flush_history(factory, &mut batch, &mut cursor, &mut stats)?;
+                if let Some(record) = other {
+                    stream.unread(record);
+                }
+                break;
+            }
+        }
+    }
+
+    if stats.objects == 0 {
+        return Err(eyre::eyre!("the stream's history section is empty"));
+    }
+    // The last object's post root is the state the state section is about to describe, and the
+    // reader has already checked the chain of roots that leads to it (ADR-004 S2, S3).
+    stream.check_history_meets_state()?;
+
+    // Nothing above `P` may carry a changeset, or an unwind would walk into a block whose state the
+    // datadir does not have.
+    if stats.last_block != manifest.block {
+        return Err(eyre::eyre!(
+            "history ends at {}, but the convert point is {}",
+            stats.last_block,
+            manifest.block
+        ));
+    }
+    Ok(stats)
+}
+
+fn flush_history<DB: SnapshotDb>(
+    factory: &ProviderFactory<NodeTypesWithDBAdapter<ArbNode, DB>>,
+    batch: &mut Vec<HistoryObject>,
+    cursor: &mut Option<u64>,
+    stats: &mut HistorySectionStats,
+) -> eyre::Result<()> {
+    if batch.is_empty() {
+        return Ok(());
+    }
+    let provider = factory.database_provider_rw()?;
+    let from_block = cursor.unwrap_or(batch[0].block);
+
+    if cursor.is_none() {
+        // The segments would otherwise start at their 500k file boundary, so the first block with
+        // history would be written at the wrong offset and every read after it shifted. The files
+        // are renamed to match once the import is done, since reth resolves their path from this.
+        stats.first_block = from_block;
+        let sfp = provider.static_file_provider();
+        for segment in [
+            StaticFileSegment::AccountChangeSets,
+            StaticFileSegment::StorageChangeSets,
+        ] {
+            sfp.get_writer(from_block, segment)?
+                .user_header_mut()
+                .set_expected_block_start(from_block);
+        }
+    }
+
+    let mut accounts_writer = EitherWriter::new_account_changesets(&provider, from_block)?;
+    let mut storage_writer = EitherWriter::new_storage_changesets(&provider, from_block)?;
+    let mut at = from_block;
+
+    for object in batch.iter() {
+        if object.block < at {
+            return Err(eyre::eyre!(
+                "history object at block {} is at or below the previous one ({})",
+                object.block,
+                at.saturating_sub(1)
+            ));
+        }
+        // Blocks between two objects changed no state, so their changeset is empty.
+        for empty in at..object.block {
+            accounts_writer.append_account_changeset(empty, Vec::new())?;
+            storage_writer.append_storage_changeset(empty, Vec::new())?;
+            stats.blocks += 1;
+        }
+
+        let mut accounts = Vec::with_capacity(object.accounts.len());
+        let mut slots = Vec::new();
+        for account in &object.accounts {
+            accounts.push(AccountBeforeTx {
+                address: account.address,
+                info: account
+                    .previous
+                    .map(|(nonce, balance, bytecode_hash)| Account {
+                        nonce,
+                        balance,
+                        bytecode_hash,
+                    }),
+            });
+            for (key, value) in &account.storage {
+                slots.push(StorageBeforeTx {
+                    address: account.address,
+                    key: *key,
+                    value: *value,
+                });
+            }
+        }
+        stats.accounts += accounts.len() as u64;
+        stats.slots += slots.len() as u64;
+        accounts_writer.append_account_changeset(object.block, accounts)?;
+        storage_writer.append_storage_changeset(object.block, slots)?;
+
+        stats.objects += 1;
+        stats.blocks += 1;
+        stats.last_block = object.block;
+        at = object.block + 1;
+    }
+
+    drop(accounts_writer);
+    drop(storage_writer);
+    *cursor = Some(at);
+    provider
+        .commit()
+        .map_err(|error| eyre::eyre!("commit history up to {}: {error}", at - 1))?;
+    batch.clear();
+    info!(
+        target: "arb-snapshot",
+        objects = stats.objects,
+        accounts = stats.accounts,
+        slots = stats.slots,
+        at = at - 1,
+        "wrote state history"
+    );
+    Ok(())
+}
+
+/// Rename changeset static files whose name disagrees with the expected range in their header.
+///
+/// reth resolves a segment file's path from that range, and the first changeset file's start was
+/// moved to `S_lo` after it was created in its fixed 500k slot, so its name is stale. Every other
+/// file already agrees; this checks them all rather than assuming which one moved.
+fn rename_changeset_files_to_header(static_files: &std::path::Path) -> eyre::Result<()> {
+    for segment in ["account-change-sets", "storage-change-sets"] {
+        let prefix = format!("static_file_{segment}_");
+        let names: Vec<String> = std::fs::read_dir(static_files)?
+            .filter_map(Result::ok)
+            .map(|entry| entry.file_name().to_string_lossy().into_owned())
+            .filter(|name| name.starts_with(&prefix) && !name.contains('.'))
+            .collect();
+
+        for name in names {
+            let conf = std::fs::read(static_files.join(format!("{name}.conf")))?;
+            if conf.len() < 24 {
+                continue;
+            }
+            let start = u64::from_le_bytes(conf[8..16].try_into().expect("8 bytes"));
+            let end = u64::from_le_bytes(conf[16..24].try_into().expect("8 bytes"));
+            let want = format!("static_file_{segment}_{start}_{end}");
+            if name == want {
+                continue;
+            }
+            for extension in ["", ".conf", ".off", ".csoff"] {
+                let from = static_files.join(format!("{name}{extension}"));
+                let to = static_files.join(format!("{want}{extension}"));
+                if from.exists() && from != to {
+                    std::fs::rename(&from, &to)?;
+                }
+            }
+            info!(target: "arb-snapshot", segment, from = %name, to = %want, "renamed changeset file to match its header");
+        }
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use alloy_consensus::{Eip658Value, Receipt, ReceiptWithBloom, TxEip1559};
@@ -468,15 +714,35 @@ mod tests {
         Bytes, Log, LogData, Signature, TxKind, U256, address, b256, logs_bloom,
     };
     use alloy_rlp::Encodable;
+    use arb_reth_genesis::snapshot_stream::{HistoryAccount, HistoryObject};
     use arb_reth_genesis::snapshot_stream::{Manifest, StreamBuilder};
     use arbitrum_alloy_consensus::{
         receipt::{ArbReceipt, ArbReceiptEnvelope},
         transactions::{ArbTxEnvelope, deposit::TxDeposit},
     };
     use reth_provider::test_utils::create_test_provider_factory_with_node_types;
-    use reth_storage_api::{ReceiptProvider, TransactionsProvider};
+    use reth_storage_api::{
+        ChangeSetReader, ReceiptProvider, StorageChangeSetReader, TransactionsProvider,
+    };
 
     use super::*;
+
+    /// A factory over a temporary MDBX, static files and RocksDB, in storage v2 like the import.
+    fn v2_factory() -> reth_provider::ProviderFactory<
+        NodeTypesWithDBAdapter<
+            ArbNode,
+            Arc<reth_db::test_utils::TempDatabase<reth_db::DatabaseEnv>>,
+        >,
+    > {
+        let factory = create_test_provider_factory_with_node_types::<ArbNode>(spec());
+        factory.set_storage_settings_cache(StorageSettings::v2());
+        let provider = factory.database_provider_rw().unwrap();
+        provider
+            .write_storage_settings(StorageSettings::v2())
+            .unwrap();
+        provider.commit().unwrap();
+        factory
+    }
 
     fn spec() -> Arc<ChainSpec> {
         use arb_revm::arbos_init::ArbosInitConfig;
@@ -741,6 +1007,237 @@ mod tests {
                 .is_empty(),
             "an empty block keeps an empty receipt list, not a missing one"
         );
+    }
+
+    const ACCOUNT_A: alloy_primitives::Address =
+        address!("00000000000000000000000000000000000000a1");
+    const ACCOUNT_B: alloy_primitives::Address =
+        address!("00000000000000000000000000000000000000b2");
+
+    /// Blocks 0..=4 with history at 2 and 4 only. That covers the three cases the writer has to get
+    /// right: history starting above the chain's first block, a block in between that changed
+    /// nothing, and history ending exactly at the convert point.
+    fn history_stream(root: B256) -> (Vec<u8>, Manifest, Vec<HistoryObject>) {
+        let mut builder = StreamBuilder::new(&Manifest {
+            block: 4,
+            root,
+            state_id: 5,
+            hash: B256::repeat_byte(0xaa),
+        })
+        .blocks();
+        let mut parent = B256::ZERO;
+        for number in 0..=4u64 {
+            let h = header(number, parent, &[], &[]);
+            parent = h.hash_slow();
+            builder = builder
+                .header(number, &alloy_rlp::encode(&h))
+                .body(number, &body_rlp(&[]));
+        }
+        let manifest = Manifest {
+            block: 4,
+            root,
+            state_id: 5,
+            hash: parent,
+        };
+
+        let objects = vec![
+            HistoryObject {
+                state_id: 3,
+                block: 2,
+                parent_root: B256::repeat_byte(0x11),
+                post_root: B256::repeat_byte(0x22),
+                accounts: vec![
+                    HistoryAccount {
+                        address: ACCOUNT_A,
+                        previous: Some((7, U256::from(1234u64), Some(B256::repeat_byte(0x9)))),
+                        storage: vec![
+                            (B256::repeat_byte(0x01), U256::from(5u64)),
+                            (B256::repeat_byte(0x02), U256::ZERO),
+                        ],
+                    },
+                    // Did not exist before this block.
+                    HistoryAccount {
+                        address: ACCOUNT_B,
+                        previous: None,
+                        storage: vec![],
+                    },
+                ],
+            },
+            HistoryObject {
+                state_id: 5,
+                block: 4,
+                parent_root: B256::repeat_byte(0x22),
+                post_root: root,
+                accounts: vec![HistoryAccount {
+                    address: ACCOUNT_B,
+                    previous: Some((1, U256::from(9u64), None)),
+                    storage: vec![(B256::repeat_byte(0x03), U256::from(77u64))],
+                }],
+            },
+        ];
+
+        let mut builder = builder.end_section().history_section();
+        for object in &objects {
+            builder = builder.history(object);
+        }
+        let bytes = builder.end_section().state().end_section().finish();
+        (bytes, manifest, objects)
+    }
+
+    #[test]
+    fn writes_state_history_as_changesets_reth_can_read() {
+        let factory = v2_factory();
+        let root = B256::repeat_byte(0xee);
+        let (bytes, manifest, objects) = history_stream(root);
+
+        let mut stream = SnapshotStream::open(bytes.as_slice()).unwrap();
+        write_blocks(&factory, &mut stream, &manifest).unwrap();
+        let stats = write_history(&factory, &mut stream, &manifest).unwrap();
+
+        assert_eq!(stats.objects, 2);
+        assert_eq!(stats.accounts, 3);
+        assert_eq!(stats.slots, 3);
+        // Blocks 2, 3 and 4 all get an entry; block 3 changed nothing so its entry is empty.
+        assert_eq!(stats.blocks, 3);
+        assert_eq!((stats.first_block, stats.last_block), (2, 4));
+
+        let provider = factory.provider().unwrap();
+
+        let changed = provider.account_block_changeset(2).unwrap();
+        assert_eq!(
+            changed,
+            vec![
+                AccountBeforeTx {
+                    address: ACCOUNT_A,
+                    info: Some(Account {
+                        nonce: 7,
+                        balance: U256::from(1234u64),
+                        bytecode_hash: Some(B256::repeat_byte(0x9)),
+                    }),
+                },
+                AccountBeforeTx {
+                    address: ACCOUNT_B,
+                    info: None,
+                },
+            ],
+            "pre-block values, with a missing account kept as missing"
+        );
+
+        let slots = provider.storage_changeset(2).unwrap();
+        assert_eq!(slots.len(), 2);
+        assert_eq!(slots[0].0.address(), ACCOUNT_A);
+        assert_eq!(slots[0].1.key, B256::repeat_byte(0x01));
+        assert_eq!(slots[0].1.value, U256::from(5u64));
+        // A slot that was zero before the block is still a change, and has to stay in the set.
+        assert_eq!(slots[1].1.key, B256::repeat_byte(0x02));
+        assert_eq!(slots[1].1.value, U256::ZERO);
+
+        assert!(
+            provider.account_block_changeset(3).unwrap().is_empty(),
+            "a block that changed nothing has an empty changeset, not a missing one"
+        );
+        assert!(provider.storage_changeset(3).unwrap().is_empty());
+
+        assert_eq!(
+            provider.account_block_changeset(4).unwrap(),
+            vec![AccountBeforeTx {
+                address: ACCOUNT_B,
+                info: Some(Account {
+                    nonce: 1,
+                    balance: U256::from(9u64),
+                    bytecode_hash: None,
+                }),
+            }]
+        );
+        assert_eq!(objects[1].post_root, root);
+    }
+
+    /// The first changeset file is created in its fixed 500k slot and then has its expected start
+    /// moved to `S_lo`, so its name no longer matches the range reth resolves paths from. Until it
+    /// is renamed, a freshly opened provider cannot find it at all.
+    #[test]
+    fn renaming_makes_the_changeset_files_findable_by_a_fresh_provider() {
+        let factory = v2_factory();
+        let root = B256::repeat_byte(0xee);
+        let (bytes, manifest, _) = history_stream(root);
+
+        let mut stream = SnapshotStream::open(bytes.as_slice()).unwrap();
+        write_blocks(&factory, &mut stream, &manifest).unwrap();
+        write_history(&factory, &mut stream, &manifest).unwrap();
+
+        let directory = factory.static_file_provider().directory().to_path_buf();
+        let names = |dir: &std::path::Path| -> Vec<String> {
+            let mut found: Vec<String> = std::fs::read_dir(dir)
+                .unwrap()
+                .filter_map(Result::ok)
+                .map(|e| e.file_name().to_string_lossy().into_owned())
+                .filter(|n| n.starts_with("static_file_account-change-sets_") && !n.contains('.'))
+                .collect();
+            found.sort();
+            found
+        };
+        assert_eq!(
+            names(&directory),
+            vec!["static_file_account-change-sets_0_499999".to_string()],
+            "created in the fixed slot, while its header now expects to start at 2"
+        );
+
+        rename_changeset_files_to_header(&directory).unwrap();
+        assert_eq!(
+            names(&directory),
+            vec!["static_file_account-change-sets_2_499999".to_string()],
+        );
+
+        // A provider that has just opened the directory reads the changesets back at the right
+        // blocks, which is the case the running node is in.
+        let reopened =
+            StaticFileProvider::<<ArbNode as reth_node_types::NodeTypes>::Primitives>::read_only(
+                &directory,
+            )
+            .unwrap();
+        assert_eq!(reopened.account_block_changeset(2).unwrap().len(), 2);
+        assert!(reopened.account_block_changeset(3).unwrap().is_empty());
+        assert_eq!(reopened.account_block_changeset(4).unwrap().len(), 1);
+    }
+
+    /// History has to reach the convert point, or the datadir would claim to unwind to a block
+    /// whose state it cannot reconstruct.
+    #[test]
+    fn rejects_history_that_stops_below_the_convert_point() {
+        let factory = v2_factory();
+        let root = B256::repeat_byte(0xee);
+        let (_, manifest, _) = history_stream(root);
+
+        let mut builder = StreamBuilder::new(&manifest).blocks();
+        let mut parent = B256::ZERO;
+        for number in 0..=4u64 {
+            let h = header(number, parent, &[], &[]);
+            parent = h.hash_slow();
+            builder = builder
+                .header(number, &alloy_rlp::encode(&h))
+                .body(number, &body_rlp(&[]));
+        }
+        let bytes = builder
+            .end_section()
+            .history_section()
+            .history(&HistoryObject {
+                state_id: 3,
+                block: 2,
+                parent_root: B256::repeat_byte(0x11),
+                post_root: root,
+                accounts: vec![],
+            })
+            .end_section()
+            .state()
+            .end_section()
+            .finish();
+
+        let mut stream = SnapshotStream::open(bytes.as_slice()).unwrap();
+        write_blocks(&factory, &mut stream, &manifest).unwrap();
+        let error = write_history(&factory, &mut stream, &manifest)
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("history ends at block 2"), "{error}");
     }
 
     /// The transactions root is recomputed from the decoded transactions, so a body that does not

--- a/crates/arb-reth-node/src/commands/snapshot_full.rs
+++ b/crates/arb-reth-node/src/commands/snapshot_full.rs
@@ -7,9 +7,8 @@
 //! `arb-kb/decisions/ADR-004-snapshot-conversion-invariants.md`; the checks below name the ones they
 //! enforce.
 //!
-//! Nothing here writes the completion manifest, so an interrupted or failed run leaves a datadir the
-//! node refuses to boot. That is deliberate: a partial conversion that boots would answer historical
-//! queries with silence rather than an error.
+//! The completion manifest is written last and only on success, so an interrupted run leaves a
+//! datadir the node refuses to boot rather than one that answers historical queries with silence.
 
 use std::{
     collections::HashSet,
@@ -136,11 +135,9 @@ pub struct SnapshotFinalizeArgs {
 
 /// Finish a datadir that was imported up to its state root but never finalised.
 ///
-/// The sections take most of an hour on a real chain and finalisation is the last and longest step,
-/// so making it re-runnable on its own is the difference between losing an afternoon and losing a
-/// few minutes. Everything it needs is recoverable from the datadir: the convert point is the
-/// highest header, its root and hash come from that header, and `S_lo` is where the changeset
-/// segments begin.
+/// Separately runnable so a failure in the last step does not force a re-import. Everything it
+/// needs comes back out of the datadir: the convert point is the highest header, its root and hash
+/// come from that header, and `S_lo` is where the changeset segments begin.
 pub fn finalize_datadir(args: SnapshotFinalizeArgs) -> eyre::Result<()> {
     let manifest_path = args
         .datadir
@@ -351,9 +348,8 @@ pub fn import_full(args: SnapshotImportFullArgs) -> eyre::Result<()> {
 /// imported, the checkpoints that say how far it is synced, the boundary below which historical
 /// state is unavailable, and the manifest that marks the conversion complete.
 ///
-/// The indices are built by running reth's own stages rather than by hand. They read exactly the
-/// changesets, bodies and transactions just written, so what they produce is what a forward sync
-/// would have produced, which is the property the whole conversion is trying to hold.
+/// The indices are built by running reth's own stages rather than by hand, so they read exactly the
+/// changesets, bodies and transactions just written and produce what a forward sync would have.
 fn finalize<DB: SnapshotDb>(
     factory: &ProviderFactory<NodeTypesWithDBAdapter<ArbNode, DB>>,
     manifest: &Manifest,
@@ -471,10 +467,9 @@ where
 
 /// Give the node its L1-derivation cursor, so it does not re-derive from batch 0.
 ///
-/// Nothing in the L2 state says where derivation left off, so without this the node falls back to
-/// re-deriving the whole chain: on Robinhood that was 685,718 parent-chain blocks of `getLogs` and
-/// blob fetches, every result discarded, before a single new block. The exporter reads the answer
-/// out of the snapshot's own `arbitrumdata` and carries it in the manifest.
+/// Nothing in L2 state records where derivation left off, so without this the node re-derives from
+/// batch 0: the chain's whole parent-chain range fetched and discarded before one new block. The
+/// exporter reads the answer out of the snapshot's `arbitrumdata` and carries it in the manifest.
 fn write_resume_log(manifest: &Manifest, out: &std::path::Path) -> eyre::Result<()> {
     let Some(resume) = manifest.resume else {
         info!(

--- a/crates/arb-reth-node/src/commands/snapshot_full.rs
+++ b/crates/arb-reth-node/src/commands/snapshot_full.rs
@@ -44,8 +44,14 @@ use reth_provider::{
     ProviderFactory, StaticFileProviderFactory, StaticFileWriter, StorageSettingsCache,
     providers::{RocksDBProvider, StaticFileProvider},
 };
+use reth_prune_types::{PruneCheckpoint, PruneMode, PruneSegment};
+use reth_stages::stages::{
+    IndexAccountHistoryStage, IndexStorageHistoryStage, SenderRecoveryStage, TransactionLookupStage,
+};
+use reth_stages_api::{ExecInput, Stage};
+use reth_stages_types::{StageCheckpoint, StageId};
 use reth_static_file_types::StaticFileSegment;
-use reth_storage_api::BlockBodyIndicesProvider;
+use reth_storage_api::{BlockBodyIndicesProvider, StageCheckpointWriter};
 use reth_tasks::Runtime;
 use reth_tracing::tracing::info;
 
@@ -198,17 +204,170 @@ pub fn import_full(args: SnapshotImportFullArgs) -> eyre::Result<()> {
     }
     info!(target: "arb-snapshot", %root, "state root matches the convert point");
 
-    drop(factory);
+    // The changeset files have to carry their real names before anything reads them back, and the
+    // index stages below do exactly that.
+    factory.static_file_provider().commit()?;
     rename_changeset_files_to_header(&static_files_path)?;
 
-    Err(eyre::eyre!(
-        "the datadir is not finished: stage checkpoints, history indices and the completion \
-         manifest are still to come, so it will not boot ({} blocks, {} history objects, {} \
-         accounts)",
+    finalize(&factory, &manifest, history.first_block, &args.out)?;
+
+    println!(
+        "converted {} blocks ({} transactions, {} receipts), {} history objects, {} accounts at \
+         block {} root {root:#x}",
         blocks.blocks,
+        blocks.transactions,
+        blocks.receipts,
         history.objects,
-        state.accounts
-    ))
+        state.accounts,
+        manifest.block,
+    );
+    Ok(())
+}
+
+/// Everything the datadir needs beyond the data itself: the indices reth derives from what was
+/// imported, the checkpoints that say how far it is synced, the boundary below which historical
+/// state is unavailable, and the manifest that marks the conversion complete.
+///
+/// The indices are built by running reth's own stages rather than by hand. They read exactly the
+/// changesets, bodies and transactions just written, so what they produce is what a forward sync
+/// would have produced, which is the property the whole conversion is trying to hold.
+fn finalize<DB: SnapshotDb>(
+    factory: &ProviderFactory<NodeTypesWithDBAdapter<ArbNode, DB>>,
+    manifest: &Manifest,
+    history_from: u64,
+    out: &std::path::Path,
+) -> eyre::Result<()> {
+    run_stage(
+        factory,
+        SenderRecoveryStage::default(),
+        manifest.block,
+        "sender recovery",
+    )?;
+    run_stage(
+        factory,
+        TransactionLookupStage::default(),
+        manifest.block,
+        "transaction lookup",
+    )?;
+    run_stage(
+        factory,
+        IndexAccountHistoryStage::default(),
+        manifest.block,
+        "account history index",
+    )?;
+    run_stage(
+        factory,
+        IndexStorageHistoryStage::default(),
+        manifest.block,
+        "storage history index",
+    )?;
+
+    let provider = factory.database_provider_rw()?;
+
+    // Read the convert point's header back rather than carrying it here, which also proves the
+    // blocks section actually landed it.
+    let head = reth_storage_api::HeaderProvider::sealed_header(&provider, manifest.block)?
+        .ok_or_else(|| eyre::eyre!("block {} has no header after the import", manifest.block))?;
+    if head.hash() != manifest.hash {
+        return Err(eyre::eyre!(
+            "block {} hashes to {:#x}, but the manifest says {:#x}",
+            manifest.block,
+            head.hash(),
+            manifest.hash
+        ));
+    }
+
+    // Stages must all name the convert point, since reth treats the database as synced only as far
+    // as the lowest of them.
+    let checkpoint = StageCheckpoint::new(manifest.block);
+    for stage in StageId::ALL {
+        provider.save_stage_checkpoint(stage, checkpoint)?;
+    }
+
+    write_history_boundary(&provider, history_from)?;
+    provider
+        .commit()
+        .map_err(|error| eyre::eyre!("commit finalisation: {error}"))?;
+
+    // Last, and only once everything above held. Without it the node refuses to boot, so a run that
+    // dies anywhere earlier leaves a datadir that cannot be mistaken for a finished one.
+    super::snapshot::write_snapshot_import_manifest(
+        out,
+        &(manifest.block, head.hash(), head.header().clone()),
+    )?;
+    Ok(())
+}
+
+/// Drive one of reth's stages to completion over `[.., target]`.
+///
+/// A stage may return before reaching the target when it has done a batch's worth of work, so it is
+/// re-entered from its own checkpoint until it reports done.
+fn run_stage<DB, S>(
+    factory: &ProviderFactory<NodeTypesWithDBAdapter<ArbNode, DB>>,
+    mut stage: S,
+    target: u64,
+    what: &str,
+) -> eyre::Result<()>
+where
+    DB: SnapshotDb,
+    S: Stage<
+        reth_provider::DatabaseProvider<
+            <DB as Database>::TXMut,
+            NodeTypesWithDBAdapter<ArbNode, DB>,
+        >,
+    >,
+{
+    let started = std::time::Instant::now();
+    let mut checkpoint = None;
+    loop {
+        let provider = factory.database_provider_rw()?;
+        let output = stage
+            .execute(
+                &provider,
+                ExecInput {
+                    target: Some(target),
+                    checkpoint,
+                },
+            )
+            .map_err(|error| eyre::eyre!("{what}: {error}"))?;
+        provider
+            .commit()
+            .map_err(|error| eyre::eyre!("{what}: commit: {error}"))?;
+
+        checkpoint = Some(output.checkpoint);
+        if output.done {
+            break;
+        }
+        info!(target: "arb-snapshot", stage = what, at = output.checkpoint.block_number, "building index");
+    }
+    info!(target: "arb-snapshot", stage = what, elapsed = ?started.elapsed(), "index built");
+    Ok(())
+}
+
+/// Record that historical state below `history_from` is unavailable, and nothing else.
+///
+/// The converted datadir has changesets from `S_lo` upward, so a historical lookup below it has no
+/// answer. Marking the missing prefix pruned makes reth fall back rather than infer, for example
+/// reading an imported account as one first created after the snapshot. The existing head-state
+/// importer marks everything below its head, which for a full conversion would be a lie about the
+/// history that is actually present (ADR-004 D4).
+fn write_history_boundary(
+    provider: &impl reth_storage_api::PruneCheckpointWriter,
+    history_from: u64,
+) -> eyre::Result<()> {
+    let Some(last_missing) = history_from.checked_sub(1) else {
+        // History reaches the first block, so nothing is missing.
+        return Ok(());
+    };
+    let checkpoint = PruneCheckpoint {
+        block_number: Some(last_missing),
+        tx_number: None,
+        prune_mode: PruneMode::before_inclusive(last_missing),
+    };
+    for segment in [PruneSegment::AccountHistory, PruneSegment::StorageHistory] {
+        provider.save_prune_checkpoint(segment, checkpoint)?;
+    }
+    Ok(())
 }
 
 fn open_factory(
@@ -869,7 +1028,8 @@ mod tests {
     use reth_db_api::transaction::DbTx;
     use reth_provider::test_utils::create_test_provider_factory_with_node_types;
     use reth_storage_api::{
-        ChangeSetReader, ReceiptProvider, StorageChangeSetReader, TransactionsProvider,
+        ChangeSetReader, PruneCheckpointReader, ReceiptProvider, StageCheckpointReader,
+        StorageChangeSetReader, TransactionsProvider,
     };
 
     use super::*;
@@ -1331,10 +1491,88 @@ mod tests {
             .storage(keccak256(B256::repeat_byte(0x01)), U256::from(5u64))
             // A zero slot is absent from the trie, so it must not reach the database.
             .storage(keccak256(B256::repeat_byte(0x02)), U256::ZERO)
-            .account(keccak256(ACCOUNT_B), 1, U256::from(9u64), None)
+            .account(keccak256(ACCOUNT_B), 3, U256::from(42u64), None)
             .end_section()
             .finish();
         (bytes, manifest)
+    }
+
+    /// Finalisation on top of a converted datadir: reth's own stages build the indices from what
+    /// was imported, the checkpoints say how far it is synced, and the boundary says how far back
+    /// history goes.
+    #[test]
+    fn finalisation_builds_the_indices_and_marks_the_history_boundary() {
+        let factory = v2_factory();
+        let root = B256::repeat_byte(0xee);
+        let (bytes, manifest) = full_stream(root);
+        let mut stream = SnapshotStream::open(bytes.as_slice()).unwrap();
+        write_blocks(&factory, &mut stream, &manifest).unwrap();
+        let history = write_history(&factory, &mut stream, &manifest).unwrap();
+        write_state(&factory, &mut stream).unwrap();
+
+        factory.static_file_provider().commit().unwrap();
+        rename_changeset_files_to_header(factory.static_file_provider().directory()).unwrap();
+
+        let out = tempfile::tempdir().unwrap();
+        finalize(&factory, &manifest, history.first_block, out.path()).unwrap();
+
+        let provider = factory.provider().unwrap();
+
+        // Every stage names the convert point, or reth reads the database as synced to the lowest.
+        for stage in StageId::ALL {
+            assert_eq!(
+                provider
+                    .get_stage_checkpoint(stage)
+                    .unwrap()
+                    .map(|c| c.block_number),
+                Some(manifest.block),
+                "{stage} checkpoint"
+            );
+        }
+
+        // History starts at S_lo = 2, so blocks 0 and 1 are the unavailable prefix and nothing else.
+        for segment in [PruneSegment::AccountHistory, PruneSegment::StorageHistory] {
+            assert_eq!(
+                provider
+                    .get_prune_checkpoint(segment)
+                    .unwrap()
+                    .and_then(|c| c.block_number),
+                Some(history.first_block - 1),
+                "{segment:?} boundary"
+            );
+        }
+
+        drop(provider);
+
+        // The query the whole feature exists for, and the one the head-state importer cannot
+        // answer: account B's balance as of block 3, which only the changesets know. The head
+        // state holds different values, so a lookup that quietly fell through to it would fail
+        // here rather than pass by coincidence.
+        use reth_storage_api::AccountReader;
+        let historical = factory.history_by_block_number(3).unwrap();
+        let before = historical
+            .basic_account(&ACCOUNT_B)
+            .unwrap()
+            .expect("account B at block 3");
+        assert_eq!(
+            (before.nonce, before.balance),
+            (1, U256::from(9u64)),
+            "pre-block-4 values, taken from the changeset"
+        );
+
+        let latest = factory.latest().unwrap();
+        let head = latest
+            .basic_account(&ACCOUNT_B)
+            .unwrap()
+            .expect("account B at head");
+        assert_eq!(
+            (head.nonce, head.balance),
+            (3, U256::from(42u64)),
+            "head state, taken from the state section"
+        );
+
+        // The completion manifest is written last and only on success.
+        assert!(out.path().join("snapshot-import.json").is_file());
     }
 
     /// The whole conversion, end to end: every section written, then the trie built over the

--- a/crates/arb-reth-node/src/commands/snapshot_full.rs
+++ b/crates/arb-reth-node/src/commands/snapshot_full.rs
@@ -1,0 +1,874 @@
+//! `arb-reth snapshot import-full`: turn a `reth-export --mode full-snapshot` stream into a reth
+//! datadir that carries block history and per-block state history, not just head state.
+//!
+//! The stream holds a manifest, then blocks, then state history, then the state trie, all ending at
+//! the same block. Sections are written in that order, which is also append-only order for reth's
+//! static files. Invariants and their reasoning live in
+//! `arb-kb/decisions/ADR-004-snapshot-conversion-invariants.md`; the checks below name the ones they
+//! enforce.
+//!
+//! Nothing here writes the completion manifest, so an interrupted or failed run leaves a datadir the
+//! node refuses to boot. That is deliberate: a partial conversion that boots would answer historical
+//! queries with silence rather than an error.
+
+use std::{
+    fs::File,
+    io::{BufReader, Read},
+    path::PathBuf,
+    sync::Arc,
+};
+
+use alloy_consensus::{
+    Header,
+    proofs::{calculate_receipt_root, calculate_transaction_root},
+};
+use alloy_primitives::B256;
+use alloy_rlp::Decodable;
+use arb_reth_genesis::snapshot_stream::{Manifest, Record, SnapshotStream};
+use arbitrum_alloy_consensus::reth::ArbBlockBody;
+use clap::Parser;
+use reth_chainspec::ChainSpec;
+use reth_db::{ClientVersion, init_db, mdbx::DatabaseArguments};
+use reth_db_api::{database::Database, models::StorageSettings, tables, transaction::DbTxMut};
+use reth_node_types::NodeTypesWithDBAdapter;
+use reth_provider::{
+    BlockWriter, DBProvider, DatabaseProviderFactory, EitherWriter, MetadataWriter,
+    ProviderFactory, StaticFileProviderFactory, StaticFileWriter, StorageSettingsCache,
+    providers::{RocksDBProvider, StaticFileProvider},
+};
+use reth_static_file_types::StaticFileSegment;
+use reth_storage_api::BlockBodyIndicesProvider;
+use reth_tasks::Runtime;
+use reth_tracing::tracing::info;
+
+use crate::{ArbNode, stored_receipt::decode_stored_receipts};
+
+type ArbNodeTypesWithDB = NodeTypesWithDBAdapter<ArbNode, reth_db::DatabaseEnv>;
+
+/// A database a [`ProviderFactory`] can be built over: the real MDBX environment when importing, a
+/// temporary one under test. The section writers are generic over it so the tests exercise the same
+/// code the command runs.
+pub trait SnapshotDb:
+    Database + reth_db_api::database_metrics::DatabaseMetrics + Clone + Unpin + 'static
+{
+}
+
+impl<T> SnapshotDb for T where
+    T: Database + reth_db_api::database_metrics::DatabaseMetrics + Clone + Unpin + 'static
+{
+}
+
+/// Read-ahead over the stream. It is read strictly forward, so a large buffer is all that matters.
+const STREAM_BUFFER: usize = 16 * 1024 * 1024;
+
+/// Blocks accumulated before a database transaction is committed. Bounds dirty-page growth over a
+/// chain of tens of millions of blocks.
+const BLOCK_BATCH: usize = 4_000;
+
+/// Transactions accumulated before committing early, for chains whose blocks are much fuller than
+/// Arbitrum's average of roughly one transaction each.
+const TX_BATCH: usize = 50_000;
+
+/// Convert a full-snapshot stream into a reth datadir.
+#[derive(Debug, Parser)]
+#[command(
+    name = "arb-snapshot-import-full",
+    about = "Convert a reth-export --mode full-snapshot stream into a reth datadir"
+)]
+pub struct SnapshotImportFullArgs {
+    /// Stream produced by `reth-export --mode full-snapshot`.
+    #[arg(long, value_name = "FILE")]
+    stream: PathBuf,
+
+    /// Output datadir. Must be empty; `db`, `static_files` and `rocksdb` are created inside it.
+    #[arg(long, value_name = "DIR")]
+    out: PathBuf,
+
+    /// Nitro `chaininfo.json` for the chain the snapshot came from.
+    #[arg(long = "chain-info", value_name = "PATH")]
+    chain_info: PathBuf,
+
+    /// Nitro `genesis.json` for the same chain.
+    #[arg(long = "genesis", value_name = "PATH")]
+    genesis_json: PathBuf,
+}
+
+/// What a section wrote, for the run's summary and for cross-checking against the exporter's own
+/// counts.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct BlockSectionStats {
+    pub blocks: u64,
+    pub bodies: u64,
+    pub transactions: u64,
+    pub receipt_sets: u64,
+    pub receipts: u64,
+    pub first_block: u64,
+    pub last_block: u64,
+}
+
+pub fn import_full(args: SnapshotImportFullArgs) -> eyre::Result<()> {
+    super::snapshot::ensure_fresh_import_target(&args.out)?;
+
+    let file = File::open(&args.stream)
+        .map_err(|error| eyre::eyre!("open {}: {error}", args.stream.display()))?;
+    let mut stream = SnapshotStream::open(BufReader::with_capacity(STREAM_BUFFER, file))?;
+    let manifest = stream.manifest().clone();
+    info!(
+        target: "arb-snapshot",
+        block = manifest.block,
+        root = %manifest.root,
+        state_id = manifest.state_id,
+        "opened full-snapshot stream"
+    );
+
+    let chain_info = std::fs::read(&args.chain_info)
+        .map_err(|error| eyre::eyre!("read {}: {error}", args.chain_info.display()))?;
+    let genesis = std::fs::read(&args.genesis_json)
+        .map_err(|error| eyre::eyre!("read {}: {error}", args.genesis_json.display()))?;
+    let (chain_spec, _init, _info) = crate::orbit_chain_from_files(&chain_info, &genesis)?;
+    let chain_spec = Arc::new(chain_spec);
+
+    let db_path = args.out.join("db");
+    let static_files_path = args.out.join("static_files");
+    let rocksdb_path = args.out.join("rocksdb");
+    std::fs::create_dir_all(&static_files_path)?;
+    std::fs::create_dir_all(&rocksdb_path)?;
+
+    let factory = open_factory(&db_path, &static_files_path, &rocksdb_path, chain_spec)?;
+
+    let blocks = write_blocks(&factory, &mut stream, &manifest)?;
+    info!(
+        target: "arb-snapshot",
+        blocks = blocks.blocks,
+        transactions = blocks.transactions,
+        receipts = blocks.receipts,
+        range = format!("{}..={}", blocks.first_block, blocks.last_block),
+        "blocks section imported"
+    );
+
+    Err(eyre::eyre!(
+        "the history and state sections are not implemented yet; {} blocks were written but the \
+         datadir is incomplete and has no completion manifest, so it will not boot",
+        blocks.blocks
+    ))
+}
+
+fn open_factory(
+    db_path: &std::path::Path,
+    static_files_path: &std::path::Path,
+    rocksdb_path: &std::path::Path,
+    chain_spec: Arc<ChainSpec>,
+) -> eyre::Result<ProviderFactory<ArbNodeTypesWithDB>> {
+    let db = init_db(db_path, DatabaseArguments::new(ClientVersion::default()))?;
+    let static_file_provider = StaticFileProvider::read_write(static_files_path)?;
+    let rocksdb_provider = RocksDBProvider::builder(rocksdb_path)
+        .with_default_tables()
+        .build()
+        .map_err(|error| eyre::eyre!("RocksDB open error: {error}"))?;
+
+    let factory: ProviderFactory<ArbNodeTypesWithDB> = ProviderFactory::new(
+        db,
+        chain_spec,
+        static_file_provider,
+        rocksdb_provider,
+        Runtime::test(),
+    )
+    .map_err(|error| eyre::eyre!("ProviderFactory::new: {error}"))?;
+
+    // Storage v2 is where changesets live in static files and history indices in RocksDB, which is
+    // what a converted archive datadir needs. Cache it before any write so every provider agrees,
+    // and persist it so the node reads v2 on boot rather than defaulting to v1.
+    factory.set_storage_settings_cache(StorageSettings::v2());
+    let provider_rw = factory.database_provider_rw()?;
+    provider_rw.write_storage_settings(StorageSettings::v2())?;
+    provider_rw
+        .commit()
+        .map_err(|error| eyre::eyre!("persist storage settings: {error}"))?;
+
+    Ok(factory)
+}
+
+/// One block's records, gathered until the next header shows the block is complete.
+struct PendingBlock {
+    number: u64,
+    hash: B256,
+    header: Header,
+    body: Option<ArbBlockBody>,
+    receipts: Option<Vec<arbitrum_alloy_consensus::receipt::ArbReceiptEnvelope>>,
+}
+
+/// Write the blocks section: headers, bodies and receipts for `[B_lo, P]`.
+///
+/// Every block is checked against its own header before it is written (ADR-004 B2). Both roots are
+/// recomputed from the decoded values rather than copied, so a match also proves the decode is
+/// faithful: the transactions re-encode to the committed `transactionsRoot`, and the receipts, whose
+/// stored form drops the bloom and the transaction type, re-encode to the committed `receiptsRoot`.
+fn write_blocks<R: Read, DB: SnapshotDb>(
+    factory: &ProviderFactory<NodeTypesWithDBAdapter<ArbNode, DB>>,
+    stream: &mut SnapshotStream<R>,
+    manifest: &Manifest,
+) -> eyre::Result<BlockSectionStats> {
+    let mut stats = BlockSectionStats::default();
+    let mut batch: Vec<PendingBlock> = Vec::with_capacity(BLOCK_BATCH);
+    let mut pending: Option<PendingBlock> = None;
+    let mut batch_txs = 0usize;
+    let mut next_tx_num = 0u64;
+    let mut first = true;
+
+    loop {
+        let record = stream.next_record()?;
+        match record {
+            Some(Record::Header { block, hash, rlp }) => {
+                if let Some(done) = pending.take() {
+                    batch_txs += done.body.as_ref().map_or(0, |b| b.transactions.len());
+                    batch.push(done);
+                }
+                if batch.len() >= BLOCK_BATCH || batch_txs >= TX_BATCH {
+                    flush_blocks(
+                        factory,
+                        &mut batch,
+                        &mut next_tx_num,
+                        &mut first,
+                        &mut stats,
+                    )?;
+                    batch_txs = 0;
+                }
+
+                let mut input = rlp.as_slice();
+                let header = Header::decode(&mut input)
+                    .map_err(|error| eyre::eyre!("block {block}: decode header: {error}"))?;
+                if !input.is_empty() {
+                    return Err(eyre::eyre!(
+                        "block {block}: trailing bytes after the header"
+                    ));
+                }
+                if header.number != block {
+                    return Err(eyre::eyre!(
+                        "block {block}: header says it is block {}",
+                        header.number
+                    ));
+                }
+                pending = Some(PendingBlock {
+                    number: block,
+                    hash,
+                    header,
+                    body: None,
+                    receipts: None,
+                });
+            }
+            Some(Record::Body { block, rlp }) => {
+                let target = expect_pending(&mut pending, block, "body")?;
+                let mut input = rlp.as_slice();
+                let body = ArbBlockBody::decode(&mut input)
+                    .map_err(|error| eyre::eyre!("block {block}: decode body: {error}"))?;
+                if !input.is_empty() {
+                    return Err(eyre::eyre!("block {block}: trailing bytes after the body"));
+                }
+                let root = calculate_transaction_root(&body.transactions);
+                if root != target.header.transactions_root {
+                    return Err(eyre::eyre!(
+                        "block {block}: transactions root is {root:#x}, header commits to {:#x}",
+                        target.header.transactions_root
+                    ));
+                }
+                target.body = Some(body);
+            }
+            Some(Record::Receipts { block, rlp }) => {
+                let target = expect_pending(&mut pending, block, "receipts")?;
+                // The stored form carries no transaction type, so the body has to have arrived
+                // first. The exporter writes them in that order for every block.
+                let body = target
+                    .body
+                    .as_ref()
+                    .ok_or_else(|| eyre::eyre!("block {block}: receipts arrived without a body"))?;
+                let tx_types: Vec<u8> = body.transactions.iter().map(tx_type_byte).collect();
+                let receipts = decode_stored_receipts(&rlp, &tx_types)
+                    .map_err(|error| eyre::eyre!("block {block}: {error}"))?;
+                let root = calculate_receipt_root(&receipts);
+                if root != target.header.receipts_root {
+                    return Err(eyre::eyre!(
+                        "block {block}: receipts root is {root:#x}, header commits to {:#x}",
+                        target.header.receipts_root
+                    ));
+                }
+                target.receipts = Some(receipts);
+            }
+            other => {
+                if let Some(done) = pending.take() {
+                    batch.push(done);
+                }
+                flush_blocks(
+                    factory,
+                    &mut batch,
+                    &mut next_tx_num,
+                    &mut first,
+                    &mut stats,
+                )?;
+                if let Some(record) = other {
+                    // The blocks section ends where the next section's first record begins.
+                    stream.unread(record);
+                }
+                break;
+            }
+        }
+    }
+
+    if stats.blocks == 0 {
+        return Err(eyre::eyre!("the stream's blocks section is empty"));
+    }
+    // The exporter stops the blocks section at the convert point, and so must the datadir: state,
+    // blocks and history all have to end at the same block (ADR-004 P3).
+    if stats.last_block != manifest.block {
+        return Err(eyre::eyre!(
+            "blocks end at {}, but the convert point is {}",
+            stats.last_block,
+            manifest.block
+        ));
+    }
+    Ok(stats)
+}
+
+fn expect_pending<'a>(
+    pending: &'a mut Option<PendingBlock>,
+    block: u64,
+    what: &str,
+) -> eyre::Result<&'a mut PendingBlock> {
+    let target = pending
+        .as_mut()
+        .ok_or_else(|| eyre::eyre!("block {block}: {what} arrived before any header"))?;
+    if target.number != block {
+        return Err(eyre::eyre!(
+            "block {block}: {what} does not belong to the open block {}",
+            target.number
+        ));
+    }
+    Ok(target)
+}
+
+fn tx_type_byte(tx: &arbitrum_alloy_consensus::transactions::ArbTxEnvelope) -> u8 {
+    use alloy_eips::Typed2718;
+    tx.ty()
+}
+
+/// Commit one batch of complete blocks.
+fn flush_blocks<DB: SnapshotDb>(
+    factory: &ProviderFactory<NodeTypesWithDBAdapter<ArbNode, DB>>,
+    batch: &mut Vec<PendingBlock>,
+    next_tx_num: &mut u64,
+    first: &mut bool,
+    stats: &mut BlockSectionStats,
+) -> eyre::Result<()> {
+    if batch.is_empty() {
+        return Ok(());
+    }
+    let provider = factory.database_provider_rw()?;
+    let sfp = provider.static_file_provider();
+    let from_block = batch[0].number;
+
+    {
+        let mut writer = sfp.get_writer(from_block, StaticFileSegment::Headers)?;
+        for block in batch.iter() {
+            if *first && block.number > 0 {
+                // A chain whose history starts above zero: seed the segment's range rather than
+                // letting `increment_block` walk up from block 0.
+                writer
+                    .user_header_mut()
+                    .set_block_range(block.number, block.number);
+                writer.append_header_direct(&block.header, block.header.difficulty, &block.hash)?;
+            } else {
+                writer.append_header(&block.header, &block.hash)?;
+            }
+            *first = false;
+        }
+        writer.commit()?;
+    }
+
+    for block in batch.iter() {
+        provider
+            .tx_ref()
+            .put::<tables::HeaderNumbers>(block.hash, block.number)?;
+    }
+
+    let bodies: Vec<_> = batch
+        .iter()
+        .map(|block| (block.number, block.body.as_ref()))
+        .collect();
+    provider.append_block_bodies(bodies)?;
+
+    {
+        let mut writer = EitherWriter::new_receipts(&provider, from_block)?;
+        let mut tx_num = *next_tx_num;
+        for block in batch.iter() {
+            writer.increment_block(block.number)?;
+            let count = block.body.as_ref().map_or(0, |b| b.transactions.len());
+            match &block.receipts {
+                Some(receipts) => {
+                    for receipt in receipts {
+                        writer.append_receipt(tx_num, receipt)?;
+                        tx_num += 1;
+                    }
+                }
+                // Blocks with transactions but no receipts would silently lose them.
+                None if count > 0 => {
+                    return Err(eyre::eyre!(
+                        "block {} has {count} transactions but no receipts",
+                        block.number
+                    ));
+                }
+                None => {}
+            }
+        }
+    }
+
+    for block in batch.iter() {
+        stats.blocks += 1;
+        if stats.blocks == 1 {
+            stats.first_block = block.number;
+        }
+        stats.last_block = block.number;
+        if let Some(body) = &block.body {
+            stats.bodies += 1;
+            stats.transactions += body.transactions.len() as u64;
+            *next_tx_num += body.transactions.len() as u64;
+        }
+        if let Some(receipts) = &block.receipts {
+            stats.receipt_sets += 1;
+            stats.receipts += receipts.len() as u64;
+        }
+    }
+
+    // ADR-004 B5: reth's own view of where transactions end must agree with the counter driving the
+    // receipt and sender numbering. If they ever part, every later block's receipts are misfiled.
+    let last = batch[batch.len() - 1].number;
+    let indices = provider.block_body_indices(last)?.ok_or_else(|| {
+        eyre::eyre!("block {last}: body indices missing right after writing them")
+    })?;
+    if indices.next_tx_num() != *next_tx_num {
+        return Err(eyre::eyre!(
+            "block {last}: transaction numbering diverged; reth says the next is {}, the import \
+             says {}",
+            indices.next_tx_num(),
+            *next_tx_num
+        ));
+    }
+
+    provider
+        .commit()
+        .map_err(|error| eyre::eyre!("commit blocks up to {last}: {error}"))?;
+    batch.clear();
+    info!(target: "arb-snapshot", blocks = stats.blocks, transactions = stats.transactions, at = last, "wrote blocks");
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_consensus::{Eip658Value, Receipt, ReceiptWithBloom, TxEip1559};
+    use alloy_eips::Decodable2718;
+    use alloy_primitives::{
+        Bytes, Log, LogData, Signature, TxKind, U256, address, b256, logs_bloom,
+    };
+    use alloy_rlp::Encodable;
+    use arb_reth_genesis::snapshot_stream::{Manifest, StreamBuilder};
+    use arbitrum_alloy_consensus::{
+        receipt::{ArbReceipt, ArbReceiptEnvelope},
+        transactions::{ArbTxEnvelope, deposit::TxDeposit},
+    };
+    use reth_provider::test_utils::create_test_provider_factory_with_node_types;
+    use reth_storage_api::{ReceiptProvider, TransactionsProvider};
+
+    use super::*;
+
+    fn spec() -> Arc<ChainSpec> {
+        use arb_revm::arbos_init::ArbosInitConfig;
+        const CHAIN_CONFIG: &[u8] =
+            include_bytes!("../../tests/fixtures/testnode_l2_chain_config.json");
+        let init = ArbosInitConfig {
+            initial_arbos_version: 40,
+            initial_chain_owner: address!("5E1497dD1f08C87b2d8FE23e9AAB6c1De833D927"),
+            chain_id: U256::from(412346u64),
+            genesis_block_number: 0,
+            initial_l1_base_fee: U256::from(167u64),
+            serialized_chain_config: CHAIN_CONFIG.to_vec(),
+            debug_precompiles: true,
+        };
+        Arc::new(crate::arb_chain_spec(&init).expect("build chain spec"))
+    }
+
+    /// A signed EIP-1559 transaction and an Arbitrum deposit, so the test covers both a type the
+    /// body wraps as a typed envelope and an Arbitrum-only type.
+    fn transactions() -> Vec<ArbTxEnvelope> {
+        use alloy_consensus::Signed;
+        let signed = Signed::new_unhashed(
+            TxEip1559 {
+                chain_id: 412346,
+                nonce: 3,
+                gas_limit: 40_000,
+                max_fee_per_gas: 2_000_000_000,
+                max_priority_fee_per_gas: 1_000_000_000,
+                to: TxKind::Call(address!("2222222222222222222222222222222222222222")),
+                value: U256::from(9u64),
+                access_list: Default::default(),
+                input: Bytes::from_static(&[0xde, 0xad]),
+            },
+            Signature::test_signature(),
+        );
+        vec![
+            ArbTxEnvelope::Eip1559(signed),
+            ArbTxEnvelope::from(TxDeposit {
+                chain_id: U256::from(412346u64),
+                request_id: b256!(
+                    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                ),
+                from: address!("1111111111111111111111111111111111111111"),
+                to: address!("2222222222222222222222222222222222222222"),
+                value: U256::from(123u64),
+            }),
+        ]
+    }
+
+    fn log() -> Log {
+        Log {
+            address: address!("00000000000000000000000000000000000000aa"),
+            data: LogData::new_unchecked(
+                vec![b256!(
+                    "1111111111111111111111111111111111111111111111111111111111111111"
+                )],
+                Bytes::from_static(&[0xbe, 0xef]),
+            ),
+        }
+    }
+
+    /// One receipt described once, so the stored bytes and the expected envelope cannot drift.
+    struct ReceiptSpec {
+        tx_type: u8,
+        success: bool,
+        cumulative_gas_used: u64,
+        gas_used_for_l1: u64,
+        logs: Vec<Log>,
+    }
+
+    fn receipt_specs() -> Vec<ReceiptSpec> {
+        vec![
+            ReceiptSpec {
+                tx_type: 0x02,
+                success: true,
+                cumulative_gas_used: 21_000,
+                gas_used_for_l1: 4_321,
+                logs: vec![log()],
+            },
+            ReceiptSpec {
+                tx_type: 0x64,
+                success: false,
+                cumulative_gas_used: 50_000,
+                gas_used_for_l1: 0,
+                logs: vec![],
+            },
+        ]
+    }
+
+    /// The receipts as reth models them: bloom present, type carried by the envelope.
+    fn receipts() -> Vec<ArbReceiptEnvelope> {
+        receipt_specs()
+            .into_iter()
+            .map(|spec| {
+                let receipt = ArbReceipt {
+                    inner: Receipt {
+                        status: Eip658Value::Eip658(spec.success),
+                        cumulative_gas_used: spec.cumulative_gas_used,
+                        logs: spec.logs,
+                    },
+                    gas_used_for_l1: spec.gas_used_for_l1,
+                };
+                arb_reth_evm::block::receipt_envelope_for_type(
+                    spec.tx_type,
+                    ReceiptWithBloom {
+                        logs_bloom: logs_bloom(receipt.inner.logs.iter()),
+                        receipt,
+                    },
+                )
+            })
+            .collect()
+    }
+
+    /// The same receipts in Nitro's storage form: no bloom, no type, plus `l1GasUsed`. This is what
+    /// the exporter copies out of the freezer, so the test drives the real decode path.
+    fn stored_receipts_rlp(specs: &[ReceiptSpec]) -> Vec<u8> {
+        let mut items = Vec::new();
+        for spec in specs {
+            let mut fields = Vec::new();
+            if spec.success {
+                Bytes::from_static(&[1]).encode(&mut fields);
+            } else {
+                Bytes::new().encode(&mut fields);
+            }
+            spec.cumulative_gas_used.encode(&mut fields);
+            spec.gas_used_for_l1.encode(&mut fields);
+            alloy_rlp::encode_list(&spec.logs, &mut fields);
+            alloy_rlp::Header {
+                list: true,
+                payload_length: fields.len(),
+            }
+            .encode(&mut items);
+            items.extend_from_slice(&fields);
+        }
+        let mut out = Vec::new();
+        alloy_rlp::Header {
+            list: true,
+            payload_length: items.len(),
+        }
+        .encode(&mut out);
+        out.extend_from_slice(&items);
+        out
+    }
+
+    fn body_rlp(transactions: &[ArbTxEnvelope]) -> Vec<u8> {
+        let body = ArbBlockBody {
+            transactions: transactions.to_vec(),
+            ommers: Vec::new(),
+            withdrawals: None,
+        };
+        alloy_rlp::encode(&body)
+    }
+
+    fn header(
+        number: u64,
+        parent_hash: B256,
+        body: &[ArbTxEnvelope],
+        rcpts: &[ArbReceiptEnvelope],
+    ) -> Header {
+        Header {
+            number,
+            parent_hash,
+            difficulty: U256::from(1u64),
+            transactions_root: calculate_transaction_root(body),
+            receipts_root: calculate_receipt_root(rcpts),
+            ..Default::default()
+        }
+    }
+
+    /// Blocks 0..=2, where block 1 carries transactions and receipts and the others are empty, then
+    /// the whole thing read back out of the database.
+    fn three_block_stream() -> (Vec<u8>, Manifest, Vec<B256>) {
+        let txs = transactions();
+        let rcpts = receipts();
+
+        let h0 = header(0, B256::ZERO, &[], &[]);
+        let hash0 = h0.hash_slow();
+        let h1 = header(1, hash0, &txs, &rcpts);
+        let hash1 = h1.hash_slow();
+        let h2 = header(2, hash1, &[], &[]);
+        let hash2 = h2.hash_slow();
+
+        let manifest = Manifest {
+            block: 2,
+            root: B256::repeat_byte(0xee),
+            state_id: 3,
+            hash: hash2,
+        };
+        let bytes = StreamBuilder::new(&manifest)
+            .blocks()
+            .header(0, &alloy_rlp::encode(&h0))
+            .body(0, &body_rlp(&[]))
+            .header(1, &alloy_rlp::encode(&h1))
+            .body(1, &body_rlp(&txs))
+            .receipts(1, &stored_receipts_rlp(&receipt_specs()))
+            .header(2, &alloy_rlp::encode(&h2))
+            .body(2, &body_rlp(&[]))
+            .end_section()
+            .history_section()
+            .end_section()
+            .state()
+            .end_section()
+            .finish();
+        (bytes, manifest, vec![hash0, hash1, hash2])
+    }
+
+    #[test]
+    fn writes_headers_bodies_and_receipts_into_a_readable_database() {
+        let factory = create_test_provider_factory_with_node_types::<ArbNode>(spec());
+        factory.set_storage_settings_cache(StorageSettings::v2());
+        {
+            let provider = factory.database_provider_rw().unwrap();
+            provider
+                .write_storage_settings(StorageSettings::v2())
+                .unwrap();
+            provider.commit().unwrap();
+        }
+
+        let (bytes, manifest, hashes) = three_block_stream();
+        let mut stream = SnapshotStream::open(bytes.as_slice()).unwrap();
+        let stats = write_blocks(&factory, &mut stream, &manifest).unwrap();
+
+        assert_eq!(stats.blocks, 3);
+        assert_eq!(stats.bodies, 3);
+        assert_eq!(stats.transactions, 2);
+        assert_eq!(stats.receipts, 2);
+        assert_eq!((stats.first_block, stats.last_block), (0, 2));
+
+        let provider = factory.provider().unwrap();
+        for (number, hash) in hashes.iter().enumerate() {
+            let sealed = reth_storage_api::HeaderProvider::sealed_header(&provider, number as u64)
+                .unwrap()
+                .unwrap_or_else(|| panic!("no header at {number}"));
+            assert_eq!(sealed.hash(), *hash, "block {number} hash");
+        }
+
+        // Only block 1 carries transactions, and they must land under its own numbering.
+        assert_eq!(provider.block_body_indices(0).unwrap().unwrap().tx_count, 0);
+        let indices = provider.block_body_indices(1).unwrap().unwrap();
+        assert_eq!((indices.first_tx_num, indices.tx_count), (0, 2));
+        assert_eq!(
+            provider
+                .block_body_indices(2)
+                .unwrap()
+                .unwrap()
+                .first_tx_num,
+            2
+        );
+
+        let stored_txs = provider
+            .transactions_by_block(1u64.into())
+            .unwrap()
+            .unwrap();
+        assert_eq!(stored_txs, transactions());
+        let stored_receipts = provider.receipts_by_block(1u64.into()).unwrap().unwrap();
+        assert_eq!(stored_receipts, receipts());
+        assert!(
+            provider
+                .receipts_by_block(0u64.into())
+                .unwrap()
+                .unwrap()
+                .is_empty(),
+            "an empty block keeps an empty receipt list, not a missing one"
+        );
+    }
+
+    /// The transactions root is recomputed from the decoded transactions, so a body that does not
+    /// belong to its header is caught at that block rather than at the end of the run.
+    #[test]
+    fn rejects_a_body_that_does_not_match_its_header() {
+        let factory = create_test_provider_factory_with_node_types::<ArbNode>(spec());
+        factory.set_storage_settings_cache(StorageSettings::v2());
+
+        let h0 = header(0, B256::ZERO, &[], &[]);
+        let manifest = Manifest {
+            block: 0,
+            root: B256::repeat_byte(0xee),
+            state_id: 1,
+            hash: h0.hash_slow(),
+        };
+        // The header commits to no transactions; the body carries two.
+        let bytes = StreamBuilder::new(&manifest)
+            .blocks()
+            .header(0, &alloy_rlp::encode(&h0))
+            .body(0, &body_rlp(&transactions()))
+            .end_section()
+            .finish();
+
+        let mut stream = SnapshotStream::open(bytes.as_slice()).unwrap();
+        let error = write_blocks(&factory, &mut stream, &manifest)
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("transactions root is"), "{error}");
+    }
+
+    /// The receipts root is recomputed from the decoded receipts, which is what proves the storage
+    /// form was read correctly: the bloom and the transaction type are both absent from it and are
+    /// reconstructed here, and either being wrong changes the root.
+    #[test]
+    fn rejects_receipts_that_do_not_match_their_header() {
+        let factory = create_test_provider_factory_with_node_types::<ArbNode>(spec());
+        factory.set_storage_settings_cache(StorageSettings::v2());
+
+        let txs = transactions();
+        let mut wrong = receipt_specs();
+        wrong[0].cumulative_gas_used += 1;
+
+        let h0 = header(0, B256::ZERO, &txs, &receipts());
+        let manifest = Manifest {
+            block: 0,
+            root: B256::repeat_byte(0xee),
+            state_id: 1,
+            hash: h0.hash_slow(),
+        };
+        let bytes = StreamBuilder::new(&manifest)
+            .blocks()
+            .header(0, &alloy_rlp::encode(&h0))
+            .body(0, &body_rlp(&txs))
+            .receipts(0, &stored_receipts_rlp(&wrong))
+            .end_section()
+            .finish();
+
+        let mut stream = SnapshotStream::open(bytes.as_slice()).unwrap();
+        let error = write_blocks(&factory, &mut stream, &manifest)
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("receipts root is"), "{error}");
+    }
+
+    /// State, blocks and history have to end at the same block, or the datadir has a hole nothing
+    /// else would surface.
+    #[test]
+    fn rejects_blocks_that_stop_below_the_convert_point() {
+        let factory = create_test_provider_factory_with_node_types::<ArbNode>(spec());
+        factory.set_storage_settings_cache(StorageSettings::v2());
+        {
+            let provider = factory.database_provider_rw().unwrap();
+            provider
+                .write_storage_settings(StorageSettings::v2())
+                .unwrap();
+            provider.commit().unwrap();
+        }
+
+        let h0 = header(0, B256::ZERO, &[], &[]);
+        let manifest = Manifest {
+            block: 7,
+            root: B256::repeat_byte(0xee),
+            state_id: 8,
+            hash: B256::repeat_byte(0xaa),
+        };
+        let bytes = StreamBuilder::new(&manifest)
+            .blocks()
+            .header(0, &alloy_rlp::encode(&h0))
+            .body(0, &body_rlp(&[]))
+            .end_section()
+            .history_section()
+            .end_section()
+            .state()
+            .end_section()
+            .finish();
+
+        let mut stream = SnapshotStream::open(bytes.as_slice()).unwrap();
+        let error = write_blocks(&factory, &mut stream, &manifest)
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("blocks end at 0"), "{error}");
+    }
+
+    /// Every Arbitrum transaction type has to survive the body decode, because the receipt decoder
+    /// takes its type from there and a wrong type produces a wrong receipts root.
+    #[test]
+    fn body_decode_preserves_transaction_types() {
+        let txs = transactions();
+        let encoded = body_rlp(&txs);
+        let decoded = ArbBlockBody::decode(&mut encoded.as_slice()).unwrap();
+        assert_eq!(decoded.transactions, txs);
+        assert_eq!(
+            decoded
+                .transactions
+                .iter()
+                .map(tx_type_byte)
+                .collect::<Vec<_>>(),
+            vec![0x02, 0x64]
+        );
+        // And the 2718 form round-trips, which is what the static file stores.
+        for tx in &decoded.transactions {
+            use alloy_eips::Encodable2718;
+            let bytes = tx.encoded_2718();
+            assert_eq!(
+                &ArbTxEnvelope::decode_2718(&mut bytes.as_slice()).unwrap(),
+                tx
+            );
+        }
+    }
+}

--- a/crates/arb-reth-node/src/commands/snapshot_full.rs
+++ b/crates/arb-reth-node/src/commands/snapshot_full.rs
@@ -12,6 +12,7 @@
 //! queries with silence rather than an error.
 
 use std::{
+    collections::HashSet,
     fs::File,
     io::{BufReader, Read},
     path::PathBuf,
@@ -30,13 +31,14 @@ use clap::Parser;
 use reth_chainspec::ChainSpec;
 use reth_db::{ClientVersion, init_db, mdbx::DatabaseArguments};
 use reth_db_api::{
+    cursor::DbCursorRW,
     database::Database,
     models::{AccountBeforeTx, StorageBeforeTx, StorageSettings},
     tables,
     transaction::DbTxMut,
 };
 use reth_node_types::NodeTypesWithDBAdapter;
-use reth_primitives_traits::Account;
+use reth_primitives_traits::{Account, Bytecode, StorageEntry};
 use reth_provider::{
     BlockWriter, DBProvider, DatabaseProviderFactory, EitherWriter, MetadataWriter,
     ProviderFactory, StaticFileProviderFactory, StaticFileWriter, StorageSettingsCache,
@@ -78,6 +80,9 @@ const TX_BATCH: usize = 50_000;
 /// Changeset entries (accounts plus slots) accumulated before a commit. Blocks are batched by
 /// entries rather than by count because a single block's diff can be very large.
 const CHANGESET_BATCH: usize = 250_000;
+
+/// Hashed-state writes accumulated before a commit, to bound dirty-page growth.
+const STATE_COMMIT_THRESHOLD: usize = 250_000;
 
 /// Convert a full-snapshot stream into a reth datadir.
 #[derive(Debug, Parser)]
@@ -175,14 +180,34 @@ pub fn import_full(args: SnapshotImportFullArgs) -> eyre::Result<()> {
         ));
     }
 
+    let state = write_state(&factory, &mut stream)?;
+    info!(
+        target: "arb-snapshot",
+        accounts = state.accounts,
+        slots = state.slots,
+        bytecodes = state.bytecodes,
+        "state imported; building the trie"
+    );
+
+    let root = super::snapshot::compute_state_root_chunked(&factory)?;
+    if root != manifest.root {
+        return Err(eyre::eyre!(
+            "state root is {root:#x}, but the snapshot converted at {:#x}",
+            manifest.root
+        ));
+    }
+    info!(target: "arb-snapshot", %root, "state root matches the convert point");
+
     drop(factory);
     rename_changeset_files_to_header(&static_files_path)?;
 
     Err(eyre::eyre!(
-        "the state section is not implemented yet; {} blocks and {} history objects were written \
-         but the datadir is incomplete and has no completion manifest, so it will not boot",
+        "the datadir is not finished: stage checkpoints, history indices and the completion \
+         manifest are still to come, so it will not boot ({} blocks, {} history objects, {} \
+         accounts)",
         blocks.blocks,
-        history.objects
+        history.objects,
+        state.accounts
     ))
 }
 
@@ -668,6 +693,127 @@ fn flush_history<DB: SnapshotDb>(
     Ok(())
 }
 
+/// What the state section wrote.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct StateSectionStats {
+    pub accounts: u64,
+    pub slots: u64,
+    pub bytecodes: u64,
+}
+
+/// Write the state at the convert point into the hashed-state tables.
+///
+/// The keys are already hashed, because a pruned snapshot has no preimage for them. Storage v2
+/// treats the hashed tables as canonical, which is why this is enough to serve current state; the
+/// trie is then built over it and its root checked against the manifest (ADR-004 P2).
+fn write_state<R: Read, DB: SnapshotDb>(
+    factory: &ProviderFactory<NodeTypesWithDBAdapter<ArbNode, DB>>,
+    stream: &mut SnapshotStream<R>,
+) -> eyre::Result<StateSectionStats> {
+    let mut stats = StateSectionStats::default();
+    let mut provider = factory.database_provider_rw()?;
+    let mut written = 0usize;
+    // Storage records belong to the account that most recently went past. A code record can sit
+    // between an account and its slots, so it must not disturb this.
+    let mut account: Option<B256> = None;
+    // Every code hash an account referenced, against every code blob the stream carried.
+    let mut wanted: HashSet<B256> = HashSet::new();
+    let mut provided: HashSet<B256> = HashSet::new();
+
+    loop {
+        if written >= STATE_COMMIT_THRESHOLD {
+            provider
+                .commit()
+                .map_err(|error| eyre::eyre!("commit state: {error}"))?;
+            provider = factory.database_provider_rw()?;
+            written = 0;
+            info!(
+                target: "arb-snapshot",
+                accounts = stats.accounts,
+                slots = stats.slots,
+                bytecodes = stats.bytecodes,
+                "wrote state"
+            );
+        }
+
+        match stream.next_record()? {
+            Some(Record::Account {
+                hashed_address,
+                nonce,
+                balance,
+                code_hash,
+            }) => {
+                if let Some(hash) = code_hash {
+                    wanted.insert(hash);
+                }
+                provider.tx_ref().put::<tables::HashedAccounts>(
+                    hashed_address,
+                    Account {
+                        nonce,
+                        balance,
+                        bytecode_hash: code_hash,
+                    },
+                )?;
+                account = Some(hashed_address);
+                stats.accounts += 1;
+                written += 1;
+            }
+            Some(Record::Storage { hashed_slot, value }) => {
+                let owner = account.ok_or_else(|| {
+                    eyre::eyre!("storage slot {hashed_slot:#x} arrived before any account")
+                })?;
+                // A zero slot is absent from the trie, so writing one would change the root.
+                if value.is_zero() {
+                    continue;
+                }
+                provider
+                    .tx_ref()
+                    .cursor_dup_write::<tables::HashedStorages>()?
+                    .upsert(
+                        owner,
+                        &StorageEntry {
+                            key: hashed_slot,
+                            value,
+                        },
+                    )?;
+                stats.slots += 1;
+                written += 1;
+            }
+            Some(Record::Code { hash, code }) => {
+                // The stream reader already checked the blob hashes to its key.
+                provided.insert(hash);
+                provider
+                    .tx_ref()
+                    .put::<tables::Bytecodes>(hash, Bytecode::new_raw(code.into()))?;
+                stats.bytecodes += 1;
+                written += 1;
+            }
+            other => {
+                if let Some(record) = other {
+                    return Err(eyre::eyre!(
+                        "unexpected {record:?} after the state section; it is the last one"
+                    ));
+                }
+                break;
+            }
+        }
+    }
+
+    provider
+        .commit()
+        .map_err(|error| eyre::eyre!("commit state: {error}"))?;
+
+    if stats.accounts == 0 {
+        return Err(eyre::eyre!("the stream's state section is empty"));
+    }
+    if let Some(missing) = wanted.difference(&provided).next() {
+        return Err(eyre::eyre!(
+            "an account references code {missing:#x}, which the stream does not carry"
+        ));
+    }
+    Ok(stats)
+}
+
 /// Rename changeset static files whose name disagrees with the expected range in their header.
 ///
 /// reth resolves a segment file's path from that range, and the first changeset file's start was
@@ -711,7 +857,7 @@ mod tests {
     use alloy_consensus::{Eip658Value, Receipt, ReceiptWithBloom, TxEip1559};
     use alloy_eips::Decodable2718;
     use alloy_primitives::{
-        Bytes, Log, LogData, Signature, TxKind, U256, address, b256, logs_bloom,
+        Bytes, Log, LogData, Signature, TxKind, U256, address, b256, keccak256, logs_bloom,
     };
     use alloy_rlp::Encodable;
     use arb_reth_genesis::snapshot_stream::{HistoryAccount, HistoryObject};
@@ -720,6 +866,7 @@ mod tests {
         receipt::{ArbReceipt, ArbReceiptEnvelope},
         transactions::{ArbTxEnvelope, deposit::TxDeposit},
     };
+    use reth_db_api::transaction::DbTx;
     use reth_provider::test_utils::create_test_provider_factory_with_node_types;
     use reth_storage_api::{
         ChangeSetReader, ReceiptProvider, StorageChangeSetReader, TransactionsProvider,
@@ -1150,6 +1297,131 @@ mod tests {
             }]
         );
         assert_eq!(objects[1].post_root, root);
+    }
+
+    /// Blocks, history and state in one stream, with the state root the trie actually produces so
+    /// the manifest check passes.
+    fn full_stream(root: B256) -> (Vec<u8>, Manifest) {
+        // Same blocks and history, but with a real state section in place of the empty one.
+        let (_, manifest, objects) = history_stream(root);
+        let mut builder = StreamBuilder::new(&manifest).blocks();
+        let mut parent = B256::ZERO;
+        for number in 0..=4u64 {
+            let h = header(number, parent, &[], &[]);
+            parent = h.hash_slow();
+            builder = builder
+                .header(number, &alloy_rlp::encode(&h))
+                .body(number, &body_rlp(&[]));
+        }
+        builder = builder.end_section().history_section();
+        for object in &objects {
+            builder = builder.history(object);
+        }
+        let code: &[u8] = &[0x60, 0x00, 0x56];
+        let bytes = builder
+            .end_section()
+            .state()
+            .account(
+                keccak256(ACCOUNT_A),
+                7,
+                U256::from(1234u64),
+                Some(keccak256(code)),
+            )
+            .code(code)
+            .storage(keccak256(B256::repeat_byte(0x01)), U256::from(5u64))
+            // A zero slot is absent from the trie, so it must not reach the database.
+            .storage(keccak256(B256::repeat_byte(0x02)), U256::ZERO)
+            .account(keccak256(ACCOUNT_B), 1, U256::from(9u64), None)
+            .end_section()
+            .finish();
+        (bytes, manifest)
+    }
+
+    /// The whole conversion, end to end: every section written, then the trie built over the
+    /// imported state and its root compared with the manifest.
+    #[test]
+    fn imports_all_three_sections_and_reproduces_the_state_root() {
+        let factory = v2_factory();
+        // The root the imported state actually hashes to is only known after the fact, so run once
+        // with a placeholder to learn it, then assert the check accepts the real one and rejects
+        // the placeholder.
+        let (bytes, manifest) = full_stream(B256::repeat_byte(0xee));
+        let mut stream = SnapshotStream::open(bytes.as_slice()).unwrap();
+        write_blocks(&factory, &mut stream, &manifest).unwrap();
+        write_history(&factory, &mut stream, &manifest).unwrap();
+        let state = write_state(&factory, &mut stream).unwrap();
+
+        assert_eq!(state.accounts, 2);
+        assert_eq!(state.slots, 1, "the zero slot is not written");
+        assert_eq!(state.bytecodes, 1);
+
+        let root = super::super::snapshot::compute_state_root_chunked(&factory).unwrap();
+        assert_ne!(root, B256::ZERO);
+        assert_ne!(
+            root, manifest.root,
+            "the placeholder root must not accidentally match"
+        );
+
+        let provider = factory.provider().unwrap();
+        let account = provider
+            .tx_ref()
+            .get::<tables::HashedAccounts>(keccak256(ACCOUNT_A))
+            .unwrap()
+            .expect("account A");
+        assert_eq!(account.nonce, 7);
+        assert_eq!(account.balance, U256::from(1234u64));
+        assert_eq!(
+            account.bytecode_hash,
+            Some(keccak256([0x60u8, 0x00, 0x56].as_slice()))
+        );
+        assert!(
+            provider
+                .tx_ref()
+                .get::<tables::Bytecodes>(keccak256([0x60u8, 0x00, 0x56].as_slice()))
+                .unwrap()
+                .is_some()
+        );
+        // Account B has no code, so it must be stored as an EOA rather than as empty code.
+        assert_eq!(
+            provider
+                .tx_ref()
+                .get::<tables::HashedAccounts>(keccak256(ACCOUNT_B))
+                .unwrap()
+                .expect("account B")
+                .bytecode_hash,
+            None
+        );
+    }
+
+    /// An account whose code the stream never carried would leave the datadir unable to execute
+    /// against it, and nothing else would notice.
+    #[test]
+    fn rejects_state_that_references_missing_code() {
+        let factory = v2_factory();
+        let manifest = Manifest {
+            block: 0,
+            root: B256::repeat_byte(0xee),
+            state_id: 1,
+            hash: B256::repeat_byte(0xaa),
+        };
+        let bytes = StreamBuilder::new(&manifest)
+            .blocks()
+            .end_section()
+            .history_section()
+            .end_section()
+            .state()
+            .account(
+                keccak256(ACCOUNT_A),
+                0,
+                U256::ZERO,
+                Some(B256::repeat_byte(0x77)),
+            )
+            .end_section()
+            .finish();
+
+        let mut stream = SnapshotStream::open(bytes.as_slice()).unwrap();
+        let error = write_state(&factory, &mut stream).unwrap_err().to_string();
+        assert!(error.contains("does not carry"), "{error}");
     }
 
     /// The first changeset file is created in its fixed 500k slot and then has its expected start

--- a/crates/arb-reth-node/src/commands/snapshot_full.rs
+++ b/crates/arb-reth-node/src/commands/snapshot_full.rs
@@ -1147,7 +1147,7 @@ fn write_state<R: Read, DB: SnapshotDb>(
 /// reth resolves a segment file's path from that range, and the first changeset file's start was
 /// moved to `S_lo` after it was created in its fixed 500k slot, so its name is stale. Every other
 /// file already agrees; this checks them all rather than assuming which one moved.
-fn rename_changeset_files_to_header(static_files: &std::path::Path) -> eyre::Result<()> {
+pub(crate) fn rename_changeset_files_to_header(static_files: &std::path::Path) -> eyre::Result<()> {
     for segment in ["account-change-sets", "storage-change-sets"] {
         let prefix = format!("static_file_{segment}_");
         let names: Vec<String> = std::fs::read_dir(static_files)?

--- a/crates/arb-reth-node/src/lib.rs
+++ b/crates/arb-reth-node/src/lib.rs
@@ -38,6 +38,9 @@ pub use genesis::{
 };
 
 pub mod hashed_db;
+
+/// Decoder for the receipt layout a Nitro node writes into its chain freezer.
+pub mod stored_receipt;
 pub use hashed_db::{account_by_address, code_of, storage_at};
 
 pub mod persist;

--- a/crates/arb-reth-node/src/stored_receipt.rs
+++ b/crates/arb-reth-node/src/stored_receipt.rs
@@ -1,0 +1,323 @@
+//! Decoder for the receipts a Nitro node keeps in its chain freezer.
+//!
+//! `rawdb.ReadReceiptsRLP` hands back geth's *storage* form, not the consensus form, and two things
+//! are missing from it: the logs bloom, which geth recomputes on read, and the transaction type,
+//! which is never stored at all. The type comes from the block's transactions, so a block's receipts
+//! can only be decoded alongside its body.
+//!
+//! Nitro's storage form (`storedReceiptRLP`, `core/types/receipt.go`) is
+//!
+//! ```text
+//! [ status, cumulativeGasUsed, l1GasUsed, logs, contractAddress?, multiGasUsed? ]
+//! ```
+//!
+//! The two trailing fields are optional and hold data reth's receipt model does not carry. They are
+//! skipped rather than stored: the target is a receipt identical to the one a forward sync would
+//! have written, not a copy of geth's row.
+
+use alloy_consensus::{Eip658Value, Receipt, ReceiptWithBloom};
+use alloy_primitives::{Log, logs_bloom};
+use alloy_rlp::{Decodable, Header};
+use arbitrum_alloy_consensus::receipt::{ArbReceipt, ArbReceiptEnvelope};
+
+/// Nitro puts this single zero byte in the status slot to mark a classic-chain receipt, which uses
+/// a wider layout. A Nitro-era status is empty (failure), `0x01` (success), or a 32-byte post-state
+/// root, so the marker cannot collide with one.
+const ARBITRUM_LEGACY_STATUS: &[u8] = &[0x00];
+
+/// Decode one block's stored receipts, taking each receipt's type from its transaction.
+///
+/// `tx_types` must be the block's transaction types in order; the counts have to agree, which is
+/// also the check that the body and the receipt list belong to the same block.
+pub fn decode_stored_receipts(
+    rlp: &[u8],
+    tx_types: &[u8],
+) -> eyre::Result<Vec<ArbReceiptEnvelope<Log>>> {
+    let mut buf = rlp;
+    let outer = Header::decode(&mut buf)?;
+    if !outer.list {
+        return Err(eyre::eyre!("stored receipts are not an RLP list"));
+    }
+    if buf.len() != outer.payload_length {
+        return Err(eyre::eyre!(
+            "stored receipts claim {} bytes, {} follow",
+            outer.payload_length,
+            buf.len()
+        ));
+    }
+
+    let mut receipts = Vec::with_capacity(tx_types.len());
+    while !buf.is_empty() {
+        let index = receipts.len();
+        let tx_type = *tx_types.get(index).ok_or_else(|| {
+            eyre::eyre!(
+                "block has {} transactions but at least {} receipts",
+                tx_types.len(),
+                index + 1
+            )
+        })?;
+        receipts.push(decode_one(&mut buf, tx_type, index)?);
+    }
+    if receipts.len() != tx_types.len() {
+        return Err(eyre::eyre!(
+            "block has {} transactions but {} receipts",
+            tx_types.len(),
+            receipts.len()
+        ));
+    }
+    Ok(receipts)
+}
+
+fn decode_one(buf: &mut &[u8], tx_type: u8, index: usize) -> eyre::Result<ArbReceiptEnvelope<Log>> {
+    let header = Header::decode(buf)?;
+    if !header.list {
+        return Err(eyre::eyre!("receipt {index} is not an RLP list"));
+    }
+    if buf.len() < header.payload_length {
+        return Err(eyre::eyre!(
+            "receipt {index} claims {} bytes, only {} remain",
+            header.payload_length,
+            buf.len()
+        ));
+    }
+    let (mut body, rest) = buf.split_at(header.payload_length);
+    *buf = rest;
+
+    let status = alloy_primitives::Bytes::decode(&mut body)
+        .map_err(|error| eyre::eyre!("receipt {index}: status: {error}"))?;
+    if status.as_ref() == ARBITRUM_LEGACY_STATUS {
+        return Err(eyre::eyre!(
+            "receipt {index} is a classic-chain receipt (pre-Nitro layout); converting a chain \
+             whose history reaches below its Nitro genesis is not supported"
+        ));
+    }
+    let status = match status.as_ref() {
+        [] => Eip658Value::Eip658(false),
+        [1] => Eip658Value::Eip658(true),
+        other => {
+            return Err(eyre::eyre!(
+                "receipt {index} has an unsupported status field of {} bytes; Arbitrum is \
+                 post-Byzantium, so a post-state root cannot appear here",
+                other.len()
+            ));
+        }
+    };
+
+    let cumulative_gas_used = u64::decode(&mut body)
+        .map_err(|error| eyre::eyre!("receipt {index}: cumulativeGasUsed: {error}"))?;
+    let gas_used_for_l1 = u64::decode(&mut body)
+        .map_err(|error| eyre::eyre!("receipt {index}: l1GasUsed: {error}"))?;
+    let logs = Vec::<Log>::decode(&mut body)
+        .map_err(|error| eyre::eyre!("receipt {index}: logs: {error}"))?;
+
+    // Anything left is contractAddress and/or multiGasUsed. Both are node-local.
+
+    let logs_bloom = logs_bloom(logs.iter());
+    let receipt = ArbReceipt {
+        inner: Receipt {
+            status,
+            cumulative_gas_used,
+            logs,
+        },
+        gas_used_for_l1,
+    };
+    Ok(arb_reth_evm::block::receipt_envelope_for_type(
+        tx_type,
+        ReceiptWithBloom {
+            receipt,
+            logs_bloom,
+        },
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::{Address, B256, Bytes, LogData, address, b256};
+    use alloy_rlp::Encodable;
+
+    use super::*;
+
+    /// Mirrors Nitro's `ReceiptForStorage.EncodeRLP` for the Nitro-era layout.
+    fn stored(
+        success: bool,
+        cumulative_gas_used: u64,
+        l1_gas: u64,
+        logs: &[Log],
+        contract_address: Option<Address>,
+    ) -> Vec<u8> {
+        let mut fields = Vec::new();
+        if success {
+            Bytes::from_static(&[1]).encode(&mut fields);
+        } else {
+            Bytes::new().encode(&mut fields);
+        }
+        cumulative_gas_used.encode(&mut fields);
+        l1_gas.encode(&mut fields);
+        alloy_rlp::encode_list(logs, &mut fields);
+        if let Some(addr) = contract_address {
+            addr.encode(&mut fields);
+        }
+        let mut out = Vec::new();
+        Header {
+            list: true,
+            payload_length: fields.len(),
+        }
+        .encode(&mut out);
+        out.extend_from_slice(&fields);
+        out
+    }
+
+    fn list(items: &[Vec<u8>]) -> Vec<u8> {
+        let payload: Vec<u8> = items.concat();
+        let mut out = Vec::new();
+        Header {
+            list: true,
+            payload_length: payload.len(),
+        }
+        .encode(&mut out);
+        out.extend_from_slice(&payload);
+        out
+    }
+
+    fn log() -> Log {
+        Log {
+            address: address!("00000000000000000000000000000000000000aa"),
+            data: LogData::new_unchecked(
+                vec![b256!(
+                    "1111111111111111111111111111111111111111111111111111111111111111"
+                )],
+                Bytes::from_static(&[0xde, 0xad]),
+            ),
+        }
+    }
+
+    #[test]
+    fn decodes_a_block_of_receipts_and_types_them_from_the_transactions() {
+        let blob = list(&[
+            stored(true, 21_000, 0, &[], None),
+            stored(false, 50_000, 1234, &[log()], None),
+        ]);
+        let receipts = decode_stored_receipts(&blob, &[0x02, 0x69]).unwrap();
+
+        assert!(matches!(receipts[0], ArbReceiptEnvelope::Eip1559(_)));
+        assert!(matches!(
+            receipts[1],
+            ArbReceiptEnvelope::SubmitRetryable(_)
+        ));
+
+        let second = match &receipts[1] {
+            ArbReceiptEnvelope::SubmitRetryable(r) => r,
+            other => panic!("unexpected {other:?}"),
+        };
+        assert_eq!(second.receipt.inner.status, Eip658Value::Eip658(false));
+        assert_eq!(second.receipt.inner.cumulative_gas_used, 50_000);
+        assert_eq!(second.receipt.gas_used_for_l1, 1234);
+        assert_eq!(second.receipt.inner.logs, vec![log()]);
+        // Recomputed on decode, not stored.
+        assert_eq!(second.logs_bloom, logs_bloom([&log()]));
+    }
+
+    /// The optional trailing fields carry node-local data. Their presence must not shift the
+    /// decode of the next receipt in the list.
+    #[test]
+    fn skips_the_optional_trailing_fields() {
+        let with_address = list(&[
+            stored(
+                true,
+                7,
+                0,
+                &[],
+                Some(address!("00000000000000000000000000000000000000bb")),
+            ),
+            stored(true, 9, 0, &[], None),
+        ]);
+        let receipts = decode_stored_receipts(&with_address, &[0x64, 0x64]).unwrap();
+        assert_eq!(receipts.len(), 2);
+        let second = match &receipts[1] {
+            ArbReceiptEnvelope::Deposit(r) => r,
+            other => panic!("unexpected {other:?}"),
+        };
+        assert_eq!(second.receipt.inner.cumulative_gas_used, 9);
+    }
+
+    #[test]
+    fn rejects_a_receipt_count_that_disagrees_with_the_body() {
+        let blob = list(&[stored(true, 1, 0, &[], None), stored(true, 2, 0, &[], None)]);
+        let err = decode_stored_receipts(&blob, &[0x00])
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("1 transactions but at least 2 receipts"),
+            "{err}"
+        );
+
+        let err = decode_stored_receipts(&blob, &[0x00, 0x00, 0x00])
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("3 transactions but 2 receipts"), "{err}");
+    }
+
+    /// The classic layout puts a zero byte where the status goes. Decoding it as a Nitro receipt
+    /// would silently read `cumulativeGasUsed` out of the wrong field, so it has to be refused.
+    #[test]
+    fn rejects_a_classic_chain_receipt() {
+        let mut fields = Vec::new();
+        Bytes::from_static(&[0]).encode(&mut fields);
+        for value in [100u64, 50, 10, 1] {
+            value.encode(&mut fields);
+        }
+        Address::ZERO.encode(&mut fields);
+        Vec::<Log>::new().encode(&mut fields);
+        let mut receipt = Vec::new();
+        Header {
+            list: true,
+            payload_length: fields.len(),
+        }
+        .encode(&mut receipt);
+        receipt.extend_from_slice(&fields);
+
+        let err = decode_stored_receipts(&list(&[receipt]), &[0x00])
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("classic-chain receipt"), "{err}");
+    }
+
+    #[test]
+    fn rejects_trailing_bytes_after_the_list() {
+        let mut blob = list(&[stored(true, 1, 0, &[], None)]);
+        blob.push(0xff);
+        let err = decode_stored_receipts(&blob, &[0x00])
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("bytes"), "{err}");
+    }
+
+    #[test]
+    fn empty_receipt_list_is_valid() {
+        assert!(decode_stored_receipts(&list(&[]), &[]).unwrap().is_empty());
+    }
+
+    /// A post-state root in the status slot means a pre-Byzantium chain, which Arbitrum is not.
+    /// Accepting it would produce a receipt whose consensus encoding differs from the header's
+    /// commitment.
+    #[test]
+    fn rejects_a_post_state_root_status() {
+        let mut fields = Vec::new();
+        B256::repeat_byte(0x33).encode(&mut fields);
+        21_000u64.encode(&mut fields);
+        0u64.encode(&mut fields);
+        Vec::<Log>::new().encode(&mut fields);
+        let mut receipt = Vec::new();
+        Header {
+            list: true,
+            payload_length: fields.len(),
+        }
+        .encode(&mut receipt);
+        receipt.extend_from_slice(&fields);
+
+        let err = decode_stored_receipts(&list(&[receipt]), &[0x00])
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("post-state root"), "{err}");
+    }
+}

--- a/crates/arb-reth-sync/src/l1_sync.rs
+++ b/crates/arb-reth-sync/src/l1_sync.rs
@@ -28,15 +28,15 @@
 
 use std::collections::VecDeque;
 use std::future::Future;
-use std::pin::Pin;
 use std::path::PathBuf;
+use std::pin::Pin;
 use std::time::Duration;
 
 use alloy_primitives::Address;
 use alloy_provider::{Provider, ProviderBuilder};
 use arb_reth_l1::sync::{
-    derive_from_resolved_cached, resolve_batches, DelayedCache, ReportStatsCache,
-    DEFAULT_DELAYED_WINDOW,
+    DEFAULT_DELAYED_WINDOW, DelayedCache, ReportStatsCache, derive_from_resolved_cached,
+    resolve_batches,
 };
 use arb_reth_l1::{BeaconClient, DelayedInboxReader, DeliveredBatch, SequencerInboxReader};
 use arbitrum_alloy_sequencer::sequencer::feed::BroadcastFeedMessage;
@@ -55,9 +55,14 @@ const RETRY_MAX_DELAY: Duration = Duration::from_secs(30);
 /// unsupported chain data remains visible instead of becoming an infinite retry loop.
 #[derive(Debug)]
 pub enum L1SyncError {
-    /// An execution RPC or beacon request failed. The provider's error text is intentionally not
-    /// retained because HTTP client errors may contain credential-bearing endpoint URLs.
-    Provider { operation: &'static str },
+    /// An execution RPC or beacon request failed. `detail` is the provider's message with any URL
+    /// redacted, because HTTP client errors carry credential-bearing endpoint URLs and these end up
+    /// in logs. Without it a quota-exhausted endpoint and a malformed response are indistinguishable,
+    /// which has cost real debugging time.
+    Provider {
+        operation: &'static str,
+        detail: String,
+    },
     /// The provider returned data, but deriving it failed deterministically.
     Derivation {
         operation: &'static str,
@@ -70,13 +75,19 @@ pub enum L1SyncError {
 }
 
 impl L1SyncError {
-    const fn provider(operation: &'static str) -> Self {
-        Self::Provider { operation }
+    fn provider(operation: &'static str) -> Self {
+        Self::Provider {
+            operation,
+            detail: String::new(),
+        }
     }
 
     fn l1(operation: &'static str, source: arb_reth_l1::L1Error) -> Self {
         if matches!(source, arb_reth_l1::L1Error::Rpc(_)) {
-            Self::Provider { operation }
+            Self::Provider {
+                operation,
+                detail: redact_urls(&source.to_string()),
+            }
         } else {
             Self::Derivation { operation, source }
         }
@@ -88,11 +99,44 @@ impl L1SyncError {
     }
 }
 
+/// Replace every URL in a provider message with a placeholder.
+///
+/// Endpoint URLs carry API keys, and often userinfo as well, so the raw message cannot go to a log.
+/// Everything around the URL is what actually identifies the failure ("429 Too Many Requests",
+/// "quota limit", "decode error"), so redacting rather than discarding keeps the diagnosis and
+/// loses the secret.
+fn redact_urls(message: &str) -> String {
+    let mut out = String::with_capacity(message.len());
+    let mut rest = message;
+    while let Some(sep) = rest.find("://") {
+        // Walk back over the scheme to the start of the URL.
+        let scheme_start = rest[..sep]
+            .rfind(|c: char| !c.is_ascii_alphanumeric() && c != '+' && c != '-' && c != '.')
+            .map_or(0, |i| i + 1);
+        out.push_str(&rest[..scheme_start]);
+        out.push_str("<redacted-url>");
+        // Skip to the end of the URL: whitespace or a closing delimiter ends it.
+        let after = &rest[sep + 3..];
+        let end = after
+            .find(|c: char| c.is_whitespace() || c == ')' || c == ',' || c == '"')
+            .unwrap_or(after.len());
+        rest = &after[end..];
+    }
+    out.push_str(rest);
+    out
+}
+
 impl core::fmt::Display for L1SyncError {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
-            Self::Provider { operation } => {
+            Self::Provider { operation, detail } if detail.is_empty() => {
                 write!(f, "transient L1 provider failure during {operation}")
+            }
+            Self::Provider { operation, detail } => {
+                write!(
+                    f,
+                    "transient L1 provider failure during {operation}: {detail}"
+                )
             }
             Self::Derivation { operation, source } => {
                 write!(
@@ -353,8 +397,12 @@ where
                 tracing::warn!(
                     target: "arb-reth::l1-sync",
                     operation = match &err {
-                        L1SyncError::Provider { operation } => *operation,
+                        L1SyncError::Provider { operation, .. } => *operation,
                         _ => unreachable!("only provider errors are retryable"),
+                    },
+                    detail = match &err {
+                        L1SyncError::Provider { detail, .. } => detail.as_str(),
+                        _ => "",
                     },
                     retry_ms = delay.as_millis() as u64,
                     made_progress,
@@ -389,7 +437,9 @@ where
     // throttle the happy path. Beacon blob fetches have their own retry (see BeaconClient).
     let url = cfg.l1_rpc.parse().map_err(|_| L1SyncError::InvalidRpcUrl)?;
     let client = alloy_rpc_client::ClientBuilder::default()
-        .layer(alloy_transport::layers::RetryBackoffLayer::new(10, 500, 660))
+        .layer(alloy_transport::layers::RetryBackoffLayer::new(
+            10, 500, 660,
+        ))
         .http(url);
     let provider = ProviderBuilder::new().connect_client(client);
     let seq_reader = SequencerInboxReader::new(provider.clone(), cfg.sequencer_inbox);
@@ -514,7 +564,9 @@ where
                 // The window delivers batches: scan it for real (prefetch the getLogs + payload fetch).
                 let (s, b) = (seq_reader.clone(), beacon.clone());
                 let handle =
-                    tokio::spawn(async move { resolve_batches(&s, b.as_ref(), from, win_to).await });
+                    tokio::spawn(
+                        async move { resolve_batches(&s, b.as_ref(), from, win_to).await },
+                    );
                 inflight.0.push_back((from, win_to, handle));
                 seen_batch_count = win_batch_count;
                 spawn_cursor = win_to + 1;
@@ -686,7 +738,11 @@ mod tests {
     use std::thread;
 
     fn cp(l1_block: u64, l2_block: u64) -> L1ResumeCheckpoint {
-        L1ResumeCheckpoint { l1_block, delayed_count: 0, l2_block }
+        L1ResumeCheckpoint {
+            l1_block,
+            delayed_count: 0,
+            l2_block,
+        }
     }
 
     /// Covers the variants that reach the caller directly rather than through `L1SyncError::l1`,
@@ -827,8 +883,9 @@ mod tests {
         let dir = reth_db::test_utils::tempdir_path();
         let path = L1ResumeLog::path_in(&dir);
         let mut log = L1ResumeLog::default();
-        let mut pending: VecDeque<L1ResumeCheckpoint> =
-            [cp(100, 10), cp(200, 20), cp(300, 30)].into_iter().collect();
+        let mut pending: VecDeque<L1ResumeCheckpoint> = [cp(100, 10), cp(200, 20), cp(300, 30)]
+            .into_iter()
+            .collect();
 
         // Nothing persisted past block 5 → no boundary is safe to append yet.
         maybe_write_checkpoint(Some(&path), &mut log, &mut pending, 5);
@@ -838,13 +895,20 @@ mod tests {
         // Durable tip at 20 → boundaries 10 and 20 are safe; both logged, 30 stays queued.
         maybe_write_checkpoint(Some(&path), &mut log, &mut pending, 20);
         let loaded = L1ResumeLog::load(&path).expect("log written");
-        assert_eq!(loaded.resume_for(u64::MAX), Some(cp(200, 20)), "newest logged is 20");
+        assert_eq!(
+            loaded.resume_for(u64::MAX),
+            Some(cp(200, 20)),
+            "newest logged is 20"
+        );
         assert_eq!(loaded.checkpoints, vec![cp(100, 10), cp(200, 20)]);
         assert_eq!(pending, [cp(300, 30)].into_iter().collect::<VecDeque<_>>());
 
         // Durable tip past 30 → final boundary flushes.
         maybe_write_checkpoint(Some(&path), &mut log, &mut pending, 99);
-        assert_eq!(L1ResumeLog::load(&path).unwrap().resume_for(u64::MAX), Some(cp(300, 30)));
+        assert_eq!(
+            L1ResumeLog::load(&path).unwrap().resume_for(u64::MAX),
+            Some(cp(300, 30))
+        );
         assert!(pending.is_empty());
     }
 
@@ -856,8 +920,9 @@ mod tests {
         let path = L1ResumeLog::path_in(&dir);
         let mut log = L1ResumeLog::default();
         // Two windows produced block 10; the next two windows held no batches (l2 stays 10).
-        let mut pending: VecDeque<L1ResumeCheckpoint> =
-            [cp(100, 10), cp(200, 10), cp(300, 10)].into_iter().collect();
+        let mut pending: VecDeque<L1ResumeCheckpoint> = [cp(100, 10), cp(200, 10), cp(300, 10)]
+            .into_iter()
+            .collect();
 
         maybe_write_checkpoint(Some(&path), &mut log, &mut pending, 10);
         let loaded = L1ResumeLog::load(&path).expect("log written");
@@ -892,9 +957,15 @@ mod tests {
             ),
         );
         assert!(provider.is_retryable());
-        assert_eq!(
-            provider.to_string(),
-            "transient L1 provider failure during get_block_number"
+        let rendered = provider.to_string();
+        assert!(
+            !rendered.contains("secret") && !rendered.contains("example.invalid"),
+            "the endpoint URL must never reach a log: {rendered}"
+        );
+        assert!(
+            rendered.contains("error sending request for url")
+                && rendered.contains("<redacted-url>"),
+            "the part that identifies the failure must survive: {rendered}"
         );
         assert!(!format!("{provider:?}").contains("secret"));
 
@@ -903,7 +974,11 @@ mod tests {
             arb_reth_l1::L1Error::Missing("SequencerBatchData event"),
         );
         assert!(!deterministic.is_retryable());
-        assert!(deterministic.to_string().contains("missing SequencerBatchData event"));
+        assert!(
+            deterministic
+                .to_string()
+                .contains("missing SequencerBatchData event")
+        );
     }
 
     #[test]

--- a/crates/arb-reth-sync/src/l1_sync.rs
+++ b/crates/arb-reth-sync/src/l1_sync.rs
@@ -57,8 +57,8 @@ const RETRY_MAX_DELAY: Duration = Duration::from_secs(30);
 pub enum L1SyncError {
     /// An execution RPC or beacon request failed. `detail` is the provider's message with any URL
     /// redacted, because HTTP client errors carry credential-bearing endpoint URLs and these end up
-    /// in logs. Without it a quota-exhausted endpoint and a malformed response are indistinguishable,
-    /// which has cost real debugging time.
+    /// in logs. Without it a quota-exhausted endpoint and a malformed response are
+    /// indistinguishable.
     Provider {
         operation: &'static str,
         detail: String,


### PR DESCRIPTION
## Convert a Nitro snapshot into a reth datadir with full history

`snapshot import` only ever wrote head state, so a converted node could not answer
any historical query. This adds the full path: blocks, per-block state history, and
state, in two commands.

```
reth-export --mode full-snapshot --arbitrumdata <snap>/arbitrumdata
            --parallel 12 --cache 45000 <snap>/l2chaindata > snapshot.bin

arb-reth snapshot import-full --stream snapshot.bin --out <datadir>
            --chain-info chaininfo.json --genesis genesis.json
```
### Validated on the Robinhood archive snapshot

27,433,114 blocks, 245,034,962 transactions, 5,287,614 accounts, 160M slots.
Import ~50 min, finalisation ~ 35 min, ~500 GiB out.

- every block's `transactionsRoot` and `receiptsRoot` recomputed and matched, 0 failures
- state root reproduced exactly
- historical `eth_getBalance` / `getCode` / `getStorageAt` / `eth_call` match the
  canonical RPC at 12 blocks from 500k to the head
- boots, resumes derivation, and the blocks it derives match canonical including the
  first one past the convert point

Receipts are fiddly, geth stores neither the logs bloom nor the transaction
type, so both are reconstructed. 

The stream also carries the L1 derivation cursor, read out of Nitro's arbitrumdata.

### Also here

`snapshot finalize --datadir` runs the last stage on its own, so a failure there does
not force a re-import.

`L1SyncError::Provider` kept only an operation name and dropped the cause, so a
quota-exhausted endpoint and a malformed response looked identical. URLs are now
redacted and the rest survives, which is what the existing test name already promised.
