### PR TITLE
deps(arbitrum-revm): bump Stylus account code fix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ incremental = false
 [workspace.dependencies]
 # Keep the ArbOS implementation revision in one place. Individual crates opt into it with
 # `arb-revm.workspace = true`; only the EVM integration enables the Stylus runtime.
-arb-revm = { git = "https://github.com/nuntax/arbitrum-revm", rev = "887157a3dc04bc55b686a336b8d53191a2bbeb42" }
+arb-revm = { git = "https://github.com/nuntax/arbitrum-revm", rev = "8047d5e0d4bc8f7fb791cfdb9522240ce6c6ccd7" }
 # Pinned to revm 42 to unify with arb_revm workspace.
 revm = { version = "42.0.1", features = ["optional_priority_fee_check", "optional_balance_check", "optional_no_base_fee", "optional_eip7623", "optional_eip3541"] }
 alloy-rlp = "0.3.12"


### PR DESCRIPTION
Pins arbitrum-revm at 8047d5e0d4bc8f7fb791cfdb9522240ce6c6ccd7. This includes the missing Stylus account_code host call implementation that caused Robinhood block 53,753,680 transaction 13 to revert locally instead of succeeding.