### PR TITLE
ix(rpc): report the base fee as effectiveGasPric

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,8 +69,8 @@ incremental = false
 [workspace.dependencies]
 # Keep the ArbOS implementation revision in one place. Individual crates opt into it with
 # `arb-revm.workspace = true`; only the EVM integration enables the Stylus runtime.
-arb-revm = { git = "https://github.com/nuntax/arbitrum-revm", rev = "2ebb753bea34be79950bebe1631461de7f079f59" }
+arb-revm = { git = "https://github.com/nuntax/arbitrum-revm", rev = "d38ddb0c72fb9ae256cc279b56c46a8cb272c5bb" }
 # Pinned to revm 42 to unify with arb_revm workspace.
-revm = { version = "42.0.1", features = ["optional_priority_fee_check", "optional_balance_check", "optional_eip7623", "optional_eip3541"] }
+revm = { version = "42.0.1", features = ["optional_priority_fee_check", "optional_balance_check", "optional_no_base_fee", "optional_eip7623", "optional_eip3541"] }
 alloy-rlp = "0.3.12"
 serde_json = "1.0.145"

--- a/crates/arb-reth-rpc/src/lib.rs
+++ b/crates/arb-reth-rpc/src/lib.rs
@@ -166,11 +166,19 @@ where
     // Use a Cell to capture gas_used_for_l1 from within the mapping closure.
     let gas_cell = std::cell::Cell::new(0u64);
 
-    let core = build_receipt::<N, _>(input, None, |envelope, next_log_index, meta| {
+    // Arbitrum has no priority fee: the sequencer charges the base fee and refunds the difference,
+    // so what a transaction actually paid per gas is the block's base fee. reth derives the field
+    // with Ethereum's tip formula, which returns the transaction's max fee instead.
+    let base_fee = input.meta.base_fee;
+
+    let mut core = build_receipt::<N, _>(input, None, |envelope, next_log_index, meta| {
         let (g, rpc_envelope) = map_arb_receipt_envelope(envelope, next_log_index, meta);
         gas_cell.set(g);
         rpc_envelope
     });
+    if let Some(base_fee) = base_fee {
+        core.effective_gas_price = base_fee as u128;
+    }
 
     Ok(ArbTransactionReceipt {
         inner: core,


### PR DESCRIPTION
Arbitrum has no priority fee: the sequencer charges the base fee and refunds
the difference, so what a transaction paid per gas is the block's base fee.
reth derives the field with Ethereum's tip formula, which returns the
transaction's max fee, and every receipt we served carried that instead.

Measured against the canonical Robinhood RPC at three blocks, ours equalled
the transaction's gas price and canonical equalled the block's base fee,
exactly, at every one.
