### PR TITLE
fix(persistence): retain Storage V2 frontiers

### DIFF
--- a/crates/arb-reth-engine/Cargo.toml
+++ b/crates/arb-reth-engine/Cargo.toml
@@ -31,33 +31,33 @@ tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync", "time"
 revm = { workspace = true }
 revm-database = "42.0.0"
 
-reth-chain-state = { git = "https://github.com/nuntax/reth.git", rev = "49e941db296fc441c4747dca23b0e2f66c0a5872" }
-reth-db-api = { git = "https://github.com/nuntax/reth.git", rev = "49e941db296fc441c4747dca23b0e2f66c0a5872" }
-reth-basic-payload-builder = { git = "https://github.com/nuntax/reth.git", rev = "49e941db296fc441c4747dca23b0e2f66c0a5872" }
-reth-consensus = { git = "https://github.com/nuntax/reth.git", rev = "49e941db296fc441c4747dca23b0e2f66c0a5872" }
-reth-engine-primitives = { git = "https://github.com/nuntax/reth.git", rev = "49e941db296fc441c4747dca23b0e2f66c0a5872" }
-reth-engine-tree = { git = "https://github.com/nuntax/reth.git", rev = "49e941db296fc441c4747dca23b0e2f66c0a5872" }
-reth-evm = { git = "https://github.com/nuntax/reth.git", rev = "49e941db296fc441c4747dca23b0e2f66c0a5872" }
-reth-execution-cache = { git = "https://github.com/nuntax/reth.git", rev = "49e941db296fc441c4747dca23b0e2f66c0a5872" }
-reth-execution-types = { git = "https://github.com/nuntax/reth.git", rev = "49e941db296fc441c4747dca23b0e2f66c0a5872" }
-reth-exex-types = { git = "https://github.com/nuntax/reth.git", rev = "49e941db296fc441c4747dca23b0e2f66c0a5872" }
-reth-payload-builder = { git = "https://github.com/nuntax/reth.git", rev = "49e941db296fc441c4747dca23b0e2f66c0a5872" }
-reth-payload-primitives = { git = "https://github.com/nuntax/reth.git", rev = "49e941db296fc441c4747dca23b0e2f66c0a5872" }
+reth-chain-state = { git = "https://github.com/nuntax/reth.git", rev = "547581ff58e62577ef880e986a1b870feaa1a1b0" }
+reth-db-api = { git = "https://github.com/nuntax/reth.git", rev = "547581ff58e62577ef880e986a1b870feaa1a1b0" }
+reth-basic-payload-builder = { git = "https://github.com/nuntax/reth.git", rev = "547581ff58e62577ef880e986a1b870feaa1a1b0" }
+reth-consensus = { git = "https://github.com/nuntax/reth.git", rev = "547581ff58e62577ef880e986a1b870feaa1a1b0" }
+reth-engine-primitives = { git = "https://github.com/nuntax/reth.git", rev = "547581ff58e62577ef880e986a1b870feaa1a1b0" }
+reth-engine-tree = { git = "https://github.com/nuntax/reth.git", rev = "547581ff58e62577ef880e986a1b870feaa1a1b0" }
+reth-evm = { git = "https://github.com/nuntax/reth.git", rev = "547581ff58e62577ef880e986a1b870feaa1a1b0" }
+reth-execution-cache = { git = "https://github.com/nuntax/reth.git", rev = "547581ff58e62577ef880e986a1b870feaa1a1b0" }
+reth-execution-types = { git = "https://github.com/nuntax/reth.git", rev = "547581ff58e62577ef880e986a1b870feaa1a1b0" }
+reth-exex-types = { git = "https://github.com/nuntax/reth.git", rev = "547581ff58e62577ef880e986a1b870feaa1a1b0" }
+reth-payload-builder = { git = "https://github.com/nuntax/reth.git", rev = "547581ff58e62577ef880e986a1b870feaa1a1b0" }
+reth-payload-primitives = { git = "https://github.com/nuntax/reth.git", rev = "547581ff58e62577ef880e986a1b870feaa1a1b0" }
 reth-primitives-traits = { version = "0.6.0", default-features = false }
-reth-provider = { git = "https://github.com/nuntax/reth.git", rev = "49e941db296fc441c4747dca23b0e2f66c0a5872" }
-reth-prune = { git = "https://github.com/nuntax/reth.git", rev = "49e941db296fc441c4747dca23b0e2f66c0a5872" }
-reth-revm = { git = "https://github.com/nuntax/reth.git", rev = "49e941db296fc441c4747dca23b0e2f66c0a5872" }
-reth-stages-api = { git = "https://github.com/nuntax/reth.git", rev = "49e941db296fc441c4747dca23b0e2f66c0a5872" }
-reth-stages = { git = "https://github.com/nuntax/reth.git", rev = "49e941db296fc441c4747dca23b0e2f66c0a5872" }
-reth-storage-api = { git = "https://github.com/nuntax/reth.git", rev = "49e941db296fc441c4747dca23b0e2f66c0a5872", features = ["db-api"] }
-reth-storage-overlay = { git = "https://github.com/nuntax/reth.git", rev = "49e941db296fc441c4747dca23b0e2f66c0a5872" }
-reth-tasks = { git = "https://github.com/nuntax/reth.git", rev = "49e941db296fc441c4747dca23b0e2f66c0a5872" }
-reth-trie-db = { git = "https://github.com/nuntax/reth.git", rev = "49e941db296fc441c4747dca23b0e2f66c0a5872" }
-reth-trie = { git = "https://github.com/nuntax/reth.git", rev = "49e941db296fc441c4747dca23b0e2f66c0a5872" }
+reth-provider = { git = "https://github.com/nuntax/reth.git", rev = "547581ff58e62577ef880e986a1b870feaa1a1b0" }
+reth-prune = { git = "https://github.com/nuntax/reth.git", rev = "547581ff58e62577ef880e986a1b870feaa1a1b0" }
+reth-revm = { git = "https://github.com/nuntax/reth.git", rev = "547581ff58e62577ef880e986a1b870feaa1a1b0" }
+reth-stages-api = { git = "https://github.com/nuntax/reth.git", rev = "547581ff58e62577ef880e986a1b870feaa1a1b0" }
+reth-stages = { git = "https://github.com/nuntax/reth.git", rev = "547581ff58e62577ef880e986a1b870feaa1a1b0" }
+reth-storage-api = { git = "https://github.com/nuntax/reth.git", rev = "547581ff58e62577ef880e986a1b870feaa1a1b0", features = ["db-api"] }
+reth-storage-overlay = { git = "https://github.com/nuntax/reth.git", rev = "547581ff58e62577ef880e986a1b870feaa1a1b0" }
+reth-tasks = { git = "https://github.com/nuntax/reth.git", rev = "547581ff58e62577ef880e986a1b870feaa1a1b0" }
+reth-trie-db = { git = "https://github.com/nuntax/reth.git", rev = "547581ff58e62577ef880e986a1b870feaa1a1b0" }
+reth-trie = { git = "https://github.com/nuntax/reth.git", rev = "547581ff58e62577ef880e986a1b870feaa1a1b0" }
 
 [dev-dependencies]
-reth-db-common = { git = "https://github.com/nuntax/reth.git", rev = "49e941db296fc441c4747dca23b0e2f66c0a5872" }
-reth-chainspec = { git = "https://github.com/nuntax/reth.git", rev = "49e941db296fc441c4747dca23b0e2f66c0a5872" }
-reth-node-types = { git = "https://github.com/nuntax/reth.git", rev = "49e941db296fc441c4747dca23b0e2f66c0a5872" }
-reth-provider = { git = "https://github.com/nuntax/reth.git", rev = "49e941db296fc441c4747dca23b0e2f66c0a5872", features = ["test-utils", "partial-persistence"] }
+reth-db-common = { git = "https://github.com/nuntax/reth.git", rev = "547581ff58e62577ef880e986a1b870feaa1a1b0" }
+reth-chainspec = { git = "https://github.com/nuntax/reth.git", rev = "547581ff58e62577ef880e986a1b870feaa1a1b0" }
+reth-node-types = { git = "https://github.com/nuntax/reth.git", rev = "547581ff58e62577ef880e986a1b870feaa1a1b0" }
+reth-provider = { git = "https://github.com/nuntax/reth.git", rev = "547581ff58e62577ef880e986a1b870feaa1a1b0", features = ["test-utils", "partial-persistence"] }
 tempfile = "3"

--- a/crates/arb-reth-engine/src/storage_v2.rs
+++ b/crates/arb-reth-engine/src/storage_v2.rs
@@ -7,11 +7,12 @@
 
 use std::{
     sync::{Arc, OnceLock, mpsc},
-    thread::JoinHandle,
-    time::Instant,
+    thread::{self, JoinHandle},
+    time::{Duration, Instant},
 };
 
 use alloy_consensus::Header;
+use alloy_eips::BlockNumHash;
 use alloy_primitives::{
     Address, B256, U256, keccak256,
     map::{B256Map, HashSet},
@@ -27,7 +28,7 @@ use reth_db_api::{
     tables,
     transaction::DbTx,
 };
-use reth_engine_tree::persistence::{PersistenceAction, PersistenceHandle};
+use reth_engine_tree::persistence::{PersistenceAction, PersistenceHandle, PersistenceResult};
 use reth_execution_types::BlockExecutionOutput;
 use reth_payload_primitives::BuiltPayloadExecutedBlock;
 use reth_provider::{
@@ -48,6 +49,49 @@ use reth_trie::{
 
 /// Joins the persistence proxy after the engine-tree request sender has been dropped.
 pub(crate) struct PersistenceProxyGuard(Option<JoinHandle<()>>);
+
+/// The durable persistence frontiers confirmed by Reth's persistence service.
+///
+/// Reth determines these while it still owns the write transaction. Retaining them avoids
+/// reopening a static-file header immediately after a commit, before its index is necessarily
+/// visible to a new read-only provider.
+#[derive(Debug, Default)]
+struct PersistenceFrontiers {
+    last_block: Option<BlockNumHash>,
+    last_state_trie_block: Option<BlockNumHash>,
+}
+
+impl PersistenceFrontiers {
+    fn update(&mut self, result: &PersistenceResult) {
+        self.last_block = Some(result.last_block);
+        self.last_state_trie_block = Some(result.last_state_trie_block);
+    }
+
+    fn state_trie_parent(
+        &self,
+        prev_db_tip: u64,
+        prev_partial_state_trie: u64,
+    ) -> eyre::Result<B256> {
+        let last_block = self.last_block.ok_or_else(|| {
+            eyre!("persistence frontier cache is incomplete: missing database tip")
+        })?;
+        let last_state_trie_block = self.last_state_trie_block.ok_or_else(|| {
+            eyre!("persistence frontier cache is incomplete: missing state/trie tip")
+        })?;
+
+        if (last_block.number, last_state_trie_block.number)
+            != (prev_db_tip, prev_partial_state_trie)
+        {
+            return Err(eyre!(
+                "persistence input frontiers ({prev_db_tip}, {prev_partial_state_trie}) do not match confirmed frontiers ({}, {})",
+                last_block.number,
+                last_state_trie_block.number,
+            ));
+        }
+
+        Ok(last_state_trie_block.hash)
+    }
+}
 
 impl Drop for PersistenceProxyGuard {
     fn drop(&mut self) {
@@ -80,22 +124,25 @@ where
     let (sender, receiver) = mpsc::channel();
     let handle = spawn_os_thread("arb-storage-v2-persistence", move || {
         let mut preimages = None;
+        let mut frontiers = PersistenceFrontiers::default();
         while let Ok(action) = receiver.recv() {
             match action {
                 PersistenceAction::SaveBlocks(input, response) => {
-                    let input = match prepare_storage_v2_batch(&factory, input, &mut preimages) {
-                        Ok(input) => input,
-                        Err(err) => {
-                            tracing::error!(
-                                target: "arb-reth::persistence",
-                                %err,
-                                "failed to prepare Storage V2 persistence batch",
-                            );
-                            // Dropping the response sender makes the engine tree surface the
-                            // failure instead of persisting an unwind-unsafe batch.
-                            break;
-                        }
-                    };
+                    let input =
+                        match prepare_storage_v2_batch(&factory, input, &mut preimages, &frontiers)
+                        {
+                            Ok(input) => input,
+                            Err(err) => {
+                                tracing::error!(
+                                    target: "arb-reth::persistence",
+                                    %err,
+                                    "failed to prepare Storage V2 persistence batch",
+                                );
+                                // Dropping the response sender makes the engine tree surface the
+                                // failure instead of persisting an unwind-unsafe batch.
+                                break;
+                            }
+                        };
 
                     let (delegate_tx, delegate_rx) = crossbeam_channel::bounded(1);
                     if delegate.save_blocks(input, delegate_tx).is_err() {
@@ -104,6 +151,7 @@ where
                     let Ok(result) = delegate_rx.recv() else {
                         break;
                     };
+                    frontiers.update(&result);
                     let _ = response.send(result);
                 }
                 PersistenceAction::RemoveBlocksAbove(block, response) => {
@@ -114,6 +162,7 @@ where
                     let Ok(result) = delegate_rx.recv() else {
                         break;
                     };
+                    frontiers.update(&result);
                     let _ = response.send(result);
                 }
                 action => {
@@ -135,6 +184,7 @@ fn prepare_storage_v2_batch<N>(
     factory: &ProviderFactory<N>,
     input: SaveBlocksInput<ArbPrimitives>,
     preimages: &mut Option<SlotPreimages>,
+    frontiers: &PersistenceFrontiers,
 ) -> eyre::Result<SaveBlocksInput<ArbPrimitives>>
 where
     N: ProviderNodeTypes<Primitives = ArbPrimitives>,
@@ -161,7 +211,13 @@ where
         return Ok(input);
     }
 
-    validate_persistence_batch(&provider, &blocks, prev_db_tip, prev_partial_state_trie)?;
+    validate_persistence_batch(
+        factory,
+        frontiers,
+        &blocks,
+        prev_db_tip,
+        prev_partial_state_trie,
+    )?;
     let legacy = legacy_block_flags(&provider, &blocks)?;
     if !legacy.iter().any(|legacy| *legacy) {
         return Ok(input);
@@ -325,12 +381,72 @@ fn record_storage_v2_metrics(
     metrics.injected_slots.record(injected_slots as f64);
 }
 
-fn validate_persistence_batch<P>(
-    provider: &P,
+const BOOTSTRAP_FRONTIER_READ_ATTEMPTS: usize = 2;
+
+fn validate_persistence_batch<N>(
+    factory: &ProviderFactory<N>,
+    frontiers: &PersistenceFrontiers,
     blocks: &[ExecutedBlock<ArbPrimitives>],
     prev_db_tip: u64,
     prev_partial_state_trie: u64,
 ) -> eyre::Result<()>
+where
+    N: ProviderNodeTypes<Primitives = ArbPrimitives>,
+    <ProviderFactory<N> as DatabaseProviderFactory>::Provider:
+        BlockNumReader + HeaderProvider<Header = Header> + StageCheckpointReader,
+{
+    let expected_parent = if frontiers.last_state_trie_block.is_some() {
+        frontiers.state_trie_parent(prev_db_tip, prev_partial_state_trie)?
+    } else {
+        read_bootstrap_persistence_frontier(factory, prev_db_tip, prev_partial_state_trie)?
+    };
+
+    validate_persistence_blocks(blocks, prev_partial_state_trie, expected_parent)
+}
+
+fn read_bootstrap_persistence_frontier<N>(
+    factory: &ProviderFactory<N>,
+    prev_db_tip: u64,
+    prev_partial_state_trie: u64,
+) -> eyre::Result<B256>
+where
+    N: ProviderNodeTypes<Primitives = ArbPrimitives>,
+    <ProviderFactory<N> as DatabaseProviderFactory>::Provider:
+        BlockNumReader + HeaderProvider<Header = Header> + StageCheckpointReader,
+{
+    let mut last_error = None;
+    for attempt in 1..=BOOTSTRAP_FRONTIER_READ_ATTEMPTS {
+        let result = factory
+            .database_provider_ro()
+            .map_err(eyre::Report::from)
+            .and_then(|provider| {
+                read_durable_persistence_frontier(&provider, prev_db_tip, prev_partial_state_trie)
+            });
+        match result {
+            Ok(parent) => return Ok(parent),
+            Err(err) if attempt < BOOTSTRAP_FRONTIER_READ_ATTEMPTS => {
+                tracing::warn!(
+                    target: "arb-reth::persistence",
+                    attempt,
+                    max_attempts = BOOTSTRAP_FRONTIER_READ_ATTEMPTS,
+                    %err,
+                    "retrying Storage V2 persistence frontier bootstrap",
+                );
+                last_error = Some(err);
+                thread::sleep(Duration::from_millis(10));
+            }
+            Err(err) => return Err(err),
+        }
+    }
+
+    Err(last_error.expect("bootstrap frontier loop returns on the final attempt"))
+}
+
+fn read_durable_persistence_frontier<P>(
+    provider: &P,
+    prev_db_tip: u64,
+    prev_partial_state_trie: u64,
+) -> eyre::Result<B256>
 where
     P: BlockNumReader + HeaderProvider<Header = Header> + StageCheckpointReader,
 {
@@ -355,13 +471,20 @@ where
             "persistence input frontiers ({prev_db_tip}, {prev_partial_state_trie}) do not match Finish checkpoint ({checkpoint_db_tip}, {checkpoint_state_trie_tip})"
         ));
     }
+    provider
+        .sealed_header(prev_partial_state_trie)?
+        .ok_or_else(|| eyre!("missing state/trie frontier header {prev_partial_state_trie}"))
+        .map(|header| header.hash())
+}
+
+fn validate_persistence_blocks(
+    blocks: &[ExecutedBlock<ArbPrimitives>],
+    prev_partial_state_trie: u64,
+    mut expected_parent: B256,
+) -> eyre::Result<()> {
     let mut expected_number = prev_partial_state_trie
         .checked_add(1)
         .ok_or_else(|| eyre!("durable block number overflow"))?;
-    let mut expected_parent = provider
-        .sealed_header(prev_partial_state_trie)?
-        .ok_or_else(|| eyre!("missing state/trie frontier header {prev_partial_state_trie}"))?
-        .hash();
 
     for block in blocks {
         if block.block_number() != expected_number {
@@ -740,6 +863,42 @@ mod tests {
                 Arc::new(trie_updates.into_sorted()),
             ),
         )
+    }
+
+    #[test]
+    fn cached_persistence_frontier_avoids_a_durable_header_read() -> eyre::Result<()> {
+        let factory =
+            create_test_provider_factory_with_node_types::<TestArbNode>(test_chain_spec());
+        init_genesis_with_settings(&factory, StorageSettings::v2())?;
+
+        // The database intentionally remains at genesis. A correct cached-frontier path must not
+        // inspect it while validating the next batch, because its static-file header may still be
+        // temporarily unavailable immediately after the preceding persistence commit.
+        let parent = b256!("0101010101010101010101010101010101010101010101010101010101010101");
+        let frontiers = PersistenceFrontiers {
+            last_block: Some(BlockNumHash::new(1, parent)),
+            last_state_trie_block: Some(BlockNumHash::new(1, parent)),
+        };
+        let block = executed_block(
+            arb_header(2, parent, B256::ZERO),
+            BundleState::default(),
+            HashedPostState::default(),
+            TrieUpdates::default(),
+        );
+
+        validate_persistence_batch(&factory, &frontiers, &[block], 1, 1)
+    }
+
+    #[test]
+    fn cached_persistence_frontier_rejects_a_real_frontier_mismatch() {
+        let hash = b256!("0101010101010101010101010101010101010101010101010101010101010101");
+        let frontiers = PersistenceFrontiers {
+            last_block: Some(BlockNumHash::new(1, hash)),
+            last_state_trie_block: Some(BlockNumHash::new(1, hash)),
+        };
+
+        let err = frontiers.state_trie_parent(2, 1).unwrap_err();
+        assert!(err.to_string().contains("do not match confirmed frontiers"));
     }
 
     #[test]

--- a/crates/arb-reth-evm/Cargo.toml
+++ b/crates/arb-reth-evm/Cargo.toml
@@ -16,7 +16,7 @@ revm = { workspace = true }
 # impls live inside arb-alloy behind the `reth` feature (orphan rule).
 arbitrum-alloy-consensus = { git = "https://github.com/nuntax/arbitrum-alloy", rev = "83593650bf6d07d2255e8627c417a9236cd5d02b", default-features = false, features = ["reth"] }
 
-reth-evm = { git = "https://github.com/nuntax/reth.git", rev = "49e941db296fc441c4747dca23b0e2f66c0a5872" }
+reth-evm = { git = "https://github.com/nuntax/reth.git", rev = "547581ff58e62577ef880e986a1b870feaa1a1b0" }
 alloy-evm = { version = "0.38", default-features = false }
 reth-primitives-traits = { version = "0.6.0", default-features = false }
 metrics = "0.24"
@@ -29,7 +29,7 @@ alloy-primitives = { version = "1", default-features = false }
 # rpc feature: TryIntoTxEnv and BuildPendingEnv impls for Arbitrum RPC types.
 arbitrum-alloy-rpc-types = { git = "https://github.com/nuntax/arbitrum-alloy", rev = "83593650bf6d07d2255e8627c417a9236cd5d02b", optional = true }
 alloy-rpc-types-eth = { version = "2.0", default-features = false, optional = true }
-reth-rpc-eth-api = { git = "https://github.com/nuntax/reth.git", rev = "49e941db296fc441c4747dca23b0e2f66c0a5872", optional = true }
+reth-rpc-eth-api = { git = "https://github.com/nuntax/reth.git", rev = "547581ff58e62577ef880e986a1b870feaa1a1b0", optional = true }
 
 [features]
 rpc = ["arbitrum-alloy-rpc-types", "alloy-rpc-types-eth", "alloy-evm/rpc", "reth-rpc-eth-api"]

--- a/crates/arb-reth-node/Cargo.toml
+++ b/crates/arb-reth-node/Cargo.toml
@@ -28,25 +28,25 @@ serde = { version = "1", default-features = false, features = ["derive"] }
 serde_json = { workspace = true }
 
 # reth node types + storage surface
-reth-node-types = { git = "https://github.com/nuntax/reth.git", rev = "49e941db296fc441c4747dca23b0e2f66c0a5872" }
-reth-chainspec = { git = "https://github.com/nuntax/reth.git", rev = "49e941db296fc441c4747dca23b0e2f66c0a5872" }
-reth-storage-api = { git = "https://github.com/nuntax/reth.git", rev = "49e941db296fc441c4747dca23b0e2f66c0a5872", features = ["db-api"] }
-reth-payload-primitives = { git = "https://github.com/nuntax/reth.git", rev = "49e941db296fc441c4747dca23b0e2f66c0a5872" }
+reth-node-types = { git = "https://github.com/nuntax/reth.git", rev = "547581ff58e62577ef880e986a1b870feaa1a1b0" }
+reth-chainspec = { git = "https://github.com/nuntax/reth.git", rev = "547581ff58e62577ef880e986a1b870feaa1a1b0" }
+reth-storage-api = { git = "https://github.com/nuntax/reth.git", rev = "547581ff58e62577ef880e986a1b870feaa1a1b0", features = ["db-api"] }
+reth-payload-primitives = { git = "https://github.com/nuntax/reth.git", rev = "547581ff58e62577ef880e986a1b870feaa1a1b0" }
 reth-primitives-traits = { version = "0.6.0", default-features = false }
 
 # D.2.2: trie, chain-state, execution types, provider write path
-reth-chain-state = { git = "https://github.com/nuntax/reth.git", rev = "49e941db296fc441c4747dca23b0e2f66c0a5872" }
-reth-execution-types = { git = "https://github.com/nuntax/reth.git", rev = "49e941db296fc441c4747dca23b0e2f66c0a5872" }
-reth-provider = { git = "https://github.com/nuntax/reth.git", rev = "49e941db296fc441c4747dca23b0e2f66c0a5872" }
-reth-prune-types = { git = "https://github.com/nuntax/reth.git", rev = "49e941db296fc441c4747dca23b0e2f66c0a5872" }
-reth-trie-common = { git = "https://github.com/nuntax/reth.git", rev = "49e941db296fc441c4747dca23b0e2f66c0a5872" }
+reth-chain-state = { git = "https://github.com/nuntax/reth.git", rev = "547581ff58e62577ef880e986a1b870feaa1a1b0" }
+reth-execution-types = { git = "https://github.com/nuntax/reth.git", rev = "547581ff58e62577ef880e986a1b870feaa1a1b0" }
+reth-provider = { git = "https://github.com/nuntax/reth.git", rev = "547581ff58e62577ef880e986a1b870feaa1a1b0" }
+reth-prune-types = { git = "https://github.com/nuntax/reth.git", rev = "547581ff58e62577ef880e986a1b870feaa1a1b0" }
+reth-trie-common = { git = "https://github.com/nuntax/reth.git", rev = "547581ff58e62577ef880e986a1b870feaa1a1b0" }
 # Keep the optimized precompile implementations aligned with reth-node-ethereum.
 revm = { workspace = true, features = ["secp256k1", "blst", "c-kzg", "memory_limit", "p256-aws-lc-rs"] }
 revm-database = "42.0.0"
 
 # D.2.3: driver (reth BlockBuilder + revm State<StateProviderDatabase>)
-reth-evm = { git = "https://github.com/nuntax/reth.git", rev = "49e941db296fc441c4747dca23b0e2f66c0a5872" }
-reth-revm = { git = "https://github.com/nuntax/reth.git", rev = "49e941db296fc441c4747dca23b0e2f66c0a5872" }
+reth-evm = { git = "https://github.com/nuntax/reth.git", rev = "547581ff58e62577ef880e986a1b870feaa1a1b0" }
+reth-revm = { git = "https://github.com/nuntax/reth.git", rev = "547581ff58e62577ef880e986a1b870feaa1a1b0" }
 arbitrum-alloy-sequencer = { git = "https://github.com/nuntax/arbitrum-alloy", rev = "83593650bf6d07d2255e8627c417a9236cd5d02b" }
 
 # Stage F.3c: L1-derivation catch-up runtime (SequencerInbox + delayed inbox -> feed).
@@ -57,26 +57,26 @@ alloy-provider = { version = "2.0", default-features = false, features = ["reqwe
 url = "2.5"
 
 # D.3b: NodeBuilder integration (Node<N> + noop components + custom LaunchNode)
-reth-node-builder = { git = "https://github.com/nuntax/reth.git", rev = "49e941db296fc441c4747dca23b0e2f66c0a5872" }
-reth-node-api = { git = "https://github.com/nuntax/reth.git", rev = "49e941db296fc441c4747dca23b0e2f66c0a5872" }
-reth-transaction-pool = { git = "https://github.com/nuntax/reth.git", rev = "49e941db296fc441c4747dca23b0e2f66c0a5872" }
-reth-eth-wire-types = { git = "https://github.com/nuntax/reth.git", rev = "49e941db296fc441c4747dca23b0e2f66c0a5872" }
-reth-consensus = { git = "https://github.com/nuntax/reth.git", rev = "49e941db296fc441c4747dca23b0e2f66c0a5872" }
+reth-node-builder = { git = "https://github.com/nuntax/reth.git", rev = "547581ff58e62577ef880e986a1b870feaa1a1b0" }
+reth-node-api = { git = "https://github.com/nuntax/reth.git", rev = "547581ff58e62577ef880e986a1b870feaa1a1b0" }
+reth-transaction-pool = { git = "https://github.com/nuntax/reth.git", rev = "547581ff58e62577ef880e986a1b870feaa1a1b0" }
+reth-eth-wire-types = { git = "https://github.com/nuntax/reth.git", rev = "547581ff58e62577ef880e986a1b870feaa1a1b0" }
+reth-consensus = { git = "https://github.com/nuntax/reth.git", rev = "547581ff58e62577ef880e986a1b870feaa1a1b0" }
 alloy-rlp = { workspace = true }
 
 # D.3b.2: custom launcher (storage overlay, reth tasks, reth-db DatabaseEnv)
-reth-trie-db = { git = "https://github.com/nuntax/reth.git", rev = "49e941db296fc441c4747dca23b0e2f66c0a5872" }
-reth-trie = { git = "https://github.com/nuntax/reth.git", rev = "49e941db296fc441c4747dca23b0e2f66c0a5872" }
-reth-storage-overlay = { git = "https://github.com/nuntax/reth.git", rev = "49e941db296fc441c4747dca23b0e2f66c0a5872" }
-reth-db-api = { git = "https://github.com/nuntax/reth.git", rev = "49e941db296fc441c4747dca23b0e2f66c0a5872" }
-reth-tasks = { git = "https://github.com/nuntax/reth.git", rev = "49e941db296fc441c4747dca23b0e2f66c0a5872" }
-reth-db = { git = "https://github.com/nuntax/reth.git", rev = "49e941db296fc441c4747dca23b0e2f66c0a5872" }
+reth-trie-db = { git = "https://github.com/nuntax/reth.git", rev = "547581ff58e62577ef880e986a1b870feaa1a1b0" }
+reth-trie = { git = "https://github.com/nuntax/reth.git", rev = "547581ff58e62577ef880e986a1b870feaa1a1b0" }
+reth-storage-overlay = { git = "https://github.com/nuntax/reth.git", rev = "547581ff58e62577ef880e986a1b870feaa1a1b0" }
+reth-db-api = { git = "https://github.com/nuntax/reth.git", rev = "547581ff58e62577ef880e986a1b870feaa1a1b0" }
+reth-tasks = { git = "https://github.com/nuntax/reth.git", rev = "547581ff58e62577ef880e986a1b870feaa1a1b0" }
+reth-db = { git = "https://github.com/nuntax/reth.git", rev = "547581ff58e62577ef880e986a1b870feaa1a1b0" }
 
 # H/#52: boot-wiring (static-file Headers segment + stage checkpoints)
-reth-stages-types = { git = "https://github.com/nuntax/reth.git", rev = "49e941db296fc441c4747dca23b0e2f66c0a5872" }
-reth-static-file-types = { git = "https://github.com/nuntax/reth.git", rev = "49e941db296fc441c4747dca23b0e2f66c0a5872" }
+reth-stages-types = { git = "https://github.com/nuntax/reth.git", rev = "547581ff58e62577ef880e986a1b870feaa1a1b0" }
+reth-static-file-types = { git = "https://github.com/nuntax/reth.git", rev = "547581ff58e62577ef880e986a1b870feaa1a1b0" }
 # H/#1: launch genesis-acceptance gate (init_genesis_with_settings_and_validate)
-reth-db-common = { git = "https://github.com/nuntax/reth.git", rev = "49e941db296fc441c4747dca23b0e2f66c0a5872" }
+reth-db-common = { git = "https://github.com/nuntax/reth.git", rev = "547581ff58e62577ef880e986a1b870feaa1a1b0" }
 tracing = "0.1"
 metrics = "0.24"
 
@@ -95,34 +95,34 @@ rustls = { version = "0.23", default-features = false, features = ["aws_lc_rs"] 
 
 # D.3b.4: bin/arb-reth (clap CLI, reth runtime/ctrl-c harness, tracing, node-core)
 clap = { version = "4", features = ["derive"] }
-reth-cli-runner = { git = "https://github.com/nuntax/reth.git", rev = "49e941db296fc441c4747dca23b0e2f66c0a5872" }
-reth-tracing = { git = "https://github.com/nuntax/reth.git", rev = "49e941db296fc441c4747dca23b0e2f66c0a5872" }
-reth-node-core = { git = "https://github.com/nuntax/reth.git", rev = "49e941db296fc441c4747dca23b0e2f66c0a5872" }
-reth-metrics = { git = "https://github.com/nuntax/reth.git", rev = "49e941db296fc441c4747dca23b0e2f66c0a5872" }
+reth-cli-runner = { git = "https://github.com/nuntax/reth.git", rev = "547581ff58e62577ef880e986a1b870feaa1a1b0" }
+reth-tracing = { git = "https://github.com/nuntax/reth.git", rev = "547581ff58e62577ef880e986a1b870feaa1a1b0" }
+reth-node-core = { git = "https://github.com/nuntax/reth.git", rev = "547581ff58e62577ef880e986a1b870feaa1a1b0" }
+reth-metrics = { git = "https://github.com/nuntax/reth.git", rev = "547581ff58e62577ef880e986a1b870feaa1a1b0" }
 
 # D.5: Arbitrum RPC converters (receipt/rpc converters), consumed by the canonical RpcAddOns wiring.
 arb-reth-rpc = { path = "../arb-reth-rpc" }
 arbitrum-alloy-network = { git = "https://github.com/nuntax/arbitrum-alloy", rev = "83593650bf6d07d2255e8627c417a9236cd5d02b" }
 arbitrum-alloy-rpc-types = { git = "https://github.com/nuntax/arbitrum-alloy", rev = "83593650bf6d07d2255e8627c417a9236cd5d02b", features = ["reth-compat"] }
-reth-rpc = { git = "https://github.com/nuntax/reth.git", rev = "49e941db296fc441c4747dca23b0e2f66c0a5872" }
-reth-rpc-builder = { git = "https://github.com/nuntax/reth.git", rev = "49e941db296fc441c4747dca23b0e2f66c0a5872" }
-reth-rpc-eth-api = { git = "https://github.com/nuntax/reth.git", rev = "49e941db296fc441c4747dca23b0e2f66c0a5872" }
-reth-rpc-eth-types = { git = "https://github.com/nuntax/reth.git", rev = "49e941db296fc441c4747dca23b0e2f66c0a5872" }
-reth-rpc-convert = { git = "https://github.com/nuntax/reth.git", rev = "49e941db296fc441c4747dca23b0e2f66c0a5872" }
-reth-rpc-server-types = { git = "https://github.com/nuntax/reth.git", rev = "49e941db296fc441c4747dca23b0e2f66c0a5872" }
-reth-network-api = { git = "https://github.com/nuntax/reth.git", rev = "49e941db296fc441c4747dca23b0e2f66c0a5872" }
-reth-engine-primitives = { git = "https://github.com/nuntax/reth.git", rev = "49e941db296fc441c4747dca23b0e2f66c0a5872" }
-reth-tokio-util = { git = "https://github.com/nuntax/reth.git", rev = "49e941db296fc441c4747dca23b0e2f66c0a5872" }
+reth-rpc = { git = "https://github.com/nuntax/reth.git", rev = "547581ff58e62577ef880e986a1b870feaa1a1b0" }
+reth-rpc-builder = { git = "https://github.com/nuntax/reth.git", rev = "547581ff58e62577ef880e986a1b870feaa1a1b0" }
+reth-rpc-eth-api = { git = "https://github.com/nuntax/reth.git", rev = "547581ff58e62577ef880e986a1b870feaa1a1b0" }
+reth-rpc-eth-types = { git = "https://github.com/nuntax/reth.git", rev = "547581ff58e62577ef880e986a1b870feaa1a1b0" }
+reth-rpc-convert = { git = "https://github.com/nuntax/reth.git", rev = "547581ff58e62577ef880e986a1b870feaa1a1b0" }
+reth-rpc-server-types = { git = "https://github.com/nuntax/reth.git", rev = "547581ff58e62577ef880e986a1b870feaa1a1b0" }
+reth-network-api = { git = "https://github.com/nuntax/reth.git", rev = "547581ff58e62577ef880e986a1b870feaa1a1b0" }
+reth-engine-primitives = { git = "https://github.com/nuntax/reth.git", rev = "547581ff58e62577ef880e986a1b870feaa1a1b0" }
+reth-tokio-util = { git = "https://github.com/nuntax/reth.git", rev = "547581ff58e62577ef880e986a1b870feaa1a1b0" }
 
 # Tier-1 engine-tree driver: now in the arb-reth-engine crate (payload stubs + ArbEngineDriver).
 arb-reth-engine = { path = "../arb-reth-engine" }
-reth-engine-tree = { git = "https://github.com/nuntax/reth.git", rev = "49e941db296fc441c4747dca23b0e2f66c0a5872" }
-reth-payload-builder = { git = "https://github.com/nuntax/reth.git", rev = "49e941db296fc441c4747dca23b0e2f66c0a5872" }
-reth-prune = { git = "https://github.com/nuntax/reth.git", rev = "49e941db296fc441c4747dca23b0e2f66c0a5872" }
-reth-config = { git = "https://github.com/nuntax/reth.git", rev = "49e941db296fc441c4747dca23b0e2f66c0a5872" }
-reth-exex-types = { git = "https://github.com/nuntax/reth.git", rev = "49e941db296fc441c4747dca23b0e2f66c0a5872" }
-reth-stages-api = { git = "https://github.com/nuntax/reth.git", rev = "49e941db296fc441c4747dca23b0e2f66c0a5872" }
-reth-stages = { git = "https://github.com/nuntax/reth.git", rev = "49e941db296fc441c4747dca23b0e2f66c0a5872" }
+reth-engine-tree = { git = "https://github.com/nuntax/reth.git", rev = "547581ff58e62577ef880e986a1b870feaa1a1b0" }
+reth-payload-builder = { git = "https://github.com/nuntax/reth.git", rev = "547581ff58e62577ef880e986a1b870feaa1a1b0" }
+reth-prune = { git = "https://github.com/nuntax/reth.git", rev = "547581ff58e62577ef880e986a1b870feaa1a1b0" }
+reth-config = { git = "https://github.com/nuntax/reth.git", rev = "547581ff58e62577ef880e986a1b870feaa1a1b0" }
+reth-exex-types = { git = "https://github.com/nuntax/reth.git", rev = "547581ff58e62577ef880e986a1b870feaa1a1b0" }
+reth-stages-api = { git = "https://github.com/nuntax/reth.git", rev = "547581ff58e62577ef880e986a1b870feaa1a1b0" }
+reth-stages = { git = "https://github.com/nuntax/reth.git", rev = "547581ff58e62577ef880e986a1b870feaa1a1b0" }
 crossbeam-channel = "0.5"
 
 [features]
@@ -140,14 +140,14 @@ gmp = ["reth-revm/gmp", "revm/gmp"]
 
 [dev-dependencies]
 serde_json = { workspace = true }
-reth-provider = { git = "https://github.com/nuntax/reth.git", rev = "49e941db296fc441c4747dca23b0e2f66c0a5872", features = ["test-utils"] }
-reth-chainspec = { git = "https://github.com/nuntax/reth.git", rev = "49e941db296fc441c4747dca23b0e2f66c0a5872" }
-reth-node-builder = { git = "https://github.com/nuntax/reth.git", rev = "49e941db296fc441c4747dca23b0e2f66c0a5872", features = ["test-utils"] }
+reth-provider = { git = "https://github.com/nuntax/reth.git", rev = "547581ff58e62577ef880e986a1b870feaa1a1b0", features = ["test-utils"] }
+reth-chainspec = { git = "https://github.com/nuntax/reth.git", rev = "547581ff58e62577ef880e986a1b870feaa1a1b0" }
+reth-node-builder = { git = "https://github.com/nuntax/reth.git", rev = "547581ff58e62577ef880e986a1b870feaa1a1b0", features = ["test-utils"] }
 revm-state = "42.0.0"
 tempfile = "3"
 arbitrum-alloy-consensus = { git = "https://github.com/nuntax/arbitrum-alloy", rev = "83593650bf6d07d2255e8627c417a9236cd5d02b", default-features = false, features = ["reth", "k256"] }
 # Per-block replay-parity test: seed the real ArbOS genesis block into the test factory.
-reth-db-common = { git = "https://github.com/nuntax/reth.git", rev = "49e941db296fc441c4747dca23b0e2f66c0a5872" }
+reth-db-common = { git = "https://github.com/nuntax/reth.git", rev = "547581ff58e62577ef880e986a1b870feaa1a1b0" }
 
 # engine_spike / engine: Tier-1 engine-tree deps live in [dependencies] now (used by engine.rs).
 tokio = { version = "1", features = ["rt-multi-thread", "sync", "time", "macros"] }

--- a/crates/arb-reth-rpc/Cargo.toml
+++ b/crates/arb-reth-rpc/Cargo.toml
@@ -20,21 +20,21 @@ alloy-primitives = { version = "1", default-features = false }
 alloy-rpc-types-eth = { version = "2.0", default-features = false }
 eyre = "0.6.12"
 
-reth-chain-state = { git = "https://github.com/nuntax/reth.git", rev = "49e941db296fc441c4747dca23b0e2f66c0a5872" }
-reth-chainspec = { git = "https://github.com/nuntax/reth.git", rev = "49e941db296fc441c4747dca23b0e2f66c0a5872" }
-reth-consensus = { git = "https://github.com/nuntax/reth.git", rev = "49e941db296fc441c4747dca23b0e2f66c0a5872" }
-reth-engine-primitives = { git = "https://github.com/nuntax/reth.git", rev = "49e941db296fc441c4747dca23b0e2f66c0a5872" }
-reth-node-api = { git = "https://github.com/nuntax/reth.git", rev = "49e941db296fc441c4747dca23b0e2f66c0a5872" }
+reth-chain-state = { git = "https://github.com/nuntax/reth.git", rev = "547581ff58e62577ef880e986a1b870feaa1a1b0" }
+reth-chainspec = { git = "https://github.com/nuntax/reth.git", rev = "547581ff58e62577ef880e986a1b870feaa1a1b0" }
+reth-consensus = { git = "https://github.com/nuntax/reth.git", rev = "547581ff58e62577ef880e986a1b870feaa1a1b0" }
+reth-engine-primitives = { git = "https://github.com/nuntax/reth.git", rev = "547581ff58e62577ef880e986a1b870feaa1a1b0" }
+reth-node-api = { git = "https://github.com/nuntax/reth.git", rev = "547581ff58e62577ef880e986a1b870feaa1a1b0" }
 reth-primitives-traits = { version = "0.6.0", default-features = false }
-reth-rpc = { git = "https://github.com/nuntax/reth.git", rev = "49e941db296fc441c4747dca23b0e2f66c0a5872" }
-reth-rpc-builder = { git = "https://github.com/nuntax/reth.git", rev = "49e941db296fc441c4747dca23b0e2f66c0a5872" }
-reth-rpc-convert = { git = "https://github.com/nuntax/reth.git", rev = "49e941db296fc441c4747dca23b0e2f66c0a5872" }
-reth-rpc-eth-api = { git = "https://github.com/nuntax/reth.git", rev = "49e941db296fc441c4747dca23b0e2f66c0a5872" }
-reth-rpc-eth-types = { git = "https://github.com/nuntax/reth.git", rev = "49e941db296fc441c4747dca23b0e2f66c0a5872" }
-reth-rpc-server-types = { git = "https://github.com/nuntax/reth.git", rev = "49e941db296fc441c4747dca23b0e2f66c0a5872" }
-reth-storage-api = { git = "https://github.com/nuntax/reth.git", rev = "49e941db296fc441c4747dca23b0e2f66c0a5872", features = ["db-api"] }
-reth-tasks = { git = "https://github.com/nuntax/reth.git", rev = "49e941db296fc441c4747dca23b0e2f66c0a5872" }
-reth-tokio-util = { git = "https://github.com/nuntax/reth.git", rev = "49e941db296fc441c4747dca23b0e2f66c0a5872" }
-reth-transaction-pool = { git = "https://github.com/nuntax/reth.git", rev = "49e941db296fc441c4747dca23b0e2f66c0a5872" }
-reth-network-api = { git = "https://github.com/nuntax/reth.git", rev = "49e941db296fc441c4747dca23b0e2f66c0a5872" }
+reth-rpc = { git = "https://github.com/nuntax/reth.git", rev = "547581ff58e62577ef880e986a1b870feaa1a1b0" }
+reth-rpc-builder = { git = "https://github.com/nuntax/reth.git", rev = "547581ff58e62577ef880e986a1b870feaa1a1b0" }
+reth-rpc-convert = { git = "https://github.com/nuntax/reth.git", rev = "547581ff58e62577ef880e986a1b870feaa1a1b0" }
+reth-rpc-eth-api = { git = "https://github.com/nuntax/reth.git", rev = "547581ff58e62577ef880e986a1b870feaa1a1b0" }
+reth-rpc-eth-types = { git = "https://github.com/nuntax/reth.git", rev = "547581ff58e62577ef880e986a1b870feaa1a1b0" }
+reth-rpc-server-types = { git = "https://github.com/nuntax/reth.git", rev = "547581ff58e62577ef880e986a1b870feaa1a1b0" }
+reth-storage-api = { git = "https://github.com/nuntax/reth.git", rev = "547581ff58e62577ef880e986a1b870feaa1a1b0", features = ["db-api"] }
+reth-tasks = { git = "https://github.com/nuntax/reth.git", rev = "547581ff58e62577ef880e986a1b870feaa1a1b0" }
+reth-tokio-util = { git = "https://github.com/nuntax/reth.git", rev = "547581ff58e62577ef880e986a1b870feaa1a1b0" }
+reth-transaction-pool = { git = "https://github.com/nuntax/reth.git", rev = "547581ff58e62577ef880e986a1b870feaa1a1b0" }
+reth-network-api = { git = "https://github.com/nuntax/reth.git", rev = "547581ff58e62577ef880e986a1b870feaa1a1b0" }
 jsonrpsee = { version = "0.26.0", features = ["server", "http-client"] }

--- a/crates/arb-reth-sync/Cargo.toml
+++ b/crates/arb-reth-sync/Cargo.toml
@@ -27,4 +27,4 @@ tokio = { version = "1", features = ["rt-multi-thread", "sync", "time", "macros"
 tracing = "0.1"
 
 [dev-dependencies]
-reth-db = { git = "https://github.com/nuntax/reth.git", rev = "49e941db296fc441c4747dca23b0e2f66c0a5872", features = ["test-utils"] }
+reth-db = { git = "https://github.com/nuntax/reth.git", rev = "547581ff58e62577ef880e986a1b870feaa1a1b0", features = ["test-utils"] }


### PR DESCRIPTION
## Summary

Retain the frontiers confirmed by Reth persistence while preparing the next Storage V2 batch, avoiding a new read-only provider observing a static-file handoff transient.

Also retries proof-worker provider initialization once with a fresh snapshot.

## Validation

- `cargo test -p arb-reth-engine storage_v2 --lib -- --nocapture`
- `cargo test -p reth-trie-parallel retries_provider_initialization_once --lib -- --nocapture`
- `cargo test -p reth-trie-parallel returns_provider_initialization_error_after_retry --lib -- --nocapture`