### PR TITLE
fix(snapshot): align full stream magic

### DIFF
--- a/crates/arb-reth-genesis/go-exporter/reth-export.go
+++ b/crates/arb-reth-genesis/go-exporter/reth-export.go
@@ -587,7 +587,7 @@ func writeShortBytes(w *bufio.Writer, b []byte) {
 
 // Stream framing. Sections appear in this order and each is self-terminating.
 const (
-	snapStreamMagic = "ARBSNAP1"
+	snapStreamMagic = "ARBSNAP2"
 
 	// Section tags live above the record tags on purpose. They shared a range in the first draft,
 	// which made a receipts record inside the blocks section indistinguishable from the start of

--- a/crates/arb-reth-genesis/src/snapshot_stream.rs
+++ b/crates/arb-reth-genesis/src/snapshot_stream.rs
@@ -924,6 +924,13 @@ mod tests {
         assert!(err.contains("does not hash to"), "{err}");
     }
 
+    #[test]
+    fn full_snapshot_exporter_magic_matches_importer() {
+        let exporter = include_str!("../go-exporter/reth-export.go");
+        assert!(exporter.contains(r#"snapStreamMagic = "ARBSNAP2""#));
+        assert!(!exporter.contains(r#"snapStreamMagic = "ARBSNAP1""#));
+    }
+
     /// An empty body must produce the empty trie root, which is what a header with no transactions
     /// commits to.
     #[test]


### PR DESCRIPTION
Fixes #36.

Make `reth-export --mode full-snapshot` emit the importer's `ARBSNAP2` header and add a regression test that keeps both sides aligned.

Tests: `cargo test -p arb-reth-genesis`.