### PR TITLE
fix(rewind): retain deep L1 resume checkpoints

### DIFF
--- a/crates/arb-reth-node/src/commands/rewind.rs
+++ b/crates/arb-reth-node/src/commands/rewind.rs
@@ -83,6 +83,28 @@ pub struct RewindArgs {
     /// Report what would happen without modifying the database or the resume log.
     #[arg(long)]
     dry_run: bool,
+
+    /// Permit a rewind with no retained L1 derivation boundary at or below the target. The next
+    /// node start must re-derive from Nitro genesis before it can produce a new block.
+    #[arg(long)]
+    allow_genesis_rescan: bool,
+}
+
+fn resume_checkpoint_for_rewind(
+    log: Option<&L1ResumeLog>,
+    new_tip: u64,
+    genesis_block: u64,
+    allow_genesis_rescan: bool,
+) -> eyre::Result<Option<crate::L1ResumeCheckpoint>> {
+    let checkpoint = log.and_then(|log| log.resume_for(new_tip));
+    if checkpoint.is_none() && new_tip != genesis_block && !allow_genesis_rescan {
+        return Err(eyre::eyre!(
+            "no L1 resume boundary exists at or below rewind target {new_tip}; refusing to unwind \
+             because the next sync would have to re-derive from Nitro genesis; pass \
+             --allow-genesis-rescan to accept that recovery cost"
+        ));
+    }
+    Ok(checkpoint)
 }
 
 pub fn run(args: RewindArgs) -> eyre::Result<()> {
@@ -127,6 +149,24 @@ pub fn run(args: RewindArgs) -> eyre::Result<()> {
     if !db_path.exists() {
         return Err(eyre::eyre!("no database at {} (is --datadir correct?)", db_path.display()));
     }
+    if new_tip < genesis_num {
+        return Err(eyre::eyre!(
+            "new tip {new_tip} is below the imported genesis block {genesis_num}; \
+             reset the datadir instead (arb-reset-db.sh)"
+        ));
+    }
+
+    // Refuse an unrecoverable rewind before opening or repairing any database layer. An arbitrary
+    // L2 header carries the delayed cursor but not the matching L1 batch-delivery boundary, so the
+    // missing checkpoint cannot be reconstructed safely from the target header alone.
+    let log_path = L1ResumeLog::path_in(&args.datadir);
+    let mut log = L1ResumeLog::load(&log_path);
+    let surviving = resume_checkpoint_for_rewind(
+        log.as_ref(),
+        new_tip,
+        genesis_num,
+        args.allow_genesis_rescan,
+    )?;
 
     // Correct the genesis-import changeset-segment layout before opening the DB (so no reth code,
     // `check_consistency` in particular, touches the mis-seeded files first). The snapshot import
@@ -183,29 +223,23 @@ pub fn run(args: RewindArgs) -> eyre::Result<()> {
             "new tip {new_tip} is not below the current tip {current_tip}; nothing to rewind"
         ));
     }
-    if new_tip < genesis_num {
-        return Err(eyre::eyre!(
-            "new tip {new_tip} is below the imported genesis block {genesis_num}; \
-             reset the datadir instead (arb-reset-db.sh)"
-        ));
-    }
-
     // Truncate the resume log to a boundary at or below the new tip, so the next start resumes
-    // derivation from there. Preview it first; without a surviving boundary the caller must supply
-    // --l1-start-block on the next run (or reset).
-    let log_path = L1ResumeLog::path_in(&args.datadir);
-    let mut log = L1ResumeLog::load(&log_path);
-    let surviving = log.as_ref().and_then(|l| l.checkpoints.iter().rev().find(|cp| cp.l2_block <= new_tip).copied());
+    // derivation from there. The preflight above only permits a missing boundary when rewinding to
+    // genesis or when the operator explicitly accepted a genesis rescan.
     match &surviving {
         Some(cp) => info!(
             target: "arb-rewind",
             l1_block = cp.l1_block, delayed = cp.delayed_count, l2_block = cp.l2_block,
             "resume log will keep this boundary; next sync re-derives from it up to the new tip",
         ),
+        None if new_tip == genesis_num => info!(
+            target: "arb-rewind",
+            "rewinding to imported genesis; the next sync will derive from Nitro genesis",
+        ),
         None => info!(
             target: "arb-rewind",
-            "no resume-log boundary at or below {new_tip}; the next sync will re-derive from Nitro \
-             genesis and skip already-present blocks (derivation-only up to the new tip)",
+            "no resume-log boundary at or below {new_tip}; --allow-genesis-rescan was supplied, so \
+             the next sync will re-derive from Nitro genesis and skip already-present blocks",
         ),
     }
 
@@ -271,7 +305,7 @@ pub fn run(args: RewindArgs) -> eyre::Result<()> {
         log.truncate_to(new_tip);
         if log.checkpoints.is_empty() {
             // Nothing survives: remove the stale log so the next start doesn't refuse on an
-            // all-above-tip log; the operator resumes via --l1-start-block or reset.
+            // all-above-tip log; the node resumes from genesis as accepted during preflight.
             let _ = std::fs::remove_file(&log_path);
         } else {
             log.save(&log_path).map_err(|e| eyre::eyre!("rewrite resume log: {e}"))?;
@@ -371,4 +405,39 @@ fn migrate_changeset_layout(static_files: &Path, genesis: u64) -> eyre::Result<(
         );
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn checkpoint(l1_block: u64, l2_block: u64) -> crate::L1ResumeCheckpoint {
+        crate::L1ResumeCheckpoint {
+            l1_block,
+            delayed_count: 0,
+            l2_block,
+        }
+    }
+
+    #[test]
+    fn rewind_requires_a_safe_resume_boundary() {
+        let mut log = L1ResumeLog::default();
+        log.record(checkpoint(1_000, 10_000));
+        log.record(checkpoint(2_000, 20_000));
+
+        assert_eq!(
+            resume_checkpoint_for_rewind(Some(&log), 15_000, 0, false).unwrap(),
+            Some(checkpoint(1_000, 10_000))
+        );
+
+        let error = resume_checkpoint_for_rewind(Some(&log), 5_000, 0, false).unwrap_err();
+        assert!(error.to_string().contains("refusing to unwind"));
+        assert!(error.to_string().contains("--allow-genesis-rescan"));
+        assert!(resume_checkpoint_for_rewind(None, 5_000, 0, false).is_err());
+        assert_eq!(
+            resume_checkpoint_for_rewind(Some(&log), 5_000, 0, true).unwrap(),
+            None
+        );
+        assert_eq!(resume_checkpoint_for_rewind(None, 0, 0, false).unwrap(), None);
+    }
 }

--- a/crates/arb-reth-sync/src/resume.rs
+++ b/crates/arb-reth-sync/src/resume.rs
@@ -10,10 +10,12 @@
 //! resumes derivation from there (the file-based equivalent of Nitro's `arbitrumdata` mapping,
 //! for the common single-writer case).
 //!
-//! ## Why a bounded history, not one checkpoint
+//! ## Why dense recent history plus sparse historical history
 //!
-//! The file keeps the last [`MAX_CHECKPOINTS`] boundaries, not just the newest one, so a consumer
-//! can pick the newest boundary at or below a given L2 block. Two cases need that:
+//! The file keeps the latest [`RECENT_CHECKPOINTS`] boundaries at full resolution. Older entries
+//! are compacted to the earliest boundary in each [`HISTORICAL_CHECKPOINT_L2_INTERVAL`]-block L2
+//! bucket. A consumer can therefore pick a boundary at or below an arbitrarily old L2 block
+//! without retaining every derivation window. Two cases need that:
 //!
 //! * **Rewind** (`arb-rewind`) unwinds the DB to some block `N-1` after a divergence; it truncates
 //!   the log to boundaries `<= N-1` so the next start resumes from a batch boundary at or below the
@@ -36,10 +38,15 @@ use serde::{Deserialize, Serialize};
 /// File name (under the data directory) of the L1-derivation resume log.
 pub const RESUME_FILE_NAME: &str = "arb-l1-resume.json";
 
-/// How many recent boundaries the log retains. Each is one derivation window (up to
-/// `batch_window` L1 blocks), so this bounds how far back a rewind can resume from without a
-/// re-scan from genesis. Generous: the file is a few KB even when full.
-pub const MAX_CHECKPOINTS: usize = 128;
+/// How many recent derivation boundaries remain at full resolution.
+pub const RECENT_CHECKPOINTS: usize = 128;
+
+/// L2 span represented by one compacted historical checkpoint.
+///
+/// The earliest boundary in each bucket is retained. It is therefore safe to resume any target
+/// in that bucket from the retained boundary, re-deriving at most roughly this many existing L2
+/// blocks before reaching the target again.
+pub const HISTORICAL_CHECKPOINT_L2_INTERVAL: u64 = 100_000;
 
 /// A durable L1-derivation resume point, recorded at a batch/window boundary.
 ///
@@ -58,10 +65,11 @@ pub struct L1ResumeCheckpoint {
     pub l2_block: u64,
 }
 
-/// A bounded, ascending log of recent [`L1ResumeCheckpoint`]s, persisted as `arb-l1-resume.json`.
+/// An ascending log of recent and compacted historical [`L1ResumeCheckpoint`]s, persisted as
+/// `arb-l1-resume.json`.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct L1ResumeLog {
-    /// Boundaries in ascending `l2_block` order, newest last, capped at [`MAX_CHECKPOINTS`].
+    /// Boundaries in ascending `l2_block` order, with compacted history followed by a dense tail.
     pub checkpoints: Vec<L1ResumeCheckpoint>,
 }
 
@@ -100,20 +108,40 @@ impl L1ResumeLog {
         self.checkpoints.iter().rev().find(|cp| cp.l2_block <= l2_block).copied()
     }
 
-    /// Append a boundary, keeping the log ascending, deduplicated by `l2_block`, and capped at
-    /// [`MAX_CHECKPOINTS`] (oldest dropped). Boundaries arrive in ascending order during sync; a
-    /// repeat `l2_block` (an empty window that only advanced `l1_block`) replaces the prior entry so
-    /// the newest `l1_block` wins.
+    /// Append a boundary, keeping the log ascending and deduplicated by `l2_block`. Boundaries
+    /// arrive in ascending order during sync; a repeat `l2_block` (an empty window that only
+    /// advanced `l1_block`) replaces the prior entry so the newest `l1_block` wins.
+    ///
+    /// The recent tail remains dense. Older entries retain the earliest boundary in each fixed L2
+    /// bucket so a deep rewind always has a safe starting point before its target.
     pub fn record(&mut self, cp: L1ResumeCheckpoint) {
         if self.checkpoints.last().is_some_and(|last| last.l2_block == cp.l2_block) {
             *self.checkpoints.last_mut().unwrap() = cp;
         } else {
             self.checkpoints.push(cp);
         }
-        let len = self.checkpoints.len();
-        if len > MAX_CHECKPOINTS {
-            self.checkpoints.drain(0..len - MAX_CHECKPOINTS);
+        self.compact_history();
+    }
+
+    fn compact_history(&mut self) {
+        let Some(recent_start) = self.checkpoints.len().checked_sub(RECENT_CHECKPOINTS) else {
+            return;
+        };
+        if recent_start == 0 {
+            return;
         }
+
+        let mut compacted = Vec::with_capacity(self.checkpoints.len());
+        let mut last_bucket = None;
+        for checkpoint in self.checkpoints[..recent_start].iter().copied() {
+            let bucket = checkpoint.l2_block / HISTORICAL_CHECKPOINT_L2_INTERVAL;
+            if last_bucket != Some(bucket) {
+                compacted.push(checkpoint);
+                last_bucket = Some(bucket);
+            }
+        }
+        compacted.extend_from_slice(&self.checkpoints[recent_start..]);
+        self.checkpoints = compacted;
     }
 
     /// Drop every boundary above `l2_block` (used by rewind after unwinding the DB to a new tip).
@@ -157,20 +185,32 @@ mod tests {
     }
 
     #[test]
-    fn record_dedupes_empty_windows_and_caps_length() {
+    fn record_dedupes_empty_windows() {
         let mut log = L1ResumeLog::default();
         log.record(cp(100, 10));
         // Empty windows: same l2, advancing l1, so the newest l1 must win, no duplicate l2 entry.
         log.record(cp(200, 10));
         log.record(cp(300, 10));
         assert_eq!(log.checkpoints, vec![cp(300, 10)]);
+    }
 
+    #[test]
+    fn record_retains_sparse_history_and_dense_recent_tail() {
         let mut log = L1ResumeLog::default();
-        for i in 0..(MAX_CHECKPOINTS as u64 + 50) {
-            log.record(cp(i, i));
+        for l2 in (0..1_000_000).step_by(1_000) {
+            log.record(cp(l2 + 10, l2));
         }
-        assert_eq!(log.checkpoints.len(), MAX_CHECKPOINTS, "capped");
-        assert_eq!(log.checkpoints.first().copied(), Some(cp(50, 50)), "oldest dropped");
+
+        // Old buckets retain their earliest boundary instead of being discarded.
+        assert_eq!(log.resume_for(150_050), Some(cp(100_010, 100_000)));
+        assert_eq!(log.resume_for(550_050), Some(cp(500_010, 500_000)));
+
+        // The newest 128 entries remain available at their original resolution.
+        assert_eq!(log.resume_for(950_050), Some(cp(950_010, 950_000)));
+        assert_eq!(log.checkpoints.last().copied(), Some(cp(999_010, 999_000)));
+
+        // Ten historical buckets plus the dense tail is tiny compared with every input boundary.
+        assert!(log.checkpoints.len() <= 10 + RECENT_CHECKPOINTS);
     }
 
     #[test]

--- a/docs/chains/robinhood-mainnet.md
+++ b/docs/chains/robinhood-mainnet.md
@@ -95,9 +95,9 @@ Stop the node before modifying the datadir. If `N` is the first divergent L2 blo
 
 Run the same `node` command again afterwards. Start with `rewind --dry-run` when the target has not been independently verified.
 
-Normally the node resumes from `arb-l1-resume.json`. If a rewind leaves no usable checkpoint and
-reports an L1 boundary, pass that boundary with `--l1-start-block`. The node recovers the matching
-delayed-message cursor from the durable L2 tip header. `--l1-start-delayed` is only needed to
-override that value during manual recovery.
+Normally the node resumes from `arb-l1-resume.json`. It retains compacted historical boundaries so
+a deep rewind can restart from a safe point before the new tip. If no such boundary exists,
+`rewind` stops before modifying the database. Avoid guessing `--l1-start-block`: the tip header
+contains the delayed-message cursor but not the matching L1 batch-delivery boundary.
 
 See the [node command](../commands/node.md), [observability guide](../observability/README.md), and [rewind command](../commands/rewind.md) for option details.

--- a/docs/commands/rewind.md
+++ b/docs/commands/rewind.md
@@ -13,6 +13,15 @@ arb-reth rewind \
 
 Use `--to <block>` when the desired surviving tip is already known. Run `--dry-run` first to inspect the target without writing.
 
+The node keeps recent L1 derivation boundaries densely and compacted historical boundaries for
+deep recovery. `rewind` refuses to modify the database when it cannot find a safe boundary at or
+below the target. `--allow-genesis-rescan` overrides that guard, but the following node start must
+re-derive every message from Nitro genesis before producing a new block.
+
+Resume logs created by older releases only contain their final 128 boundaries. Updating cannot
+restore history those releases already discarded. After upgrading, newly observed boundaries are
+retained in the compacted history; until then, a rewind older than the legacy log is refused.
+
 The boot information must match the datadir:
 
 - Snapshot-seeded datadir: pass `--snapshot-head`.


### PR DESCRIPTION
this keeps the latest 128 checkpoints and additionally writes one resume checkpoint every 100,000  blocks so no manual l1 block has to be specified to rederive from 