### PR TITLE
feat(mev): stream transaction logs over IPC

### DIFF
--- a/crates/arb-reth-engine/src/engine.rs
+++ b/crates/arb-reth-engine/src/engine.rs
@@ -138,6 +138,11 @@ impl Drop for EngineTerminationGuard {
 }
 
 /// Produce one block and retain a breakdown of the local block-production work.
+///
+/// The input components are deliberately separate because the payload builder acquires the state
+/// providers and optional state-root task independently. Keep this local seam flat rather than
+/// adding an allocation solely to satisfy Clippy.
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn produce_with_timing<'a>(
     evm_config: &ArbEvmConfig,
     chain_id: u64,

--- a/crates/arb-reth-engine/src/engine.rs
+++ b/crates/arb-reth-engine/src/engine.rs
@@ -76,7 +76,10 @@ use reth_trie::{
 use revm::context_interface::ContextTr as _;
 
 use crate::native_payload::ArbPayloadJobGenerator;
-use crate::{ArbPayloadAttributes, ArbPayloadBuilder, ArbPayloadTypes, ArbPayloadValidator};
+use crate::{
+    ArbPayloadAttributes, ArbPayloadBuilder, ArbPayloadTypes, ArbPayloadValidator,
+    ArbTxExecutionKind, ArbTxLogBroadcaster, ArbTxLogEvent,
+};
 
 /// The concrete sender type returned by [`EngineApiTreeHandler::spawn_new`] for `ArbNode`.
 type ToTree = crossbeam_channel::Sender<
@@ -143,6 +146,7 @@ pub(crate) fn produce_with_timing<'a>(
     exec_state_provider: Box<dyn StateProvider + 'a>,
     trie_state_provider: Box<dyn StateProvider + 'a>,
     mut state_root_task: Option<PayloadStateRootHandle>,
+    tx_log_stream: Option<&ArbTxLogBroadcaster>,
 ) -> eyre::Result<(
     BuiltPayloadExecutedBlock<ArbPrimitives>,
     ArbBlockProductionTiming,
@@ -293,24 +297,30 @@ pub(crate) fn produce_with_timing<'a>(
     let mut derived_transactions = Duration::ZERO;
     let mut derived_transaction_execution = Duration::ZERO;
     let mut derived_retry_scheduling = Duration::ZERO;
+    let mut transaction_index = 0;
     loop {
-        let (tx, sender_result, is_internal) = if let Some(t) = first.take() {
+        let (tx, sender_result, kind) = if let Some(t) = first.take() {
             let sender = t.sender();
-            (t, sender, true)
+            (t, sender, ArbTxExecutionKind::StartBlock)
         } else if let Some(t) = redeems.pop_front() {
             let sender = t.sender();
-            (t, sender, false)
+            (t, sender, ArbTxExecutionKind::ScheduledRetry)
         } else if let Some((t, sender)) = user_txs.pop_front() {
-            (t, sender, false)
+            (t, sender, ArbTxExecutionKind::User)
         } else {
             break;
         };
+        let is_internal = matches!(kind, ArbTxExecutionKind::StartBlock);
         let tx_ty = tx.ty();
         let sender: Address =
             sender_result.map_err(|e| eyre!("failed to determine sender for tx {tx_ty}: {e}"))?;
+        // Do not hash or clone logs at all unless a local IPC client is actually connected.
+        let tx_log_stream = tx_log_stream.filter(|stream| stream.has_subscribers());
+        let tx_hash = tx_log_stream.map(|_| tx.hash());
         let recovered = Recovered::new_unchecked(tx, sender);
         let mut tx_logs: Vec<Log> = Vec::new();
         let mut tx_success = false;
+        let mut tx_log_event = None;
         let tx_started_at = Instant::now();
         if let Err(e) = builder.execute_transaction_with_result_closure(recovered, |res| {
             tx_success = res.result.result.is_success();
@@ -322,6 +332,17 @@ pub(crate) fn produce_with_timing<'a>(
                     .filter(|log| is_redeem_scheduled_log(log))
                     .cloned(),
             );
+            if let Some(transaction_hash) = tx_hash {
+                tx_log_event = Some(ArbTxLogEvent {
+                    block_number: parent_header.number + 1,
+                    transaction_index,
+                    transaction_hash,
+                    kind,
+                    success: tx_success,
+                    gas_used: res.result.result.tx_gas_used(),
+                    logs: res.result.result.logs().to_vec(),
+                });
+            }
         }) {
             let tx_execution = tx_started_at.elapsed();
             if is_internal {
@@ -351,6 +372,10 @@ pub(crate) fn produce_with_timing<'a>(
             );
             continue;
         }
+        if let (Some(stream), Some(event)) = (tx_log_stream, tx_log_event) {
+            stream.publish(event);
+        }
+        transaction_index += 1;
         let mut retry_scheduling = Duration::ZERO;
         if tx_success && !tx_logs.is_empty() {
             // FIFO, drained before the next user tx, matching Nitro's cascading-redeem order.
@@ -1143,6 +1168,7 @@ where
         runtime: Runtime,
         tuning: ArbEngineTuning,
         prune_builder: Option<PrunerBuilder>,
+        tx_log_stream: Option<ArbTxLogBroadcaster>,
     ) -> eyre::Result<Self> {
         // ---- persistence service (real MDBX writer; pruner from --prune.* flags) ----
         let (_finished_exex_height_tx, finished_exex_height_rx) =
@@ -1193,7 +1219,15 @@ where
             runtime.clone(),
         );
 
-        let builder = ArbPayloadBuilder::new(provider.clone(), evm_config.clone(), chain_id);
+        let builder = match tx_log_stream {
+            Some(stream) => ArbPayloadBuilder::with_tx_log_stream(
+                provider.clone(),
+                evm_config.clone(),
+                chain_id,
+                stream,
+            ),
+            None => ArbPayloadBuilder::new(provider.clone(), evm_config.clone(), chain_id),
+        };
         let generator = ArbPayloadJobGenerator::new(provider.clone(), runtime.clone(), builder);
         let (service, payload_builder) = PayloadBuilderService::<_, _, ArbPayloadTypes>::new(
             generator,

--- a/crates/arb-reth-engine/src/lib.rs
+++ b/crates/arb-reth-engine/src/lib.rs
@@ -27,10 +27,12 @@ pub mod engine;
 pub mod engine_spike;
 pub mod native_payload;
 mod storage_v2;
+mod tx_log_stream;
 
 pub use engine::{ArbAppliedMessageTiming, ArbEngineDriver, ArbEngineTuning, wait_for_head};
 pub use engine_spike::ArbPayloadValidator;
 pub use native_payload::ArbPayloadBuilder;
+pub use tx_log_stream::{ArbTxExecutionKind, ArbTxLogBroadcaster, ArbTxLogEvent};
 
 /// An executed Arbitrum payload produced by the local payload builder.
 #[derive(Debug, Clone)]

--- a/crates/arb-reth-engine/src/native_payload.rs
+++ b/crates/arb-reth-engine/src/native_payload.rs
@@ -30,7 +30,9 @@ use tokio::sync::oneshot;
 
 use metrics::{Counter, Histogram};
 
-use crate::{ArbBuiltPayload, ArbPayloadAttributes, engine::produce_with_timing};
+use crate::{
+    ArbBuiltPayload, ArbPayloadAttributes, ArbTxLogBroadcaster, engine::produce_with_timing,
+};
 
 /// Stable worker name for the serial ArbOS payload builder.
 const ARB_PAYLOAD_BUILDER_THREAD: &str = "arb-payload-builder";
@@ -41,6 +43,7 @@ pub struct ArbPayloadBuilder<P> {
     provider: P,
     evm_config: ArbEvmConfig,
     chain_id: u64,
+    tx_log_stream: Option<ArbTxLogBroadcaster>,
 }
 
 impl<P> ArbPayloadBuilder<P> {
@@ -50,6 +53,22 @@ impl<P> ArbPayloadBuilder<P> {
             provider,
             evm_config,
             chain_id,
+            tx_log_stream: None,
+        }
+    }
+
+    /// Creates a builder that emits best-effort execution observations to local consumers.
+    pub const fn with_tx_log_stream(
+        provider: P,
+        evm_config: ArbEvmConfig,
+        chain_id: u64,
+        tx_log_stream: ArbTxLogBroadcaster,
+    ) -> Self {
+        Self {
+            provider,
+            evm_config,
+            chain_id,
+            tx_log_stream: Some(tx_log_stream),
         }
     }
 
@@ -116,6 +135,7 @@ impl<P> ArbPayloadBuilder<P> {
             execution_state,
             trie_state,
             args.state_root_handle,
+            self.tx_log_stream.as_ref(),
         )
         .map_err(|err| PayloadBuilderError::other(std::io::Error::other(err.to_string())))?;
         timing.parent_state = parent_state;

--- a/crates/arb-reth-engine/src/tx_log_stream.rs
+++ b/crates/arb-reth-engine/src/tx_log_stream.rs
@@ -1,0 +1,102 @@
+//! Best-effort per-transaction execution observations for local consumers.
+//!
+//! Events leave the ArbOS payload builder immediately after a transaction has executed. They are
+//! deliberately not canonical receipts: the enclosing block can still fail while its state root is
+//! calculated or while it is handed to the engine tree.
+
+use alloy_primitives::{B256, Log};
+use tokio::sync::broadcast;
+
+/// Number of execution events retained for a slow local consumer before it is disconnected.
+pub const TX_LOG_STREAM_CAPACITY: usize = 1_024;
+
+/// The source of a transaction in the deterministic ArbOS block order.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ArbTxExecutionKind {
+    /// ArbOS's synthetic start-block transaction.
+    StartBlock,
+    /// A transaction carried by the sequencer or delayed message.
+    User,
+    /// A retry scheduled by a preceding transaction in the same block.
+    ScheduledRetry,
+}
+
+/// Logs and final execution status for one successfully included transaction.
+///
+/// `block_number` and `transaction_index` identify the block currently being built. There is no
+/// block hash because that is only available after all transactions, receipt hashing, and state-root
+/// calculation have completed.
+#[derive(Clone, Debug)]
+pub struct ArbTxLogEvent {
+    /// Number of the block currently being built.
+    pub block_number: u64,
+    /// Index in the final transaction order, including the start-block transaction.
+    pub transaction_index: u64,
+    /// Hash of the included transaction.
+    pub transaction_hash: B256,
+    /// Deterministic ArbOS transaction source.
+    pub kind: ArbTxExecutionKind,
+    /// Receipt-status equivalent for this transaction.
+    pub success: bool,
+    /// Final transaction gas used, including refunds.
+    pub gas_used: u64,
+    /// EVM logs emitted by the transaction. Reverted and halted transactions normally have none.
+    pub logs: Vec<Log>,
+}
+
+/// Non-blocking publisher for per-transaction execution observations.
+///
+/// A producer does no event cloning or serialization unless a local consumer is connected. Slow
+/// consumers are isolated by Tokio's bounded broadcast channel and cannot delay ArbOS execution.
+#[derive(Clone, Debug)]
+pub struct ArbTxLogBroadcaster {
+    sender: broadcast::Sender<ArbTxLogEvent>,
+}
+
+impl ArbTxLogBroadcaster {
+    /// Creates a broadcaster with the fixed bounded event buffer.
+    pub fn new() -> Self {
+        let (sender, _) = broadcast::channel(TX_LOG_STREAM_CAPACITY);
+        Self { sender }
+    }
+
+    /// Returns whether a local consumer is currently connected.
+    #[inline]
+    pub fn has_subscribers(&self) -> bool {
+        self.sender.receiver_count() != 0
+    }
+
+    /// Adds one local consumer to the event stream.
+    pub fn subscribe(&self) -> broadcast::Receiver<ArbTxLogEvent> {
+        self.sender.subscribe()
+    }
+
+    /// Publishes an event without ever waiting for a consumer.
+    #[inline]
+    pub fn publish(&self, event: ArbTxLogEvent) {
+        let _ = self.sender.send(event);
+    }
+}
+
+impl Default for ArbTxLogBroadcaster {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn publishes_only_when_a_consumer_is_connected() {
+        let broadcaster = ArbTxLogBroadcaster::new();
+        assert!(!broadcaster.has_subscribers());
+
+        let receiver = broadcaster.subscribe();
+        assert!(broadcaster.has_subscribers());
+        drop(receiver);
+
+        assert!(!broadcaster.has_subscribers());
+    }
+}

--- a/crates/arb-reth-node/Cargo.toml
+++ b/crates/arb-reth-node/Cargo.toml
@@ -16,7 +16,7 @@ arbitrum-alloy-consensus = { git = "https://github.com/nuntax/arbitrum-alloy", r
 arb-reth-evm = { path = "../arb-reth-evm", features = ["rpc"] }
 arb-revm.workspace = true
 
-alloy-primitives = { version = "1", default-features = false }
+alloy-primitives = { version = "1", default-features = false, features = ["serde"] }
 alloy-consensus = { version = "2.0", default-features = false }
 alloy-eips = { version = "2.0", default-features = false }
 alloy-rpc-types-eth = { version = "2.0", default-features = false }
@@ -81,7 +81,7 @@ tracing = "0.1"
 metrics = "0.24"
 
 # D.4: standalone launcher (tokio channels)
-tokio = { version = "1", features = ["rt-multi-thread", "sync", "time"] }
+tokio = { version = "1", features = ["io-util", "net", "rt-multi-thread", "sync", "time"] }
 jsonrpsee = { version = "0.26.0", features = ["server", "http-client"] }
 
 # Live sequencer-feed follower (--feed-url): websocket source into the feed channel.

--- a/crates/arb-reth-node/Cargo.toml
+++ b/crates/arb-reth-node/Cargo.toml
@@ -16,7 +16,7 @@ arbitrum-alloy-consensus = { git = "https://github.com/nuntax/arbitrum-alloy", r
 arb-reth-evm = { path = "../arb-reth-evm", features = ["rpc"] }
 arb-revm.workspace = true
 
-alloy-primitives = { version = "1", default-features = false, features = ["serde"] }
+alloy-primitives = { version = "1", default-features = false }
 alloy-consensus = { version = "2.0", default-features = false }
 alloy-eips = { version = "2.0", default-features = false }
 alloy-rpc-types-eth = { version = "2.0", default-features = false }

--- a/crates/arb-reth-node/src/commands/node.rs
+++ b/crates/arb-reth-node/src/commands/node.rs
@@ -32,6 +32,7 @@ use crate::{
     ARB_ONE_CHAIN_ID, ArbNode, L1ResumeLog, arb_chain_spec, arbos_init_from_chain_config_json,
     arbos_init_from_parsed,
 };
+use crate::mev_tx_logs::MevTxLogIpc;
 use alloy_primitives::Address;
 use alloy_provider::{Provider, ProviderBuilder};
 use arb_reth_l1::{DelayedInboxReader, SequencerInboxReader};
@@ -76,6 +77,12 @@ pub struct NodeArgs {
     /// Enable the reth Prometheus endpoint at this address.
     #[arg(long = "metrics", alias = "metrics.prometheus", value_name = "ADDR")]
     metrics: Option<SocketAddr>,
+
+    /// Path to a local Unix socket that receives one newline-delimited JSON event immediately
+    /// after each ArbOS transaction executes. This is a best-effort, pre-canonical stream: an
+    /// enclosing block can still fail during root calculation or engine insertion.
+    #[arg(long = "mev-tx-log-ipc", value_name = "PATH")]
+    mev_tx_log_ipc: Option<PathBuf>,
 
     /// Engine-tree persistence threshold: persist once the canonical tip is this many blocks
     /// ahead of the last persisted block (larger = bigger, less frequent commit batches).
@@ -414,6 +421,11 @@ async fn derive_genesis_from_l1(
 
 pub async fn run(ctx: CliContext, args: NodeArgs) -> eyre::Result<()> {
     let task_executor = ctx.task_executor;
+    let mev_tx_log_ipc = args
+        .mev_tx_log_ipc
+        .as_ref()
+        .map(|path| MevTxLogIpc::bind(path.clone()))
+        .transpose()?;
 
     // --chain-info plus --genesis boots an Orbit chain. The pair supplies both the chain spec and
     // prealloc state, plus the L1 rollup deployment. Accepting either file alone would silently
@@ -600,6 +612,7 @@ pub async fn run(ctx: CliContext, args: NodeArgs) -> eyre::Result<()> {
         l1_messages: l1_rx,
         feed_latency: feed_latency.clone(),
         rpc_addr,
+        tx_log_stream: mev_tx_log_ipc.as_ref().map(MevTxLogIpc::broadcaster),
     };
 
     let handle = launcher.launch_node(node_builder).await?;
@@ -609,6 +622,14 @@ pub async fn run(ctx: CliContext, args: NodeArgs) -> eyre::Result<()> {
         None => {
             info!(target: "arb-reth", "arb-reth node started (RPC disabled; pass --http to enable)")
         }
+    }
+
+    if let Some(ipc) = mev_tx_log_ipc {
+        let path = ipc.path().to_owned();
+        task_executor.spawn_with_graceful_shutdown_signal(|shutdown| async move {
+            ipc.serve(shutdown).await;
+        });
+        info!(target: "arb-reth::mev", path = %path.display(), "MEV transaction-log IPC listening");
     }
 
     if let Some(feed_path) = args.replay_feed {

--- a/crates/arb-reth-node/src/launcher.rs
+++ b/crates/arb-reth-node/src/launcher.rs
@@ -44,7 +44,7 @@ use tokio::sync::oneshot;
 
 use arbitrum_alloy_consensus::{ArbReceiptEnvelope, reth::ArbBlock};
 
-use arb_reth_engine::{ArbEngineDriver, ArbEngineTuning};
+use arb_reth_engine::{ArbEngineDriver, ArbEngineTuning, ArbTxLogBroadcaster};
 
 /// Handle returned by `ArbLauncher` after the node has been launched.
 ///
@@ -102,6 +102,8 @@ pub struct ArbLauncher {
     pub feed_latency: Option<FeedLatencyTracker>,
     /// Optional HTTP bind address for the `eth_*` RPC server (`None` disables RPC).
     pub rpc_addr: Option<SocketAddr>,
+    /// Optional best-effort publisher for per-transaction execution logs.
+    pub tx_log_stream: Option<ArbTxLogBroadcaster>,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -239,6 +241,7 @@ impl ArbLauncher {
             l1_messages,
             feed_latency,
             rpc_addr,
+            tx_log_stream,
         } = self;
 
         let NodeBuilderWithComponents {
@@ -365,6 +368,7 @@ impl ArbLauncher {
             task_executor.clone(),
             tuning,
             prune_config.map(reth_prune::PrunerBuilder::new),
+            tx_log_stream,
         )?;
 
         let (exit_tx, exit_rx) = oneshot::channel::<eyre::Result<()>>();
@@ -637,6 +641,7 @@ mod tests {
             l1_messages: l1_rx,
             feed_latency: None,
             rpc_addr: None,
+            tx_log_stream: None,
         };
 
         let handle = launcher
@@ -747,6 +752,7 @@ mod tests {
             l1_messages: l1_rx,
             feed_latency: None,
             rpc_addr: None,
+            tx_log_stream: None,
         };
         let handle = launcher
             .launch_node(node_builder_with_components)

--- a/crates/arb-reth-node/src/lib.rs
+++ b/crates/arb-reth-node/src/lib.rs
@@ -54,6 +54,8 @@ pub use arb_reth_sync::resume::{L1ResumeCheckpoint, L1ResumeLog};
 pub mod launcher;
 pub use launcher::{ArbLauncher, ArbNodeHandle};
 
+mod mev_tx_logs;
+
 mod metrics;
 pub use metrics::FeedLatencyTracker;
 

--- a/crates/arb-reth-node/src/mev_tx_logs.rs
+++ b/crates/arb-reth-node/src/mev_tx_logs.rs
@@ -142,16 +142,21 @@ async fn stream_client(mut stream: UnixStream, mut events: broadcast::Receiver<A
 /// Version of the binary frame format documented in `docs/mev-tx-log-ipc.md`.
 const FRAME_VERSION: u8 = 1;
 const FIXED_BODY_LEN: usize = 64;
+const MAX_LOG_TOPICS: usize = 4;
 
 fn encode_event(event: &ArbTxLogEvent) -> Result<Vec<u8>> {
+    let log_count = u32::try_from(event.logs.len())
+        .map_err(|_| eyre::eyre!("MEV transaction-log event has too many logs"))?;
     let mut body_len = FIXED_BODY_LEN;
     for log in &event.logs {
         let topics = log.data.topics();
-        if topics.len() > u8::MAX as usize {
+        if topics.len() > MAX_LOG_TOPICS {
             bail!("MEV transaction-log event has too many log topics")
         }
+        let data_len = u32::try_from(log.data.data.len())
+            .map_err(|_| eyre::eyre!("MEV transaction-log log data exceeds 4 GiB"))?;
         body_len = body_len
-            .checked_add(25 + topics.len() * B256::len_bytes() + log.data.data.len())
+            .checked_add(25 + topics.len() * B256::len_bytes() + data_len as usize)
             .ok_or_else(|| eyre::eyre!("MEV transaction-log frame length overflow"))?;
     }
     let frame_len = u32::try_from(body_len)
@@ -171,12 +176,14 @@ fn encode_event(event: &ArbTxLogEvent) -> Result<Vec<u8>> {
     encoded.extend_from_slice(&event.transaction_index.to_be_bytes());
     encoded.extend_from_slice(&event.gas_used.to_be_bytes());
     encoded.extend_from_slice(event.transaction_hash.as_slice());
-    encoded.extend_from_slice(&(event.logs.len() as u32).to_be_bytes());
+    encoded.extend_from_slice(&log_count.to_be_bytes());
     for log in &event.logs {
         let topics = log.data.topics();
         encoded.extend_from_slice(log.address.as_slice());
         encoded.push(topics.len() as u8);
-        encoded.extend_from_slice(&(log.data.data.len() as u32).to_be_bytes());
+        let data_len = u32::try_from(log.data.data.len())
+            .expect("validated while calculating MEV transaction-log frame length");
+        encoded.extend_from_slice(&data_len.to_be_bytes());
         for topic in topics {
             encoded.extend_from_slice(topic.as_slice());
         }
@@ -242,6 +249,24 @@ mod tests {
 
         assert!(remove_stale_socket(&path).is_err());
         assert!(path.exists());
+    }
+
+    #[test]
+    fn rejects_more_than_four_topics() {
+        let event = ArbTxLogEvent {
+            block_number: 42,
+            transaction_index: 3,
+            transaction_hash: B256::ZERO,
+            kind: ArbTxExecutionKind::User,
+            success: true,
+            gas_used: 21_000,
+            logs: vec![Log {
+                address: Address::ZERO,
+                data: LogData::new_unchecked(vec![B256::ZERO; 5], Bytes::new()),
+            }],
+        };
+
+        assert!(encode_event(&event).is_err());
     }
 
     #[tokio::test]

--- a/crates/arb-reth-node/src/mev_tx_logs.rs
+++ b/crates/arb-reth-node/src/mev_tx_logs.rs
@@ -1,8 +1,8 @@
 //! Best-effort local IPC for per-transaction ArbOS execution logs.
 //!
-//! The socket uses newline-delimited JSON. It is intentionally separate from RPC: callers receive
-//! a transaction as soon as its EVM execution completes, before receipt/state-root hashing and
-//! before the enclosing block becomes canonical.
+//! The socket uses a compact, length-delimited binary frame. It is intentionally separate from
+//! RPC: callers receive a transaction as soon as its EVM execution completes, before receipt/
+//! state-root hashing and before the enclosing block becomes canonical.
 
 use std::{
     fs,
@@ -10,10 +10,9 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use alloy_primitives::{Address, B256, Bytes};
+use alloy_primitives::B256;
 use arb_reth_engine::{ArbTxExecutionKind, ArbTxLogBroadcaster, ArbTxLogEvent};
 use eyre::{Context, Result, bail};
-use serde::Serialize;
 use tokio::{
     io::AsyncWriteExt,
     net::{UnixListener, UnixStream},
@@ -129,7 +128,7 @@ async fn stream_client(mut stream: UnixStream, mut events: broadcast::Receiver<A
                 reth_tracing::tracing::warn!(
                     target: "arb-reth::mev",
                     %error,
-                    "failed to serialize MEV transaction-log event"
+                    "failed to encode MEV transaction-log event"
                 );
                 continue;
             }
@@ -140,62 +139,60 @@ async fn stream_client(mut stream: UnixStream, mut events: broadcast::Receiver<A
     }
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase")]
-struct WireEvent<'a> {
-    event: &'static str,
-    block_number: u64,
-    transaction_index: u64,
-    transaction_hash: B256,
-    kind: &'static str,
-    success: bool,
-    gas_used: u64,
-    logs: Vec<WireLog<'a>>,
-}
+/// Version of the binary frame format documented in `docs/mev-tx-log-ipc.md`.
+const FRAME_VERSION: u8 = 1;
+const FIXED_BODY_LEN: usize = 64;
 
-#[derive(Serialize)]
-struct WireLog<'a> {
-    address: Address,
-    topics: &'a [B256],
-    data: &'a Bytes,
-}
+fn encode_event(event: &ArbTxLogEvent) -> Result<Vec<u8>> {
+    let mut body_len = FIXED_BODY_LEN;
+    for log in &event.logs {
+        let topics = log.data.topics();
+        if topics.len() > u8::MAX as usize {
+            bail!("MEV transaction-log event has too many log topics")
+        }
+        body_len = body_len
+            .checked_add(25 + topics.len() * B256::len_bytes() + log.data.data.len())
+            .ok_or_else(|| eyre::eyre!("MEV transaction-log frame length overflow"))?;
+    }
+    let frame_len = u32::try_from(body_len)
+        .map_err(|_| eyre::eyre!("MEV transaction-log frame exceeds 4 GiB"))?;
 
-fn encode_event(event: &ArbTxLogEvent) -> Result<Vec<u8>, serde_json::Error> {
-    let event = WireEvent {
-        event: "transactionLogs",
-        block_number: event.block_number,
-        transaction_index: event.transaction_index,
-        transaction_hash: event.transaction_hash,
-        kind: match event.kind {
-            ArbTxExecutionKind::StartBlock => "startBlock",
-            ArbTxExecutionKind::User => "user",
-            ArbTxExecutionKind::ScheduledRetry => "scheduledRetry",
-        },
-        success: event.success,
-        gas_used: event.gas_used,
-        logs: event
-            .logs
-            .iter()
-            .map(|log| WireLog {
-                address: log.address,
-                topics: log.data.topics(),
-                data: &log.data.data,
-            })
-            .collect(),
-    };
-    let mut encoded = serde_json::to_vec(&event)?;
-    encoded.push(b'\n');
+    let mut encoded = Vec::with_capacity(4 + body_len);
+    encoded.extend_from_slice(&frame_len.to_be_bytes());
+    encoded.push(FRAME_VERSION);
+    encoded.push(match event.kind {
+        ArbTxExecutionKind::StartBlock => 0,
+        ArbTxExecutionKind::User => 1,
+        ArbTxExecutionKind::ScheduledRetry => 2,
+    });
+    encoded.push(u8::from(event.success));
+    encoded.push(0); // Reserved for future flags.
+    encoded.extend_from_slice(&event.block_number.to_be_bytes());
+    encoded.extend_from_slice(&event.transaction_index.to_be_bytes());
+    encoded.extend_from_slice(&event.gas_used.to_be_bytes());
+    encoded.extend_from_slice(event.transaction_hash.as_slice());
+    encoded.extend_from_slice(&(event.logs.len() as u32).to_be_bytes());
+    for log in &event.logs {
+        let topics = log.data.topics();
+        encoded.extend_from_slice(log.address.as_slice());
+        encoded.push(topics.len() as u8);
+        encoded.extend_from_slice(&(log.data.data.len() as u32).to_be_bytes());
+        for topic in topics {
+            encoded.extend_from_slice(topic.as_slice());
+        }
+        encoded.extend_from_slice(&log.data.data);
+    }
     Ok(encoded)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alloy_primitives::{Log, LogData, b256};
-    use tokio::io::{AsyncBufReadExt, BufReader};
+    use alloy_primitives::{Address, Bytes, Log, LogData, b256};
+    use tokio::io::AsyncReadExt;
 
     #[test]
-    fn encodes_one_newline_delimited_transaction_event() {
+    fn encodes_one_binary_transaction_event() {
         let event = ArbTxLogEvent {
             block_number: 42,
             transaction_index: 3,
@@ -216,14 +213,25 @@ mod tests {
             }],
         };
 
-        let encoded = encode_event(&event).expect("event serializes");
-        assert_eq!(encoded.last(), Some(&b'\n'));
-        let value: serde_json::Value = serde_json::from_slice(&encoded).expect("valid JSON");
-        assert_eq!(value["event"], "transactionLogs");
-        assert_eq!(value["blockNumber"], 42);
-        assert_eq!(value["transactionIndex"], 3);
-        assert_eq!(value["kind"], "user");
-        assert_eq!(value["logs"][0]["data"], "0x1234");
+        let encoded = encode_event(&event).expect("event encodes");
+        assert_eq!(
+            u32::from_be_bytes(encoded[..4].try_into().unwrap()) as usize,
+            encoded.len() - 4
+        );
+        assert_eq!(encoded[4], FRAME_VERSION);
+        assert_eq!(encoded[5], 1); // user
+        assert_eq!(encoded[6], 1); // success
+        assert_eq!(u64::from_be_bytes(encoded[8..16].try_into().unwrap()), 42);
+        assert_eq!(u64::from_be_bytes(encoded[16..24].try_into().unwrap()), 3);
+        assert_eq!(
+            u64::from_be_bytes(encoded[24..32].try_into().unwrap()),
+            21_000
+        );
+        assert_eq!(u32::from_be_bytes(encoded[64..68].try_into().unwrap()), 1);
+        assert_eq!(&encoded[68..88], Address::repeat_byte(0x11).as_slice());
+        assert_eq!(encoded[88], 1);
+        assert_eq!(u32::from_be_bytes(encoded[89..93].try_into().unwrap()), 2);
+        assert_eq!(&encoded[125..127], [0x12, 0x34]);
     }
 
     #[test]
@@ -253,14 +261,16 @@ mod tests {
             logs: Vec::new(),
         });
 
-        let mut line = Vec::new();
-        BufReader::new(reader)
-            .read_until(b'\n', &mut line)
+        let mut length = [0; 4];
+        let mut reader = reader;
+        reader
+            .read_exact(&mut length)
             .await
-            .expect("read event");
-        let value: serde_json::Value = serde_json::from_slice(&line).expect("valid JSON");
-        assert_eq!(value["blockNumber"], 42);
-        assert_eq!(value["transactionIndex"], 3);
+            .expect("read frame length");
+        let mut body = vec![0; u32::from_be_bytes(length) as usize];
+        reader.read_exact(&mut body).await.expect("read frame");
+        assert_eq!(body[4..12], 42u64.to_be_bytes());
+        assert_eq!(body[12..20], 3u64.to_be_bytes());
 
         drop(broadcaster);
         client.await.expect("client task exits");

--- a/crates/arb-reth-node/src/mev_tx_logs.rs
+++ b/crates/arb-reth-node/src/mev_tx_logs.rs
@@ -1,0 +1,268 @@
+//! Best-effort local IPC for per-transaction ArbOS execution logs.
+//!
+//! The socket uses newline-delimited JSON. It is intentionally separate from RPC: callers receive
+//! a transaction as soon as its EVM execution completes, before receipt/state-root hashing and
+//! before the enclosing block becomes canonical.
+
+use std::{
+    fs,
+    os::unix::fs::FileTypeExt,
+    path::{Path, PathBuf},
+};
+
+use alloy_primitives::{Address, B256, Bytes};
+use arb_reth_engine::{ArbTxExecutionKind, ArbTxLogBroadcaster, ArbTxLogEvent};
+use eyre::{Context, Result, bail};
+use serde::Serialize;
+use tokio::{
+    io::AsyncWriteExt,
+    net::{UnixListener, UnixStream},
+    sync::broadcast,
+};
+
+/// A local Unix-domain socket server for [`ArbTxLogEvent`] values.
+pub(crate) struct MevTxLogIpc {
+    listener: UnixListener,
+    path: PathBuf,
+    broadcaster: ArbTxLogBroadcaster,
+}
+
+impl MevTxLogIpc {
+    /// Binds the requested local socket, replacing a stale socket from a previous shutdown.
+    pub(crate) fn bind(path: impl Into<PathBuf>) -> Result<Self> {
+        let path = path.into();
+        remove_stale_socket(&path)?;
+        let listener = UnixListener::bind(&path).wrap_err_with(|| {
+            format!("bind MEV transaction-log IPC socket at {}", path.display())
+        })?;
+        Ok(Self {
+            listener,
+            path,
+            broadcaster: ArbTxLogBroadcaster::new(),
+        })
+    }
+
+    /// Returns the execution-side publisher passed to the native payload builder.
+    pub(crate) fn broadcaster(&self) -> ArbTxLogBroadcaster {
+        self.broadcaster.clone()
+    }
+
+    /// Socket location, used only for the launch log.
+    pub(crate) fn path(&self) -> &Path {
+        &self.path
+    }
+
+    /// Serves local clients until the runtime begins graceful shutdown.
+    pub(crate) async fn serve(self, mut shutdown: reth_tasks::shutdown::GracefulShutdown) {
+        loop {
+            tokio::select! {
+                guard = &mut shutdown => {
+                    drop(guard);
+                    break;
+                }
+                accepted = self.listener.accept() => match accepted {
+                    Ok((stream, _)) => {
+                        let events = self.broadcaster.subscribe();
+                        tokio::spawn(stream_client(stream, events));
+                    }
+                    Err(error) => {
+                        reth_tracing::tracing::warn!(
+                            target: "arb-reth::mev",
+                            %error,
+                            path = %self.path.display(),
+                            "MEV transaction-log IPC accept failed"
+                        );
+                    }
+                },
+            }
+        }
+    }
+}
+
+impl Drop for MevTxLogIpc {
+    fn drop(&mut self) {
+        if let Err(error) = fs::remove_file(&self.path)
+            && error.kind() != std::io::ErrorKind::NotFound
+        {
+            reth_tracing::tracing::warn!(
+                target: "arb-reth::mev",
+                %error,
+                path = %self.path.display(),
+                "failed to remove MEV transaction-log IPC socket"
+            );
+        }
+    }
+}
+
+fn remove_stale_socket(path: &Path) -> Result<()> {
+    let metadata = match fs::symlink_metadata(path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(error).wrap_err_with(|| format!("inspect {}", path.display())),
+    };
+    if !metadata.file_type().is_socket() {
+        bail!(
+            "refusing to replace non-socket MEV transaction-log IPC path {}",
+            path.display()
+        );
+    }
+    fs::remove_file(path).wrap_err_with(|| format!("remove stale socket {}", path.display()))
+}
+
+async fn stream_client(mut stream: UnixStream, mut events: broadcast::Receiver<ArbTxLogEvent>) {
+    loop {
+        let event = match events.recv().await {
+            Ok(event) => event,
+            Err(broadcast::error::RecvError::Lagged(skipped)) => {
+                reth_tracing::tracing::warn!(
+                    target: "arb-reth::mev",
+                    skipped,
+                    "disconnecting slow MEV transaction-log IPC client"
+                );
+                return;
+            }
+            Err(broadcast::error::RecvError::Closed) => return,
+        };
+        let encoded = match encode_event(&event) {
+            Ok(encoded) => encoded,
+            Err(error) => {
+                reth_tracing::tracing::warn!(
+                    target: "arb-reth::mev",
+                    %error,
+                    "failed to serialize MEV transaction-log event"
+                );
+                continue;
+            }
+        };
+        if stream.write_all(&encoded).await.is_err() {
+            return;
+        }
+    }
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct WireEvent<'a> {
+    event: &'static str,
+    block_number: u64,
+    transaction_index: u64,
+    transaction_hash: B256,
+    kind: &'static str,
+    success: bool,
+    gas_used: u64,
+    logs: Vec<WireLog<'a>>,
+}
+
+#[derive(Serialize)]
+struct WireLog<'a> {
+    address: Address,
+    topics: &'a [B256],
+    data: &'a Bytes,
+}
+
+fn encode_event(event: &ArbTxLogEvent) -> Result<Vec<u8>, serde_json::Error> {
+    let event = WireEvent {
+        event: "transactionLogs",
+        block_number: event.block_number,
+        transaction_index: event.transaction_index,
+        transaction_hash: event.transaction_hash,
+        kind: match event.kind {
+            ArbTxExecutionKind::StartBlock => "startBlock",
+            ArbTxExecutionKind::User => "user",
+            ArbTxExecutionKind::ScheduledRetry => "scheduledRetry",
+        },
+        success: event.success,
+        gas_used: event.gas_used,
+        logs: event
+            .logs
+            .iter()
+            .map(|log| WireLog {
+                address: log.address,
+                topics: log.data.topics(),
+                data: &log.data.data,
+            })
+            .collect(),
+    };
+    let mut encoded = serde_json::to_vec(&event)?;
+    encoded.push(b'\n');
+    Ok(encoded)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_primitives::{Log, LogData, b256};
+    use tokio::io::{AsyncBufReadExt, BufReader};
+
+    #[test]
+    fn encodes_one_newline_delimited_transaction_event() {
+        let event = ArbTxLogEvent {
+            block_number: 42,
+            transaction_index: 3,
+            transaction_hash: b256!(
+                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+            ),
+            kind: ArbTxExecutionKind::User,
+            success: true,
+            gas_used: 21_000,
+            logs: vec![Log {
+                address: Address::repeat_byte(0x11),
+                data: LogData::new_unchecked(
+                    vec![b256!(
+                        "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+                    )],
+                    Bytes::from_static(&[0x12, 0x34]),
+                ),
+            }],
+        };
+
+        let encoded = encode_event(&event).expect("event serializes");
+        assert_eq!(encoded.last(), Some(&b'\n'));
+        let value: serde_json::Value = serde_json::from_slice(&encoded).expect("valid JSON");
+        assert_eq!(value["event"], "transactionLogs");
+        assert_eq!(value["blockNumber"], 42);
+        assert_eq!(value["transactionIndex"], 3);
+        assert_eq!(value["kind"], "user");
+        assert_eq!(value["logs"][0]["data"], "0x1234");
+    }
+
+    #[test]
+    fn only_replaces_an_existing_socket() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let path = temp.path().join("mev.sock");
+        fs::write(&path, b"not a socket").expect("write regular file");
+
+        assert!(remove_stale_socket(&path).is_err());
+        assert!(path.exists());
+    }
+
+    #[tokio::test]
+    async fn connected_client_receives_transaction_event() {
+        let broadcaster = ArbTxLogBroadcaster::new();
+        let receiver = broadcaster.subscribe();
+        let (writer, reader) = UnixStream::pair().expect("Unix stream pair");
+        let client = tokio::spawn(stream_client(writer, receiver));
+
+        broadcaster.publish(ArbTxLogEvent {
+            block_number: 42,
+            transaction_index: 3,
+            transaction_hash: B256::ZERO,
+            kind: ArbTxExecutionKind::User,
+            success: true,
+            gas_used: 21_000,
+            logs: Vec::new(),
+        });
+
+        let mut line = Vec::new();
+        BufReader::new(reader)
+            .read_until(b'\n', &mut line)
+            .await
+            .expect("read event");
+        let value: serde_json::Value = serde_json::from_slice(&line).expect("valid JSON");
+        assert_eq!(value["blockNumber"], 42);
+        assert_eq!(value["transactionIndex"], 3);
+
+        drop(broadcaster);
+        client.await.expect("client task exits");
+    }
+}

--- a/crates/arb-reth-node/tests/engine_tree_integration.rs
+++ b/crates/arb-reth-node/tests/engine_tree_integration.rs
@@ -125,6 +125,7 @@ mod tests {
             Runtime::test(),
             tuning,
             None,
+            None,
         )
         .expect("spawn native payload driver");
 

--- a/crates/arb-reth-node/tests/rpc_integration.rs
+++ b/crates/arb-reth-node/tests/rpc_integration.rs
@@ -66,6 +66,7 @@ async fn rpc_serves_eth_queries() {
         l1_messages: l1_rx,
         feed_latency: None,
         rpc_addr: Some(rpc_addr),
+        tx_log_stream: None,
     };
 
     let handle = launcher

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,5 +9,6 @@ Use the release binary in the examples below. Replace paths and endpoints with v
 - [dump-blocks](commands/dump-blocks.md): inspect persisted blocks.
 - [chains](chains/README.md): chain-specific operator notes.
 - [observability](observability/README.md): Prometheus metrics for the execute and persist loop.
+- [MEV transaction-log IPC](mev-tx-log-ipc.md): low-latency, pre-canonical transaction logs.
 
 Every command exposes its complete flag list through `arb-reth <command> --help`.

--- a/docs/commands/node.md
+++ b/docs/commands/node.md
@@ -53,10 +53,11 @@ Pass `--metrics 127.0.0.1:9001` to serve reth's Prometheus endpoint. See the [ob
 ## MEV transaction-log IPC
 
 `--mev-tx-log-ipc /run/arb-reth/mev-logs.sock` opens a local Unix socket. Each connected client
-receives newline-delimited JSON after every included ArbOS transaction finishes EVM execution.
+receives one compact binary frame after every included ArbOS transaction finishes EVM execution.
 Events include the provisional block number, transaction index and hash, transaction kind, status,
 gas used, and logs. They are deliberately pre-canonical: there is no block hash yet, and a later
-state-root or engine-insertion failure can discard the enclosing block.
+state-root or engine-insertion failure can discard the enclosing block. See the [wire
+specification](../mev-tx-log-ipc.md) before implementing a consumer.
 
 The stream is best effort. A slow client is disconnected rather than delaying execution; reconnect
 to resume from the current transaction. Nothing is allocated or serialized for this stream while no

--- a/docs/commands/node.md
+++ b/docs/commands/node.md
@@ -50,6 +50,18 @@ Use `--l1-start-block` and `--l1-start-delayed` only when the supplied values de
 
 Pass `--metrics 127.0.0.1:9001` to serve reth's Prometheus endpoint. See the [observability guide](../observability/README.md) for feed latency, engine-tree, persistence, and Prometheus scrape details.
 
+## MEV transaction-log IPC
+
+`--mev-tx-log-ipc /run/arb-reth/mev-logs.sock` opens a local Unix socket. Each connected client
+receives newline-delimited JSON after every included ArbOS transaction finishes EVM execution.
+Events include the provisional block number, transaction index and hash, transaction kind, status,
+gas used, and logs. They are deliberately pre-canonical: there is no block hash yet, and a later
+state-root or engine-insertion failure can discard the enclosing block.
+
+The stream is best effort. A slow client is disconnected rather than delaying execution; reconnect
+to resume from the current transaction. Nothing is allocated or serialized for this stream while no
+client is connected.
+
 ## Execution cache
 
 - `--engine.cross-block-cache-size <MiB>` controls Reth's cross-block account, storage, and

--- a/docs/mev-tx-log-ipc.md
+++ b/docs/mev-tx-log-ipc.md
@@ -1,0 +1,92 @@
+# MEV transaction-log IPC
+
+`arb-reth` can stream the final EVM logs for each included ArbOS transaction before it finishes
+receipt hashing, state-root calculation, and engine insertion. It is intended for a colocated
+latency-sensitive consumer, not as a replacement for RPC or an externally exposed API.
+
+Enable it with:
+
+```sh
+arb-reth node ... --mev-tx-log-ipc /run/arb-reth/mev-logs.sock
+```
+
+The socket is a Unix `SOCK_STREAM`. It is owner-access controlled by the directory and socket-file
+permissions. Do not expose it through a TCP proxy.
+
+## Delivery and validity
+
+Each event is emitted only after the transaction has completed and been accepted by the block
+builder. It includes reverted transactions, with `success = 0`; their log list will normally be
+empty.
+
+The event is **pre-canonical**. `blockNumber` identifies the block currently being built, but there
+is no block hash because the final hash depends on every transaction and the state root. If block
+building, root calculation, or engine insertion later fails, discard the events for that provisional
+block. Correlate this stream with the normal canonical block/RPC view before taking an action that
+requires finality.
+
+The stream is best effort:
+
+- It begins at the next transaction after a client connects. There is no replay.
+- Events are FIFO for a connected client.
+- A slow client is disconnected once it lags the bounded producer buffer. Reconnect and recover
+  from another source if loss matters.
+- Consumers should deduplicate by `(blockNumber, transactionIndex, transactionHash)` across a
+  reconnect or a producer restart.
+
+No payload is allocated or encoded when no client is connected. A connected client causes only a
+bounded broadcast enqueue on the execution thread; binary encoding and socket writes run in its
+own task.
+
+## Framing
+
+All integers are unsigned, big-endian. Every frame starts with a four-byte `frameLength` that
+excludes the length field itself. The frame body is exactly `frameLength` bytes.
+
+```text
+u32 frameLength
+bytes[frameLength] body
+```
+
+Version 1 uses this body. Its fixed prefix is 64 bytes.
+
+| Offset | Size | Field | Meaning |
+| --- | ---: | --- | --- |
+| 0 | 1 | `version` | Always `1`. |
+| 1 | 1 | `kind` | `0` start-block, `1` user transaction, `2` scheduled retry. |
+| 2 | 1 | `success` | `1` for EVM success, `0` for revert or halt. |
+| 3 | 1 | `flags` | Reserved. Must be zero in version 1. |
+| 4 | 8 | `blockNumber` | Provisional L2 block number. |
+| 12 | 8 | `transactionIndex` | Index in the final block transaction order, including start-block. |
+| 20 | 8 | `gasUsed` | Final transaction gas used, including refunds. |
+| 28 | 32 | `transactionHash` | 32-byte transaction hash. |
+| 60 | 4 | `logCount` | Number of log records following the fixed prefix. |
+
+Each of the `logCount` records is encoded consecutively:
+
+```text
+bytes[20] address
+u8        topicCount
+u32       dataLength
+bytes[32 * topicCount] topics
+bytes[dataLength] data
+```
+
+`topicCount` is the log's EVM topic count and must be at most four. `dataLength` may be zero.
+The consumer must reject a frame whose fields run past `frameLength` or which leaves trailing bytes
+after the final log.
+
+## Consumer requirements
+
+Read exactly four bytes, decode `frameLength`, then read exactly that many additional bytes. Never
+assume a socket read aligns with a frame. Set an application maximum before allocating the body;
+16 MiB is a reasonable initial ceiling for a local consumer, while the protocol's theoretical
+maximum is `u32::MAX` bytes.
+
+Unknown `version`, nonzero version-1 `flags`, an unknown `kind`, malformed lengths, or extra bytes
+must be treated as a protocol error. Close and reconnect rather than trying to resynchronize in the
+middle of a stream.
+
+The protocol intentionally avoids JSON, hex encoding, and a schema runtime on the hot path. Its
+only compatibility commitment is this versioned frame format. Future incompatible changes will use
+a new `version` value.


### PR DESCRIPTION
## What changed

Adds an opt-in local Unix socket for per-transaction ArbOS execution observations.

- `--mev-tx-log-ipc <PATH>` enables the stream.
- Each included transaction emits a compact, versioned binary frame immediately after execution commits to the in-progress payload.
- Slow consumers are disconnected rather than allowed to delay block production.
- No logs are cloned or encoded while no client is connected.
- Adds a complete wire specification under `docs/mev-tx-log-ipc.md`.

The stream is deliberately pre-canonical: it has no block hash, and a later root or engine failure can discard its provisional block.

## Validation

- `cargo test -p arb-reth-node mev_tx_logs --lib`
- `cargo test -p arb-reth-engine tx_log_stream --lib`
- `cargo check -p arb-reth-node`
- `cargo test -p arb-reth-node --test rpc_integration --no-run`