### PR TITLE
Bind frontier v3 to execution prefixes and strict validation

### DIFF
--- a/crates/arb-reth-engine/Cargo.toml
+++ b/crates/arb-reth-engine/Cargo.toml
@@ -20,7 +20,7 @@ arbitrum-alloy-sequencer = { git = "https://github.com/nuntax/arbitrum-alloy", r
 alloy-consensus = { version = "2.0", default-features = false }
 alloy-eips = { version = "2.0", default-features = false }
 alloy-evm = "0.38"
-alloy-primitives = { version = "1", default-features = false }
+alloy-primitives = { version = "1", default-features = false, features = ["getrandom"] }
 alloy-rpc-types-engine = { version = "2.0", default-features = false, features = ["serde"] }
 eyre = "0.6.12"
 metrics = "0.24"

--- a/crates/arb-reth-engine/src/engine.rs
+++ b/crates/arb-reth-engine/src/engine.rs
@@ -159,6 +159,9 @@ pub(crate) fn produce_with_timing<'a>(
     BuiltPayloadExecutedBlock<ArbPrimitives>,
     ArbBlockProductionTiming,
 )> {
+    if let Some(stream) = tx_log_stream {
+        stream.invalidate_frontiers();
+    }
     let started_at = Instant::now();
     let parent_header = parent.header();
     let arbos_version =
@@ -299,14 +302,16 @@ pub(crate) fn produce_with_timing<'a>(
     // Anchor exact MEV simulations after pre-execution changes. Each committed transaction adds
     // only its own state delta to a persistent chain; frontiers do not clone cumulative block
     // state and therefore remain cheap enough for the transaction-by-transaction feed.
-    let mut frontier_block = tx_log_stream.map(|stream| {
-        let evm_env = EvmEnv::new(
-            builder.evm().cfg_env().clone(),
-            builder.evm().block().clone(),
-        );
-        let pre_execution_state = builder.evm_mut().db_mut().cache.clone();
-        stream.begin_frontier_block(parent.hash(), evm_env, pre_execution_state)
-    });
+    let mut frontier_block = tx_log_stream
+        .map(|stream| {
+            let evm_env = EvmEnv::new(
+                builder.evm().cfg_env().clone(),
+                builder.evm().block().clone(),
+            );
+            let pre_execution_state = builder.evm_mut().db_mut().cache.clone();
+            stream.begin_frontier_block(parent.hash(), evm_env, pre_execution_state)
+        })
+        .transpose()?;
 
     let execution_setup = phase_started_at.elapsed();
     let phase_started_at = Instant::now();
@@ -398,7 +403,10 @@ pub(crate) fn produce_with_timing<'a>(
                 transaction_hash,
                 update,
                 builder.evm().ctx().chain.clone(),
-            ),
+            )?,
+            _ if tx_log_stream.is_some() => {
+                eyre::bail!("included transaction lacks execution frontier state");
+            }
             _ => B256::ZERO,
         };
         if let (Some(stream), Some(transaction_hash), Some(logs)) =
@@ -409,6 +417,11 @@ pub(crate) fn produce_with_timing<'a>(
                 transaction_index,
                 transaction_hash,
                 frontier_id,
+                parent_hash: parent.hash(),
+                attempt_id: frontier_block
+                    .as_ref()
+                    .expect("stream has frontier tracking")
+                    .attempt_id(),
                 kind,
                 success: tx_success,
                 gas_used: tx_gas_used,
@@ -540,6 +553,9 @@ pub(crate) fn produce_with_timing<'a>(
         state: bundle,
     });
 
+    if let Some(frontier) = &mut frontier_block {
+        frontier.complete();
+    }
     // BuiltPayloadExecutedBlock wants unsorted hashed_state / trie_updates.
     Ok((
         BuiltPayloadExecutedBlock {
@@ -1936,6 +1952,46 @@ mod termination_tests {
         };
         // The guard intentionally drops the acknowledgement receiver after requesting shutdown.
         assert!(tx.send(()).is_err());
+    }
+
+    #[test]
+    fn frontier_entry_failure_revokes_previous_completed_attempt() {
+        use alloy_primitives::U256;
+        use reth_provider::test_utils::MockEthProvider;
+        use revm_database::CacheState;
+        let parent = SealedHeader::seal_slow(Header {
+            number: 41,
+            ..Default::default()
+        });
+        let stream = ArbTxLogBroadcaster::new();
+        let mut env: EvmEnv<arb_revm::ArbSpecId, arb_reth_evm::ArbBlockEnv> = EvmEnv::default();
+        env.block_env.inner.number = U256::from(42);
+        let mut block = stream
+            .begin_frontier_block(parent.hash(), env, CacheState::default())
+            .unwrap();
+        let id = block
+            .advance(42, 0, B256::ZERO, Default::default(), Default::default())
+            .unwrap();
+        block.complete();
+        drop(block);
+        let held = stream.frontier_store().get(id).unwrap();
+        let result = produce_with_timing(
+            &ArbEvmConfig::new(4663),
+            4663,
+            &parent,
+            &BroadcastFeedMessage::default(),
+            Box::new(MockEthProvider::<ArbPrimitives>::new()),
+            Box::new(MockEthProvider::<ArbPrimitives>::new()),
+            None,
+            Some(&stream),
+        );
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("digest_message failed")
+        );
+        assert!(!stream.frontier_store().is_current(&held));
     }
 }
 

--- a/crates/arb-reth-engine/src/lib.rs
+++ b/crates/arb-reth-engine/src/lib.rs
@@ -34,7 +34,8 @@ pub use engine_spike::ArbPayloadValidator;
 pub use native_payload::ArbPayloadBuilder;
 pub use tx_log_stream::{
     ArbExecutionFrontier, ArbExecutionFrontierStore, ArbTxExecutionKind, ArbTxLogBroadcaster,
-    ArbTxLogEvent,
+    ArbTxLogEvent, EXECUTION_FRONTIER_ID_FORMULA, EXECUTION_FRONTIER_ID_SCHEME,
+    EXECUTION_FRONTIER_VERSION, execution_frontier_id,
 };
 
 /// An executed Arbitrum payload produced by the local payload builder.

--- a/crates/arb-reth-engine/src/native_payload.rs
+++ b/crates/arb-reth-engine/src/native_payload.rs
@@ -79,6 +79,10 @@ impl<P> ArbPayloadBuilder<P> {
     where
         P: StateProviderFactory,
     {
+        // State-provider acquisition can fail before produce_with_timing is entered.
+        if let Some(stream) = &self.tx_log_stream {
+            stream.invalidate_frontiers();
+        }
         let parent = args.config.parent_header;
         let parent_hash = parent.hash();
         let supplied_cache = args.execution_cache;

--- a/crates/arb-reth-engine/src/tx_log_stream.rs
+++ b/crates/arb-reth-engine/src/tx_log_stream.rs
@@ -23,6 +23,31 @@ pub const TX_LOG_STREAM_CAPACITY: usize = 1_024;
 /// Number of exact post-transaction execution frontiers retained for RPC simulation.
 pub const EXECUTION_FRONTIER_CAPACITY: usize = TX_LOG_STREAM_CAPACITY;
 
+/// Wire and identity version; a version-2 handle must never be used as a prefix proof.
+pub const EXECUTION_FRONTIER_VERSION: u8 = 3;
+pub const EXECUTION_FRONTIER_ID_SCHEME: &str = "keccak256-rhf3-prefix-v1";
+pub const EXECUTION_FRONTIER_ID_FORMULA: &str = "keccak256(RHF3||parentHash||blockNumberBE64||attemptId||previousFrontierId||transactionIndexBE64||transactionHash)";
+
+/// Hash a complete execution-prefix witness. Index zero uses a zero previous ID.
+pub fn execution_frontier_id(
+    parent_hash: B256,
+    block_number: u64,
+    attempt_id: B256,
+    previous_id: B256,
+    transaction_index: u64,
+    transaction_hash: B256,
+) -> B256 {
+    let mut identity = [0u8; 148];
+    identity[..4].copy_from_slice(b"RHF3");
+    identity[4..36].copy_from_slice(parent_hash.as_slice());
+    identity[36..44].copy_from_slice(&block_number.to_be_bytes());
+    identity[44..76].copy_from_slice(attempt_id.as_slice());
+    identity[76..108].copy_from_slice(previous_id.as_slice());
+    identity[108..116].copy_from_slice(&transaction_index.to_be_bytes());
+    identity[116..].copy_from_slice(transaction_hash.as_slice());
+    keccak256(identity)
+}
+
 /// The source of a transaction in the deterministic ArbOS block order.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum ArbTxExecutionKind {
@@ -49,6 +74,9 @@ pub struct ArbTxLogEvent {
     pub transaction_hash: B256,
     /// Exact post-transaction state frontier accepted by `arb_simulateAtFrontier`.
     pub frontier_id: B256,
+    /// Canonical parent and random block-attempt identity used by the prefix hash.
+    pub parent_hash: B256,
+    pub attempt_id: B256,
     /// Deterministic ArbOS transaction source.
     pub kind: ArbTxExecutionKind,
     /// Receipt-status equivalent for this transaction.
@@ -62,6 +90,7 @@ pub struct ArbTxLogEvent {
 #[derive(Debug)]
 struct FrontierBlockBase {
     parent_hash: B256,
+    attempt_id: B256,
     evm_env: EvmEnv<ArbSpecId, ArbBlockEnv>,
     pre_execution_state: CacheState,
 }
@@ -92,6 +121,11 @@ impl ArbExecutionFrontier {
     /// Hash of the canonical parent state on which the in-progress block is executing.
     pub fn parent_hash(&self) -> B256 {
         self.base.parent_hash
+    }
+
+    /// Random identity of this particular execution of the provisional block.
+    pub fn attempt_id(&self) -> B256 {
+        self.base.attempt_id
     }
 
     /// Exact EVM environment used by the in-progress block.
@@ -126,6 +160,7 @@ impl ArbExecutionFrontier {
 struct ExecutionFrontierInner {
     order: VecDeque<B256>,
     frontiers: HashMap<B256, ArbExecutionFrontier>,
+    active_attempt: Option<B256>,
 }
 
 /// Bounded, thread-safe store of exact post-transaction execution frontiers.
@@ -146,28 +181,62 @@ impl ArbExecutionFrontierStore {
 
     /// Looks up an exact frontier. Missing entries are expired or were never observed.
     pub fn get(&self, frontier_id: B256) -> Option<ArbExecutionFrontier> {
-        self.inner
+        let inner = self
+            .inner
             .read()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        inner
             .frontiers
             .get(&frontier_id)
+            .filter(|frontier| Some(frontier.attempt_id()) == inner.active_attempt)
             .cloned()
     }
 
-    fn insert(&self, frontier: ArbExecutionFrontier) {
+    /// Recheck after simulation: retaining an Arc cannot authorize an old attempt.
+    pub fn is_current(&self, frontier: &ArbExecutionFrontier) -> bool {
+        self.get(frontier.frontier_id).is_some_and(|current| {
+            current.attempt_id() == frontier.attempt_id()
+                && current.parent_hash() == frontier.parent_hash()
+        })
+    }
+
+    fn activate(&self, attempt_id: B256) {
+        self.inner
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .active_attempt = Some(attempt_id);
+    }
+
+    fn invalidate_attempt(&self, attempt_id: B256) {
+        let mut inner = self
+            .inner
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if inner.active_attempt == Some(attempt_id) {
+            inner.active_attempt = None;
+        }
+    }
+
+    fn insert(&self, frontier: ArbExecutionFrontier) -> eyre::Result<()> {
         let mut inner = self
             .inner
             .write()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
         let frontier_id = frontier.frontier_id;
-        if inner.frontiers.insert(frontier_id, frontier).is_none() {
-            inner.order.push_back(frontier_id);
+        if inner.active_attempt != Some(frontier.attempt_id()) {
+            eyre::bail!("execution attempt superseded");
         }
+        if inner.frontiers.contains_key(&frontier_id) {
+            eyre::bail!("duplicate execution frontier identity");
+        }
+        inner.frontiers.insert(frontier_id, frontier);
+        inner.order.push_back(frontier_id);
         while inner.order.len() > self.capacity {
             if let Some(expired) = inner.order.pop_front() {
                 inner.frontiers.remove(&expired);
             }
         }
+        Ok(())
     }
 }
 
@@ -184,6 +253,9 @@ pub struct ArbExecutionFrontierBlock {
     store: ArbExecutionFrontierStore,
     base: Arc<FrontierBlockBase>,
     tail: Option<Arc<FrontierStateDelta>>,
+    previous_id: B256,
+    next_index: u64,
+    completed: bool,
 }
 
 impl ArbExecutionFrontierBlock {
@@ -192,16 +264,35 @@ impl ArbExecutionFrontierBlock {
         parent_hash: B256,
         evm_env: EvmEnv<ArbSpecId, ArbBlockEnv>,
         pre_execution_state: CacheState,
-    ) -> Self {
-        Self {
+    ) -> eyre::Result<Self> {
+        // OS entropy failure must stop this attempt, not produce a predictable
+        // cross-process incarnation. A zero draw is retried with a bounded limit.
+        let attempt_id = (0..4)
+            .find_map(|_| B256::try_random().ok().filter(|id| *id != B256::ZERO))
+            .ok_or_else(|| eyre::eyre!("execution attempt entropy unavailable"))?;
+        store.activate(attempt_id);
+        Ok(Self {
             store,
             base: Arc::new(FrontierBlockBase {
                 parent_hash,
+                attempt_id,
                 evm_env,
                 pre_execution_state,
             }),
             tail: None,
-        }
+            previous_id: B256::ZERO,
+            next_index: 0,
+            completed: false,
+        })
+    }
+
+    /// Mark successful payload construction. Retention still does not imply canonical inclusion.
+    pub fn complete(&mut self) {
+        self.completed = true;
+    }
+
+    pub fn attempt_id(&self) -> B256 {
+        self.base.attempt_id
     }
 
     /// Advances and retains the exact state after one committed transaction.
@@ -212,18 +303,28 @@ impl ArbExecutionFrontierBlock {
         transaction_hash: B256,
         update: EvmState,
         chain_context: ArbChainContext,
-    ) -> B256 {
-        let mut identity = [0u8; 80];
-        identity[..32].copy_from_slice(self.base.parent_hash.as_slice());
-        identity[32..40].copy_from_slice(&block_number.to_be_bytes());
-        identity[40..48].copy_from_slice(&transaction_index.to_be_bytes());
-        identity[48..].copy_from_slice(transaction_hash.as_slice());
-        let frontier_id = keccak256(identity);
+    ) -> eyre::Result<B256> {
+        if transaction_index != self.next_index
+            || self.base.evm_env.block_env.inner.number
+                != alloy_primitives::U256::from(block_number)
+        {
+            eyre::bail!("execution frontier order or block mismatch");
+        }
+        let next_index = transaction_index
+            .checked_add(1)
+            .ok_or_else(|| eyre::eyre!("execution frontier index overflow"))?;
+        let frontier_id = execution_frontier_id(
+            self.base.parent_hash,
+            block_number,
+            self.base.attempt_id,
+            self.previous_id,
+            transaction_index,
+            transaction_hash,
+        );
         let tail = Arc::new(FrontierStateDelta {
             previous: self.tail.clone(),
             update: Arc::new(update),
         });
-        self.tail = Some(Arc::clone(&tail));
         self.store.insert(ArbExecutionFrontier {
             frontier_id,
             block_number,
@@ -231,9 +332,20 @@ impl ArbExecutionFrontierBlock {
             transaction_hash,
             chain_context,
             base: Arc::clone(&self.base),
-            tail,
-        });
-        frontier_id
+            tail: Arc::clone(&tail),
+        })?;
+        self.tail = Some(tail);
+        self.previous_id = frontier_id;
+        self.next_index = next_index;
+        Ok(frontier_id)
+    }
+}
+
+impl Drop for ArbExecutionFrontierBlock {
+    fn drop(&mut self) {
+        if !self.completed {
+            self.store.invalidate_attempt(self.base.attempt_id);
+        }
     }
 }
 
@@ -273,13 +385,22 @@ impl ArbTxLogBroadcaster {
         self.frontiers.clone()
     }
 
+    /// Revoke earlier attempts before any fallible preparation of a new payload.
+    pub fn invalidate_frontiers(&self) {
+        self.frontiers
+            .inner
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .active_attempt = None;
+    }
+
     /// Begins tracking one in-progress block after its pre-execution changes have committed.
     pub fn begin_frontier_block(
         &self,
         parent_hash: B256,
         evm_env: EvmEnv<ArbSpecId, ArbBlockEnv>,
         pre_execution_state: CacheState,
-    ) -> ArbExecutionFrontierBlock {
+    ) -> eyre::Result<ArbExecutionFrontierBlock> {
         ArbExecutionFrontierBlock::new(
             self.frontiers.clone(),
             parent_hash,
@@ -305,6 +426,12 @@ impl Default for ArbTxLogBroadcaster {
 mod tests {
     use super::*;
 
+    fn test_env() -> EvmEnv<ArbSpecId, ArbBlockEnv> {
+        let mut env: EvmEnv<ArbSpecId, ArbBlockEnv> = EvmEnv::default();
+        env.block_env.inner.number = alloy_primitives::U256::from(42);
+        env
+    }
+
     #[test]
     fn publishes_only_when_a_consumer_is_connected() {
         let broadcaster = ArbTxLogBroadcaster::new();
@@ -319,16 +446,13 @@ mod tests {
 
     #[test]
     fn frontier_deltas_are_retained_in_execution_order() {
-        use alloy_evm::EvmEnv;
         use alloy_primitives::Address;
         use revm::state::{Account, AccountInfo};
 
         let broadcaster = ArbTxLogBroadcaster::new();
-        let mut block = broadcaster.begin_frontier_block(
-            B256::repeat_byte(0x11),
-            EvmEnv::default(),
-            CacheState::default(),
-        );
+        let mut block = broadcaster
+            .begin_frontier_block(B256::repeat_byte(0x11), test_env(), CacheState::default())
+            .unwrap();
         let address = Address::repeat_byte(0x22);
         let mut first_account = Account::default();
         first_account.info = AccountInfo {
@@ -337,13 +461,15 @@ mod tests {
         };
         let mut first = EvmState::default();
         first.insert(address, first_account);
-        let first_id = block.advance(
-            42,
-            0,
-            B256::repeat_byte(0x33),
-            first,
-            ArbChainContext::default(),
-        );
+        let first_id = block
+            .advance(
+                42,
+                0,
+                B256::repeat_byte(0x33),
+                first,
+                ArbChainContext::default(),
+            )
+            .unwrap();
         let mut second_account = Account::default();
         second_account.info = AccountInfo {
             nonce: 2,
@@ -351,13 +477,15 @@ mod tests {
         };
         let mut second = EvmState::default();
         second.insert(address, second_account);
-        let second_id = block.advance(
-            42,
-            1,
-            B256::repeat_byte(0x44),
-            second,
-            ArbChainContext::default(),
-        );
+        let second_id = block
+            .advance(
+                42,
+                1,
+                B256::repeat_byte(0x44),
+                second,
+                ArbChainContext::default(),
+            )
+            .unwrap();
 
         assert_eq!(
             broadcaster
@@ -382,27 +510,186 @@ mod tests {
             sender: broadcast::channel(1).0,
             frontiers: store.clone(),
         };
-        let mut block = broadcaster.begin_frontier_block(
-            B256::repeat_byte(0x11),
-            EvmEnv::default(),
-            CacheState::default(),
-        );
-        let first_id = block.advance(
-            42,
-            0,
-            B256::repeat_byte(0x33),
-            EvmState::default(),
-            ArbChainContext::default(),
-        );
-        let second_id = block.advance(
-            42,
-            1,
-            B256::repeat_byte(0x44),
-            EvmState::default(),
-            ArbChainContext::default(),
-        );
+        let mut block = broadcaster
+            .begin_frontier_block(B256::repeat_byte(0x11), test_env(), CacheState::default())
+            .unwrap();
+        let first_id = block
+            .advance(
+                42,
+                0,
+                B256::repeat_byte(0x33),
+                EvmState::default(),
+                ArbChainContext::default(),
+            )
+            .unwrap();
+        let second_id = block
+            .advance(
+                42,
+                1,
+                B256::repeat_byte(0x44),
+                EvmState::default(),
+                ArbChainContext::default(),
+            )
+            .unwrap();
 
         assert!(store.get(first_id).is_none());
         assert!(store.get(second_id).is_some());
+    }
+
+    #[test]
+    fn prefix_identity_commits_every_fixed_width_field() {
+        let parent = B256::repeat_byte(0x11);
+        let attempt = B256::repeat_byte(0x22);
+        let previous = B256::repeat_byte(0x33);
+        let tx = B256::repeat_byte(0x44);
+        // Independent concatenation oracle for the public 148-byte protocol, including domain.
+        let bytes = [
+            b"RHF3".as_slice(),
+            parent.as_slice(),
+            &42u64.to_be_bytes(),
+            attempt.as_slice(),
+            previous.as_slice(),
+            &7u64.to_be_bytes(),
+            tx.as_slice(),
+        ]
+        .concat();
+        assert_eq!(bytes.len(), 148);
+        let id = execution_frontier_id(parent, 42, attempt, previous, 7, tx);
+        assert_eq!(
+            id,
+            alloy_primitives::b256!(
+                "8badcee9394a8d15f450bc007511b5377466466dc4b61bdee56023aea19b5caf"
+            )
+        );
+        assert_eq!(id, keccak256(bytes));
+        for other in [
+            execution_frontier_id(B256::ZERO, 42, attempt, previous, 7, tx),
+            execution_frontier_id(parent, 43, attempt, previous, 7, tx),
+            execution_frontier_id(parent, 42, B256::ZERO, previous, 7, tx),
+            execution_frontier_id(parent, 42, attempt, B256::ZERO, 7, tx),
+            execution_frontier_id(parent, 42, attempt, previous, 8, tx),
+            execution_frontier_id(parent, 42, attempt, previous, 7, B256::ZERO),
+        ] {
+            assert_ne!(id, other);
+        }
+    }
+
+    #[test]
+    fn rederivation_expires_old_attempt_and_cannot_alias_identical_transactions() {
+        let broadcaster = ArbTxLogBroadcaster::new();
+        let store = broadcaster.frontier_store();
+        let parent = B256::repeat_byte(0x11);
+        let tx = B256::repeat_byte(0x22);
+        let mut first = broadcaster
+            .begin_frontier_block(parent, test_env(), CacheState::default())
+            .unwrap();
+        let first_id = first
+            .advance(42, 0, tx, EvmState::default(), ArbChainContext::default())
+            .unwrap();
+        let held = store.get(first_id).unwrap();
+        assert_ne!(held.attempt_id(), B256::ZERO);
+        let mut second = broadcaster
+            .begin_frontier_block(parent, test_env(), CacheState::default())
+            .unwrap();
+        assert_ne!(first.attempt_id(), second.attempt_id());
+        assert!(store.get(first_id).is_none());
+        assert!(!store.is_current(&held));
+        assert!(
+            first
+                .advance(42, 1, tx, EvmState::default(), ArbChainContext::default())
+                .is_err()
+        );
+        let second_id = second
+            .advance(42, 0, tx, EvmState::default(), ArbChainContext::default())
+            .unwrap();
+        assert_ne!(first_id, second_id);
+        assert!(store.is_current(&store.get(second_id).unwrap()));
+    }
+
+    #[test]
+    fn advances_require_contiguous_indices_and_preserve_existing_identity() {
+        let broadcaster = ArbTxLogBroadcaster::new();
+        let parent = B256::repeat_byte(0x11);
+        let mut block = broadcaster
+            .begin_frontier_block(parent, test_env(), CacheState::default())
+            .unwrap();
+        let tx = B256::repeat_byte(0x22);
+        assert!(
+            block
+                .advance(42, 1, tx, EvmState::default(), ArbChainContext::default())
+                .is_err()
+        );
+        assert!(
+            block
+                .advance(43, 0, tx, EvmState::default(), ArbChainContext::default())
+                .is_err()
+        );
+        let first = block
+            .advance(42, 0, tx, EvmState::default(), ArbChainContext::default())
+            .unwrap();
+        assert_eq!(
+            first,
+            execution_frontier_id(parent, 42, block.attempt_id(), B256::ZERO, 0, tx)
+        );
+        let second = block
+            .advance(42, 1, tx, EvmState::default(), ArbChainContext::default())
+            .unwrap();
+        assert_eq!(
+            second,
+            execution_frontier_id(parent, 42, block.attempt_id(), first, 1, tx)
+        );
+        let store = broadcaster.frontier_store();
+        let mut duplicate = store.get(first).unwrap();
+        duplicate.transaction_hash = B256::ZERO;
+        assert!(store.insert(duplicate).is_err());
+        assert_eq!(store.get(first).unwrap().transaction_hash, tx);
+        assert!(
+            block
+                .advance(42, 1, tx, EvmState::default(), ArbChainContext::default())
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn failed_attempt_drop_revokes_handles_but_cannot_revoke_a_newer_attempt() {
+        let stream = ArbTxLogBroadcaster::new();
+        let store = stream.frontier_store();
+        let parent = B256::repeat_byte(0x11);
+        let mut block = stream
+            .begin_frontier_block(parent, test_env(), CacheState::default())
+            .unwrap();
+        let id = block
+            .advance(
+                42,
+                0,
+                B256::ZERO,
+                EvmState::default(),
+                ArbChainContext::default(),
+            )
+            .unwrap();
+        let held = store.get(id).unwrap();
+        drop(block);
+        assert!(!store.is_current(&held));
+
+        let old = stream
+            .begin_frontier_block(parent, test_env(), CacheState::default())
+            .unwrap();
+        let mut new = stream
+            .begin_frontier_block(parent, test_env(), CacheState::default())
+            .unwrap();
+        let id = new
+            .advance(
+                42,
+                0,
+                B256::ZERO,
+                EvmState::default(),
+                ArbChainContext::default(),
+            )
+            .unwrap();
+        drop(old);
+        assert!(store.get(id).is_some());
+        new.complete();
+        drop(new);
+        assert!(store.get(id).is_some());
     }
 }

--- a/crates/arb-reth-node/src/mev_frontier_rpc.rs
+++ b/crates/arb-reth-node/src/mev_frontier_rpc.rs
@@ -1,14 +1,19 @@
 //! Exact simulation against an in-progress ArbOS transaction frontier.
 
-use alloy_evm::{Evm as _, rpc::TryIntoTxEnv as _};
+use alloy_evm::{Evm as _, EvmEnv, rpc::TryIntoTxEnv as _};
 use alloy_primitives::{Address, B256, Bytes, Log};
-use arb_reth_engine::{ArbExecutionFrontier, ArbExecutionFrontierStore};
-use arb_reth_evm::ArbEvmConfig;
+use arb_reth_engine::{
+    ArbExecutionFrontier, ArbExecutionFrontierStore, EXECUTION_FRONTIER_ID_FORMULA,
+    EXECUTION_FRONTIER_ID_SCHEME, EXECUTION_FRONTIER_VERSION,
+};
+use arb_reth_evm::{ArbBlockEnv, ArbEvmConfig};
+use arb_revm::ArbSpecId;
 use arbitrum_alloy_rpc_types::ArbTransactionRequest;
 use jsonrpsee::{RpcModule, types::ErrorObjectOwned};
 use reth_evm::ConfigureEvm as _;
 use reth_provider::StateProviderFactory;
 use reth_revm::{State, database::StateProviderDatabase};
+use reth_storage_api::BlockHashReader;
 use revm::DatabaseCommit as _;
 use revm::context_interface::ContextTr as _;
 use serde::{Deserialize, Serialize};
@@ -19,11 +24,11 @@ const FRONTIER_UNAVAILABLE: i32 = -32_001;
 #[derive(Clone, Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ArbFrontierSimulationRequest {
-    /// Exact frontier identifier from the version-2 MEV transaction-log frame.
+    /// Exact frontier identifier from the version-3 MEV transaction-log frame.
     pub frontier_id: B256,
     /// Call or transaction to execute without committing its state changes.
     pub transaction: ArbTransactionRequest,
-    /// Enforce nonce and base-fee validation. Defaults to `false`, like `eth_simulateV1`.
+    /// Enforce ordinary transaction validation. Defaults to call-style relaxed validation.
     #[serde(default)]
     pub validation: bool,
 }
@@ -34,6 +39,10 @@ pub struct ArbFrontierSimulationRequest {
 pub struct ArbFrontierSimulationResult {
     /// Frontier that was used. The server never falls back to canonical state.
     pub frontier_id: B256,
+    pub frontier_version: u8,
+    pub parent_hash: B256,
+    pub attempt_id: B256,
+    pub validation_checks: ValidationChecks,
     /// Provisional L2 block containing the observed transaction.
     #[serde(with = "alloy_serde::quantity")]
     pub block_number: u64,
@@ -61,6 +70,29 @@ pub struct ArbFrontierSimulationResult {
     pub error: Option<String>,
 }
 
+/// Checks actually enabled for this result, not a promise of eventual inclusion/finality.
+#[derive(Clone, Debug, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ValidationChecks {
+    pub nonce: bool,
+    pub base_fee: bool,
+    pub sender_code: bool,
+    pub block_gas_limit: bool,
+    pub canonical_parent: bool,
+}
+
+fn capabilities() -> serde_json::Value {
+    serde_json::json!({
+        "frontierVersion": EXECUTION_FRONTIER_VERSION,
+        "frameVersion": EXECUTION_FRONTIER_VERSION,
+        "frameFixedBodyBytes": crate::mev_tx_logs::FIXED_BODY_LEN,
+        "frontierIdScheme": EXECUTION_FRONTIER_ID_SCHEME,
+        "frontierIdFormula": EXECUTION_FRONTIER_ID_FORMULA,
+        "strictValidation": true,
+        "canonicalParentValidation": true
+    })
+}
+
 /// Builds the custom RPC module. The method is installed only when frontier tracking is enabled.
 pub fn module<P>(
     store: ArbExecutionFrontierStore,
@@ -69,9 +101,10 @@ pub fn module<P>(
     gas_cap: u64,
 ) -> eyre::Result<RpcModule<()>>
 where
-    P: StateProviderFactory + Clone + Send + Sync + 'static,
+    P: StateProviderFactory + BlockHashReader + Clone + Send + Sync + 'static,
 {
     let mut module = RpcModule::new((store, provider, evm_config, gas_cap));
+    module.register_method("arb_frontierCapabilities", |_, _, _| capabilities())?;
     module.register_async_method("arb_simulateAtFrontier", |params, context, _| async move {
         let request: ArbFrontierSimulationRequest = params.one().map_err(|error| {
             ErrorObjectOwned::owned(
@@ -89,10 +122,11 @@ where
             )
         })?;
         let provider = provider.clone();
+        let store = store.clone();
         let evm_config = evm_config.clone();
         let gas_cap = *gas_cap;
         tokio::task::spawn_blocking(move || {
-            simulate(provider, evm_config, gas_cap, frontier, request)
+            simulate(provider, store, evm_config, gas_cap, frontier, request)
         })
         .await
         .map_err(|error| {
@@ -108,14 +142,16 @@ where
 
 fn simulate<P>(
     provider: P,
+    store: ArbExecutionFrontierStore,
     evm_config: ArbEvmConfig,
     gas_cap: u64,
     frontier: ArbExecutionFrontier,
     mut request: ArbFrontierSimulationRequest,
 ) -> Result<ArbFrontierSimulationResult, ErrorObjectOwned>
 where
-    P: StateProviderFactory,
+    P: StateProviderFactory + BlockHashReader,
 {
+    validate_anchor(&provider, &store, &frontier)?;
     let state_provider = provider
         .state_by_block_hash(frontier.parent_hash())
         .map_err(|error| {
@@ -134,23 +170,7 @@ where
     }
 
     let mut evm_env = frontier.evm_env().clone();
-    evm_env.cfg_env.disable_eip3607 = true;
-    evm_env.cfg_env.disable_block_gas_limit = true;
-    evm_env.cfg_env.tx_gas_limit_cap = Some(if gas_cap == 0 { u64::MAX } else { gas_cap });
-    if !request.validation {
-        evm_env.cfg_env.disable_nonce_check = true;
-        evm_env.cfg_env.disable_base_fee = true;
-        evm_env.block_env.inner.basefee = 0;
-    }
-    if gas_cap != 0
-        && request
-            .transaction
-            .inner
-            .gas
-            .is_none_or(|gas| gas > gas_cap)
-    {
-        request.transaction.inner.gas = Some(gas_cap);
-    }
+    let validation_checks = prepare_validation(&mut evm_env, &mut request, gas_cap)?;
     let tx: arb_reth_evm::ArbTx = request.transaction.try_into_tx_env(&evm_env).map_err(
         |error: alloy_evm::rpc::EthTxEnvError| {
             ErrorObjectOwned::owned(
@@ -170,6 +190,7 @@ where
         )
     })?;
     let gas_used_for_l1 = evm.ctx().chain.poster_gas;
+    validate_anchor(&provider, &store, &frontier)?;
     let result = execution.result;
     let (status, error) = match &result {
         revm::context::result::ExecutionResult::Success { .. } => ("success", None),
@@ -181,6 +202,10 @@ where
 
     Ok(ArbFrontierSimulationResult {
         frontier_id: frontier.frontier_id,
+        frontier_version: EXECUTION_FRONTIER_VERSION,
+        parent_hash: frontier.parent_hash(),
+        attempt_id: frontier.attempt_id(),
+        validation_checks,
         block_number: frontier.block_number,
         transaction_index: frontier.transaction_index,
         transaction_hash: frontier.transaction_hash,
@@ -192,4 +217,333 @@ where
         created_address: result.created_address(),
         error,
     })
+}
+
+fn validate_anchor<P: BlockHashReader>(
+    provider: &P,
+    store: &ArbExecutionFrontierStore,
+    frontier: &ArbExecutionFrontier,
+) -> Result<(), ErrorObjectOwned> {
+    let parent_number = frontier.block_number.checked_sub(1).ok_or_else(|| {
+        ErrorObjectOwned::owned(FRONTIER_UNAVAILABLE, "frontier has no parent", None::<()>)
+    })?;
+    let canonical_hash = provider.block_hash(parent_number).map_err(|error| {
+        ErrorObjectOwned::owned(
+            FRONTIER_UNAVAILABLE,
+            "frontier canonical parent unavailable",
+            Some(error.to_string()),
+        )
+    })?;
+    if canonical_hash != Some(frontier.parent_hash()) || !store.is_current(frontier) {
+        return Err(ErrorObjectOwned::owned(
+            FRONTIER_UNAVAILABLE,
+            "frontier parent is noncanonical or execution attempt expired",
+            None::<()>,
+        ));
+    }
+    Ok(())
+}
+
+fn prepare_validation(
+    env: &mut EvmEnv<ArbSpecId, ArbBlockEnv>,
+    request: &mut ArbFrontierSimulationRequest,
+    gas_cap: u64,
+) -> Result<ValidationChecks, ErrorObjectOwned> {
+    let strict = request.validation;
+    if strict {
+        // Protocol-delivered ArbOS types bypass normal nonce/code/env checks in ArbHandler.
+        // Never advertise strict validation for those privileged transaction types.
+        if request
+            .transaction
+            .inner
+            .transaction_type
+            .is_some_and(|kind| !matches!(kind, 0..=2 | 4))
+        {
+            return Err(ErrorObjectOwned::owned(
+                -32_602,
+                "strict simulation requires a supported user transaction type",
+                None::<()>,
+            ));
+        }
+        if request
+            .transaction
+            .inner
+            .gas
+            .is_none_or(|gas| gas == 0 || (gas_cap != 0 && gas > gas_cap))
+        {
+            return Err(ErrorObjectOwned::owned(
+                -32_602,
+                "strict simulation requires explicit nonzero gas within RPC gas cap",
+                None::<()>,
+            ));
+        }
+        // Explicitly undo inherited call-style flags; do not rely on the producer's defaults.
+        env.cfg_env.disable_balance_check = false;
+    } else {
+        env.cfg_env.tx_gas_limit_cap = Some(if gas_cap == 0 { u64::MAX } else { gas_cap });
+        env.block_env.inner.basefee = 0;
+        if gas_cap != 0
+            && request
+                .transaction
+                .inner
+                .gas
+                .is_none_or(|gas| gas > gas_cap)
+        {
+            request.transaction.inner.gas = Some(gas_cap);
+        }
+    }
+    env.cfg_env.disable_nonce_check = !strict;
+    env.cfg_env.disable_base_fee = !strict;
+    env.cfg_env.disable_eip3607 = !strict;
+    env.cfg_env.disable_block_gas_limit = !strict;
+    Ok(ValidationChecks {
+        nonce: strict,
+        base_fee: strict,
+        sender_code: strict,
+        block_gas_limit: strict,
+        canonical_parent: true,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_primitives::U256;
+    use arb_reth_engine::ArbTxLogBroadcaster;
+    use arb_revm::{ArbChainContext, ArbTransaction};
+    use revm::{
+        bytecode::Bytecode,
+        context::{CfgEnv, TxEnv},
+        database::{CacheDB, EmptyDB},
+        state::{AccountInfo, EvmState},
+    };
+    use revm_database::CacheState;
+    use std::cell::Cell;
+
+    fn env() -> EvmEnv<ArbSpecId, ArbBlockEnv> {
+        let mut env = EvmEnv::new(
+            CfgEnv::new_with_spec(ArbSpecId::ARBOS_51).with_chain_id(4663),
+            ArbBlockEnv::default(),
+        );
+        env.block_env.inner.number = U256::from(42);
+        env.block_env.inner.basefee = 10;
+        env.block_env.inner.gas_limit = 500_000;
+        env
+    }
+
+    fn request() -> ArbFrontierSimulationRequest {
+        serde_json::from_value(serde_json::json!({
+            "frontierId": B256::repeat_byte(0x11), "validation": true,
+            "transaction": {"from": Address::repeat_byte(0x11), "to": Address::repeat_byte(0x22),
+                "chainId":"0x1237", "type":"0x2", "nonce":"0x1", "gas":"0x186a0",
+                "maxFeePerGas":"0x14", "maxPriorityFeePerGas":"0x1"}
+        }))
+        .unwrap()
+    }
+
+    #[test]
+    fn strict_validation_resets_inherited_flags_and_preserves_gas_intent() {
+        let mut env = env();
+        env.cfg_env.disable_nonce_check = true;
+        env.cfg_env.disable_base_fee = true;
+        env.cfg_env.disable_eip3607 = true;
+        env.cfg_env.disable_block_gas_limit = true;
+        env.cfg_env.disable_balance_check = true;
+        env.cfg_env.tx_gas_limit_cap = Some(321_000);
+        let mut request = request();
+        let original = serde_json::to_value(&request.transaction).unwrap();
+        let checks = prepare_validation(&mut env, &mut request, 200_000).unwrap();
+        assert_eq!(
+            serde_json::to_value(checks).unwrap(),
+            serde_json::json!({
+                "nonce":true,"baseFee":true,"senderCode":true,"blockGasLimit":true,"canonicalParent":true
+            })
+        );
+        assert!(
+            !env.cfg_env.disable_nonce_check
+                && !env.cfg_env.disable_base_fee
+                && !env.cfg_env.disable_eip3607
+                && !env.cfg_env.disable_block_gas_limit
+                && !env.cfg_env.disable_balance_check
+        );
+        assert_eq!(env.block_env.inner.basefee, 10);
+        assert_eq!(env.cfg_env.tx_gas_limit_cap, Some(321_000));
+        assert_eq!(
+            serde_json::to_value(&request.transaction).unwrap(),
+            original
+        );
+        for gas in [None, Some(0), Some(200_001)] {
+            request.transaction.inner.gas = gas;
+            assert_eq!(
+                prepare_validation(&mut env, &mut request, 200_000)
+                    .unwrap_err()
+                    .code(),
+                -32602
+            );
+            assert_eq!(
+                request.transaction.inner.gas, gas,
+                "invalid intent must not be clamped"
+            );
+        }
+        request.transaction.inner.gas = Some(100_000);
+        for kind in [3, 0x64, 0x66, 0x68, 0x69, 0xff] {
+            request.transaction.inner.transaction_type = Some(kind);
+            assert!(prepare_validation(&mut env, &mut request, 200_000).is_err());
+        }
+    }
+
+    #[test]
+    fn loose_validation_is_reported_truthfully_and_keeps_call_compatibility() {
+        let mut env = env();
+        let mut request = request();
+        request.validation = false;
+        request.transaction.inner.gas = None;
+        let checks = prepare_validation(&mut env, &mut request, 200_000).unwrap();
+        assert_eq!(request.transaction.inner.gas, Some(200_000));
+        assert_eq!(env.block_env.inner.basefee, 0);
+        assert_eq!(
+            serde_json::to_value(checks).unwrap(),
+            serde_json::json!({
+                "nonce":false,"baseFee":false,"senderCode":false,"blockGasLimit":false,"canonicalParent":true
+            })
+        );
+    }
+
+    fn execute_request(
+        mut request: ArbFrontierSimulationRequest,
+        sender_code: bool,
+    ) -> Result<(), String> {
+        let mut env = env();
+        prepare_validation(&mut env, &mut request, 1_000_000).unwrap();
+        // Isolate real handler checks from RPC conversion, which itself rejects low fee caps
+        // before the EVM is reached. The production path keeps that conversion check as well.
+        let inner = request.transaction.inner;
+        let tx = arb_reth_evm::ArbTx(ArbTransaction::new(TxEnv {
+            tx_type: inner.transaction_type.unwrap(),
+            caller: inner.from.unwrap(),
+            gas_limit: inner.gas.unwrap(),
+            gas_price: inner.max_fee_per_gas.unwrap(),
+            gas_priority_fee: inner.max_priority_fee_per_gas,
+            kind: inner.to.unwrap(),
+            nonce: inner.nonce.unwrap(),
+            chain_id: inner.chain_id,
+            ..Default::default()
+        }));
+        let mut db = CacheDB::new(EmptyDB::default());
+        let mut account = AccountInfo {
+            nonce: 1,
+            balance: U256::from(1_000_000_000_000_000_000u64),
+            ..Default::default()
+        };
+        if sender_code {
+            let code = Bytecode::new_raw(Bytes::from_static(&[0x00]));
+            account.code_hash = code.hash_slow();
+            account.code = Some(code);
+        }
+        db.insert_account_info(Address::repeat_byte(0x11), account);
+        let mut evm = ArbEvmConfig::new(4663).evm_with_env(db, env);
+        evm.transact_raw(tx)
+            .map(|_| ())
+            .map_err(|error| format!("{error:?}"))
+    }
+
+    #[test]
+    fn actual_arb_evm_enforces_each_strict_check_and_relaxes_only_when_requested() {
+        assert!(execute_request(request(), false).is_ok());
+        for (case, expected) in [
+            (0, "Nonce"),
+            (1, "GasPriceLessThanBasefee"),
+            (2, "RejectCallerWithCode"),
+            (3, "CallerGasLimitMoreThanBlock"),
+        ] {
+            let mut request = request();
+            match case {
+                0 => request.transaction.inner.nonce = Some(0),
+                1 => {
+                    request.transaction.inner.max_fee_per_gas = Some(1);
+                    request.transaction.inner.max_priority_fee_per_gas = Some(0);
+                }
+                2 => {}
+                3 => request.transaction.inner.gas = Some(600_000),
+                _ => unreachable!(),
+            }
+            let error = execute_request(request.clone(), case == 2).unwrap_err();
+            assert!(error.contains(expected), "case {case}: {error}");
+            request.validation = false;
+            assert!(
+                execute_request(request, case == 2).is_ok(),
+                "relaxed case {case}"
+            );
+        }
+    }
+
+    struct CanonicalParent(Cell<Option<B256>>);
+    impl BlockHashReader for CanonicalParent {
+        fn block_hash(&self, number: u64) -> reth_provider::ProviderResult<Option<B256>> {
+            assert_eq!(number, 41);
+            Ok(self.0.get())
+        }
+        fn canonical_hashes_range(
+            &self,
+            _: u64,
+            _: u64,
+        ) -> reth_provider::ProviderResult<Vec<B256>> {
+            unreachable!("single parent lookup only")
+        }
+    }
+
+    #[test]
+    fn anchor_recheck_rejects_parent_reorg_missing_parent_and_same_parent_new_attempt() {
+        let parent = B256::repeat_byte(0x11);
+        let provider = CanonicalParent(Cell::new(Some(parent)));
+        let stream = ArbTxLogBroadcaster::new();
+        let store = stream.frontier_store();
+        let mut block = stream
+            .begin_frontier_block(parent, env(), CacheState::default())
+            .unwrap();
+        let id = block
+            .advance(
+                42,
+                0,
+                B256::repeat_byte(0x22),
+                EvmState::default(),
+                ArbChainContext::default(),
+            )
+            .unwrap();
+        let held = store.get(id).unwrap();
+        validate_anchor(&provider, &store, &held).unwrap();
+        provider.0.set(Some(B256::repeat_byte(0x33)));
+        assert_eq!(
+            validate_anchor(&provider, &store, &held)
+                .unwrap_err()
+                .code(),
+            FRONTIER_UNAVAILABLE
+        );
+        provider.0.set(None);
+        assert!(validate_anchor(&provider, &store, &held).is_err());
+        provider.0.set(Some(parent));
+        validate_anchor(&provider, &store, &held).unwrap();
+        let _next = stream
+            .begin_frontier_block(parent, env(), CacheState::default())
+            .unwrap();
+        assert_eq!(
+            validate_anchor(&provider, &store, &held)
+                .unwrap_err()
+                .code(),
+            FRONTIER_UNAVAILABLE
+        );
+    }
+
+    #[test]
+    fn capabilities_pin_wire_and_prefix_contract() {
+        assert_eq!(
+            capabilities(),
+            serde_json::json!({
+                "frontierVersion":3,"frameVersion":3,"frameFixedBodyBytes":160,
+                "frontierIdScheme":"keccak256-rhf3-prefix-v1",
+                "frontierIdFormula":"keccak256(RHF3||parentHash||blockNumberBE64||attemptId||previousFrontierId||transactionIndexBE64||transactionHash)",
+                "strictValidation":true,"canonicalParentValidation":true
+            })
+        );
+    }
 }

--- a/crates/arb-reth-node/src/mev_tx_logs.rs
+++ b/crates/arb-reth-node/src/mev_tx_logs.rs
@@ -11,7 +11,9 @@ use std::{
 };
 
 use alloy_primitives::B256;
-use arb_reth_engine::{ArbTxExecutionKind, ArbTxLogBroadcaster, ArbTxLogEvent};
+use arb_reth_engine::{
+    ArbTxExecutionKind, ArbTxLogBroadcaster, ArbTxLogEvent, EXECUTION_FRONTIER_VERSION,
+};
 use eyre::{Context, Result, bail};
 use tokio::{
     io::AsyncWriteExt,
@@ -140,8 +142,8 @@ async fn stream_client(mut stream: UnixStream, mut events: broadcast::Receiver<A
 }
 
 /// Version of the binary frame format documented in `docs/mev-tx-log-ipc.md`.
-const FRAME_VERSION: u8 = 2;
-const FIXED_BODY_LEN: usize = 96;
+const FRAME_VERSION: u8 = EXECUTION_FRONTIER_VERSION;
+pub(crate) const FIXED_BODY_LEN: usize = 160;
 const MAX_LOG_TOPICS: usize = 4;
 
 fn encode_event(event: &ArbTxLogEvent) -> Result<Vec<u8>> {
@@ -178,6 +180,8 @@ fn encode_event(event: &ArbTxLogEvent) -> Result<Vec<u8>> {
     encoded.extend_from_slice(event.transaction_hash.as_slice());
     encoded.extend_from_slice(event.frontier_id.as_slice());
     encoded.extend_from_slice(&log_count.to_be_bytes());
+    encoded.extend_from_slice(event.parent_hash.as_slice());
+    encoded.extend_from_slice(event.attempt_id.as_slice());
     for log in &event.logs {
         let topics = log.data.topics();
         encoded.extend_from_slice(log.address.as_slice());
@@ -208,6 +212,8 @@ mod tests {
                 "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
             ),
             frontier_id: B256::repeat_byte(0xcc),
+            parent_hash: B256::repeat_byte(0xdd),
+            attempt_id: B256::repeat_byte(0xee),
             kind: ArbTxExecutionKind::User,
             success: true,
             gas_used: 21_000,
@@ -238,10 +244,12 @@ mod tests {
         );
         assert_eq!(&encoded[64..96], B256::repeat_byte(0xcc).as_slice());
         assert_eq!(u32::from_be_bytes(encoded[96..100].try_into().unwrap()), 1);
-        assert_eq!(&encoded[100..120], Address::repeat_byte(0x11).as_slice());
-        assert_eq!(encoded[120], 1);
-        assert_eq!(u32::from_be_bytes(encoded[121..125].try_into().unwrap()), 2);
-        assert_eq!(&encoded[157..159], [0x12, 0x34]);
+        assert_eq!(&encoded[100..132], B256::repeat_byte(0xdd).as_slice());
+        assert_eq!(&encoded[132..164], B256::repeat_byte(0xee).as_slice());
+        assert_eq!(&encoded[164..184], Address::repeat_byte(0x11).as_slice());
+        assert_eq!(encoded[184], 1);
+        assert_eq!(u32::from_be_bytes(encoded[185..189].try_into().unwrap()), 2);
+        assert_eq!(&encoded[221..223], [0x12, 0x34]);
     }
 
     #[test]
@@ -261,6 +269,8 @@ mod tests {
             transaction_index: 3,
             transaction_hash: B256::ZERO,
             frontier_id: B256::repeat_byte(0xcc),
+            parent_hash: B256::repeat_byte(0xdd),
+            attempt_id: B256::repeat_byte(0xee),
             kind: ArbTxExecutionKind::User,
             success: true,
             gas_used: 21_000,
@@ -285,6 +295,8 @@ mod tests {
             transaction_index: 3,
             transaction_hash: B256::ZERO,
             frontier_id: B256::repeat_byte(0xcc),
+            parent_hash: B256::repeat_byte(0xdd),
+            attempt_id: B256::repeat_byte(0xee),
             kind: ArbTxExecutionKind::User,
             success: true,
             gas_used: 21_000,
@@ -301,6 +313,10 @@ mod tests {
         reader.read_exact(&mut body).await.expect("read frame");
         assert_eq!(body[4..12], 42u64.to_be_bytes());
         assert_eq!(body[12..20], 3u64.to_be_bytes());
+        assert_eq!(body.len(), 160);
+        assert_eq!(body[0], 3);
+        assert_eq!(&body[96..128], B256::repeat_byte(0xdd).as_slice());
+        assert_eq!(&body[128..160], B256::repeat_byte(0xee).as_slice());
 
         drop(broadcaster);
         client.await.expect("client task exits");

--- a/docs/frontier-v3-verification-2026-09-08.md
+++ b/docs/frontier-v3-verification-2026-09-08.md
@@ -1,0 +1,83 @@
+# Frontier v3 verification receipt
+
+Code-only integration based on `6100b7c7826e185e9444e16deec1e9014ff79c7d`,
+branch `codex/frontier-v3-execution`. No deployment, node restart, configuration change, or order
+activation. Review caught stale completed handles surviving failures before guard construction;
+accepted fix invalidates at native build and production entry, with a real early-failure regression.
+
+## Linux verification
+
+An isolated source and **copied** Cargo target cache were used on the existing `rh-reth-1` Linux
+host, under `/ssd1/build/frontier-v3-test.uhGVKWkn`. Build concurrency was two low-priority jobs.
+Live node PID remained 654; the RSS guard and independent posting latch were not changed.
+No external RPC was called. Fixture tests use their own temporary databases/loopback sockets.
+
+Toolchain: `rustc 1.98.1 (48a229cea 2026-09-01)`,
+`cargo 1.98.1 (797e8a9bc 2026-08-05)`.
+The existing node build's dependency lock was copied into the test source, SHA-256
+`93fd647fe97e2218b186d77643c692d5dd220ba2f591682fa5e59431420b7f58`.
+The repository does not track a lock file; the copied lock was not committed.
+
+From the isolated source directory:
+
+```sh
+CARGO_TARGET_DIR=/ssd1/build/frontier-v3-test.uhGVKWkn/target nice -n 10 \
+  /home/alphanonce/.cargo/bin/cargo test --locked --offline --release -j 2 \
+  -p arb-reth-engine -p arb-reth-node --lib frontier
+
+CARGO_TARGET_DIR=/ssd1/build/frontier-v3-test.uhGVKWkn/target nice -n 10 \
+  /home/alphanonce/.cargo/bin/cargo test --locked --offline --release -j 2 \
+  -p arb-reth-engine -p arb-reth-node --lib
+```
+
+- Frontier filter: engine **6 passed**, node **5 passed**.
+- Complete libraries: engine **25 passed**, node **73 passed / 1 ignored** (existing manual
+  deep-buffer persistence stress test). No failures. Final cached command build 0.55s;
+  test runtimes 0.75s and 1.60s, respectively. These are test durations, not trading latency.
+- The first actual-EVM test attempt failed in its helper because RPC conversion rejected a low
+  fee before reaching the EVM. The helper now constructs the test TxEnv after production flag
+  preparation to independently exercise the handler. Production conversion/rejection was retained.
+- The early-failure test initially used `Default` for a pinned provider mock exposing only `new`;
+  corrected before the passing run. No production gate was weakened to pass either test.
+- A dependency emits a future-incompatibility warning for `proc-macro-error2 2.0.1`.
+
+Test executable SHA-256:
+
+```text
+c3160967f4737b2be19991d41617c0799323d669b20da4c871027a5975dcd2fe  arb_reth_engine-36b24c306e3fee2f
+aab504e6cbdd28310e885cd52f3021140c56c6d3435355e5c5bda5ac9086fe6b  arb_reth_node-dc7a79f93ff13c81
+```
+
+These are library test executables, not a deployable node CLI build. The copied cache's old
+`target/release/arb-reth` was renamed `arb-reth.baseline-cache-only` to prevent accidental use.
+The real `/usr/local/bin/arb-reth` binary was untouched.
+
+All seven changed source/manifest files were hashed locally and remotely after the passing run;
+the pairs were identical:
+
+```text
+1a5b58f035c77d668bb4a4a6aaeb6d910bc162b5c844c7a34c0e91145af9adba  crates/arb-reth-engine/Cargo.toml
+94299e69204e9d106b3ea149cd566e2fb60ec9d5708178629103385c0b8a98af  crates/arb-reth-engine/src/engine.rs
+dd5131abb7ec302e26c50f9c4e4c825147476afce5e1115b6b403792711001c8  crates/arb-reth-engine/src/lib.rs
+145ea196efd98734703e60db43fa7fcec99e0421beb1a142da50b62ada14f282  crates/arb-reth-engine/src/native_payload.rs
+bd35abcb1b0b247899a5d6f1c0f8b634f9364203f473087bf7ced3fa6afbce5f  crates/arb-reth-engine/src/tx_log_stream.rs
+4f0f9ff2321fe9c9d543dc92a75c54648b407e04277ea437859a3e8139c2027f  crates/arb-reth-node/src/mev_frontier_rpc.rs
+a209647a480141b3ac685502c548a6eda4f3d2106e956895a223913d405dad49  crates/arb-reth-node/src/mev_tx_logs.rs
+```
+
+## Scope of assurance
+
+Touched-file rustfmt checks and `git diff --check` passed. Workspace-wide rustfmt check has
+pre-existing differences in untouched files; those were not rewritten. CI separately runs Rust
+1.97.1 `cargo check --workspace --all-targets`, Clippy with warnings denied, and workspace tests;
+CI status belongs to the PR and is not implied by this local receipt.
+
+Tests cover exact 148-byte golden hash/field binding, contiguous order, duplicate rejection,
+same-parent rederivation, failed-attempt drop, failure before execution starts, cumulative state
+retention, expiry, v3 binary offsets/socket delivery, explicit capability/result flags, strict gas
+intent, privileged-type rejection, canonical-parent recheck, and actual Arb EVM strict/relaxed
+nonce/base-fee/sender-code/block-gas validation.
+
+No live frontier simulation against the deployed executor, continuous chain-root parity,
+end-to-end signed posting, or profitability qualification is established by these tests.
+Follow the rollout/rollback boundary in [the protocol](mev-tx-log-ipc.md) before deployment.

--- a/docs/mev-tx-log-ipc.md
+++ b/docs/mev-tx-log-ipc.md
@@ -31,8 +31,10 @@ The stream is best effort:
 - Events are FIFO for a connected client.
 - A slow client is disconnected once it lags the bounded producer buffer. Reconnect and recover
   from another source if loss matters.
-- Consumers should deduplicate by `(blockNumber, transactionIndex, transactionHash)` across a
-  reconnect or a producer restart.
+- Consumers must distinguish `(parentHash, blockNumber, attemptId)` execution attempts. Identical
+  transactions and indices in a re-executed block are not evidence of identical prefix state.
+  On reconnect or a changed attempt, recover a canonical anchor and wait for index zero; do not
+  splice a suffix onto a previous attempt.
 
 Binary log payloads are allocated only while a client is connected. When this feature is enabled,
 the node also retains a bounded chain of post-transaction state deltas for exact frontier
@@ -48,20 +50,24 @@ u32 frameLength
 bytes[frameLength] body
 ```
 
-Version 2 uses this body. Its fixed prefix is 96 bytes.
+Version 3 uses this body. Its fixed prefix is 160 bytes. The first 96 bytes retain the version-2
+layout (with version set to 3), followed by the parent hash and random execution-attempt identity.
+Version 2 is no longer emitted and its frontier identities are not safe prefix witnesses.
 
 | Offset | Size | Field | Meaning |
 | --- | ---: | --- | --- |
-| 0 | 1 | `version` | Always `2`. |
+| 0 | 1 | `version` | Always `3`. |
 | 1 | 1 | `kind` | `0` start-block, `1` user transaction, `2` scheduled retry. |
 | 2 | 1 | `success` | `1` for EVM success, `0` for revert or halt. |
-| 3 | 1 | `flags` | Reserved. Must be zero in version 2. |
+| 3 | 1 | `flags` | Reserved. Must be zero in version 3. |
 | 4 | 8 | `blockNumber` | Provisional L2 block number. |
 | 12 | 8 | `transactionIndex` | Index in the final block transaction order, including start-block. |
 | 20 | 8 | `gasUsed` | Final transaction gas used, including refunds. |
 | 28 | 32 | `transactionHash` | 32-byte transaction hash. |
 | 60 | 32 | `frontierId` | Exact post-transaction state accepted by `arb_simulateAtFrontier`. |
 | 92 | 4 | `logCount` | Number of log records following the fixed prefix. |
+| 96 | 32 | `parentHash` | Canonical parent used to build this provisional block. |
+| 128 | 32 | `attemptId` | Nonzero OS-random identity generated for each block-construction attempt. |
 
 Each of the `logCount` records is encoded consecutively:
 
@@ -84,13 +90,53 @@ assume a socket read aligns with a frame. Set an application maximum before allo
 16 MiB is a reasonable initial ceiling for a local consumer, while the protocol's theoretical
 maximum is `u32::MAX` bytes.
 
-Unknown `version`, nonzero version-2 `flags`, an unknown `kind`, malformed lengths, or extra bytes
+Unknown `version`, nonzero version-3 `flags`, an unknown `kind`, malformed lengths, or extra bytes
 must be treated as a protocol error. Close and reconnect rather than trying to resynchronize in the
 middle of a stream.
 
 The protocol intentionally avoids JSON, hex encoding, and a schema runtime on the hot path. Its
 only compatibility commitment is this versioned frame format. Future incompatible changes will use
 a new `version` value.
+
+### Prefix identity and discovery
+
+Each frontier commits the entire ordered transaction prefix, not merely the last transaction:
+
+```text
+frontierId = keccak256(
+    ASCII("RHF3")       // 4 bytes, no terminator
+    || parentHash      // 32 bytes
+    || blockNumber     // unsigned big-endian u64
+    || attemptId       // 32 bytes
+    || previousId      // 32 bytes; all zero for transactionIndex == 0
+    || transactionIndex // unsigned big-endian u64
+    || transactionHash // 32 bytes
+)                      // exactly 148 bytes before hashing
+```
+
+Indices must start at zero and increase by one, including ArbOS start-block, reverted transactions,
+and scheduled retries. The node refuses duplicate identities or out-of-order advancement.
+Consumers must recompute every prefix, reject gaps/zero attempt IDs/mismatches, and independently
+check the parent against their canonical anchor. The witness proves which node-local execution
+was used, not consensus finality or the correctness of an untrusted node.
+
+`arb_frontierCapabilities` takes no arguments and returns:
+
+```json
+{
+  "frontierVersion": 3,
+  "frameVersion": 3,
+  "frameFixedBodyBytes": 160,
+  "frontierIdScheme": "keccak256-rhf3-prefix-v1",
+  "frontierIdFormula": "keccak256(RHF3||parentHash||blockNumberBE64||attemptId||previousFrontierId||transactionIndexBE64||transactionHash)",
+  "strictValidation": true,
+  "canonicalParentValidation": true
+}
+```
+
+All numeric capability/version fields are JSON numbers, unlike the simulation's block/index/gas
+quantities, which are hex quantity strings. Older servers without this capability contract must
+not be used by a version-3 execution client.
 
 ## Exact frontier simulation
 
@@ -100,7 +146,7 @@ block-scoped context, including the Stylus recent-program cache. This avoids the
 `latest` is still the parent block or has already advanced past the observed transaction.
 
 The method is installed when `--mev-tx-log-ipc` is enabled and is available through the node's
-configured JSON-RPC transports. Pass the `frontierId` from the version-2 frame:
+configured JSON-RPC transports. Pass the `frontierId` from the version-3 frame:
 
 ```json
 {
@@ -127,11 +173,63 @@ Arbitrum EVM and ArbOS hooks. `gasUsed` reports compute execution gas. `gasUsedF
 zero because an RPC transaction has no sequencer poster bytes. The simulation respects the node's
 `--rpc.gascap` limit.
 
-The result contains `frontierId`, provisional `blockNumber`, `transactionIndex`,
+With `validation: true`, nonce, base-fee, EIP-3607 sender-code, block-gas-limit and balance checks
+are explicitly enabled in the actual Arb EVM configuration. Only ordinary user transaction types
+(legacy, EIP-2930, EIP-1559, EIP-7702) are admitted; privileged ArbOS transaction types bypass some
+of those checks and are rejected. Explicit nonzero `gas` is required; exceeding `--rpc.gascap`
+returns `-32602` without silently changing the transaction. A zero configured RPC cap means no
+additional RPC cap, not permission to bypass the chain's own limits. Strict mode preserves the
+chain's transaction gas-cap and ArbOS-specific fee rules. Relaxed mode retains call-style gas
+clamping for backward compatibility. No signature is verified and no transaction is submitted.
+
+Both modes verify `block_hash(blockNumber - 1) == parentHash` and that the retained frontier still
+belongs to the active execution attempt, before and after simulation. The parent need not remain
+the latest tip: this check establishes canonical ancestry at that height, not freshness/finality.
+A new payload build supersedes every older attempt, even at the same height with the same parent,
+before state-provider acquisition or message parsing can fail. Failed payload construction revokes
+its handles. A completed payload's frontier still does not
+promise later engine insertion; clients must continue enforcing their own age and canonicality gates.
+
+The result contains `frontierId`, `frontierVersion: 3`, `parentHash`, `attemptId`,
+`validationChecks`, provisional `blockNumber`, `transactionIndex`,
 `transactionHash`, `status`, `returnData`, `gasUsed`, `gasUsedForL1`, `logs`, and an optional
 `createdAddress` or halt `error`.
 
+For strict simulation `validationChecks` is
+`{"nonce":true,"baseFee":true,"senderCode":true,"blockGasLimit":true,"canonicalParent":true}`.
+For relaxed simulation the first four fields are false, while `canonicalParent` remains true.
+These describe enabled checks, not a profitability or eventual-inclusion guarantee. Compute-only
+simulation still omits the poster-byte L1 fee; execution clients must bound that fee separately.
+
 Frontiers are memory-only and the most recent 1,024 are retained. Error `-32001` means the exact
-frontier expired, was never observed by this process, or its parent state is no longer available.
+frontier expired, was never observed by this process, its attempt failed/was superseded, or its
+parent is unavailable/noncanonical. Error `-32602` denotes invalid intent, `-32000` an EVM
+validation/execution error, and `-32603` a failed simulation worker. EVM revert/halt returns a
+normal result with the corresponding status, not a success authorization.
 The server never falls back to `latest` or another state. Clients should treat that error as a
 miss and avoid using a result from a different state.
+
+## Rollout and rollback boundary
+
+This is a breaking local wire upgrade, not a switch to enable trading. A version-2 Go MEV consumer
+must be upgraded or disabled before a v3 node is restarted. The ordinary JSON-RPC methods and
+canonical block subscriptions are unchanged. Do not infer posting state from a unit named `shadow`:
+the observed `rh-reth-1` Go `robinhood-arb-shadow.service` was armed during the implementation audit.
+
+Before a separately authorized deployment, record the node binary SHA-256, unit/config revision,
+chain/genesis, current head, all MEV consumer versions, and the actual posting owner. Save the exact
+old binary and config for rollback; do not assume an untracked build directory contains a backup.
+Build in an isolated directory with bounded CPU/memory. `arb-reth-rssguard.service` was active on
+the observed host and may stop the node under memory pressure; do not disable the guard to make a
+build succeed. The writer's independent post latch must also remain effective.
+
+Deploy with all writers disabled, then verify v3 capabilities, frame-prefix continuity, strict
+simulation, canonical parent/chain/root parity, and the intended single-writer ownership. Live
+receipt/profitability qualification and latency gates remain separate. A failure requires stopping
+the new consumer first, restoring the saved node binary/config and compatible consumer, and
+rechecking chain health. Restoring a v2 binary must leave any v3-only Rust writer blocked; it must
+not silently downgrade to unsafe v2 frontier IDs. Re-enabling Go is a separate, verified writer
+handoff, never an automatic rollback side effect.
+
+No node restart, binary replacement, configuration change, or order activation is part of the
+code-only frontier-v3 implementation and tests.


### PR DESCRIPTION
## Why

A frontier handle used for execution must identify the complete provisional transaction prefix,
not only parent/block/index/last transaction. V2 could alias re-executions with different preceding
transactions. Also, `validation: true` previously still disabled sender-code and block-gas checks.

## Change

- Wire **v3**, fixed body **160 bytes**: preserve the old 96-byte layout and append `parentHash`
  and nonzero OS-random `attemptId` before logs.
- Prefix ID is Keccak over exactly 148 bytes:
  `RHF3 || parentHash || blockBE64 || attemptId || previousId || indexBE64 || transactionHash`.
  Index zero uses zero previous ID; subsequent indices must be contiguous. Duplicate IDs cannot
  overwrite retained state. New attempts revoke old handles even for identical parent/transactions.
- Failed payload construction revokes its handles. Review additionally found that failure could
  happen before the per-block guard existed: now revocation happens at native build entry before
  provider acquisition, and at production entry before message parsing/pre-execution. The new
  regression exercises actual early production failure after a completed prior attempt.
- Add `arb_frontierCapabilities`, identity fields and explicit `validationChecks` in simulation.
  Strict mode resets nonce/base-fee/EIP-3607/block-gas flags, enforces balance checks, rejects
  protocol/custom transaction types and missing/zero/over-cap gas without clamping intent.
  Both modes check canonical parent and active attempt before and after simulation.

## Scope and rollout

**No merge, deployment, restart, configuration change, or order activation in this PR.** This is
a node integration prerequisite, not evidence that the Rust trading system is production-ready.

V3 breaks v2 Go MEV consumers. The observed `rh-reth-1` unit named
`robinhood-arb-shadow.service` was actually armed; disable or upgrade incompatible consumers and
verify the real writer before a separately authorized deployment. Save and hash the exact old
binary/config; keep the independent post latch and active `arb-reth-rssguard.service` effective.
Build with bounded resources. Rollback must stop the new consumer, restore compatible node/config,
and leave the v3 Rust writer blocked; it must not automatically re-arm Go. See the updated
`docs/mev-tx-log-ipc.md` for protocol, error, and rollout contracts.

Canonical parent checks and prefix witnesses are not finality or inclusion promises. RPC simulation
does not verify a signature, submit a transaction, or account for poster-byte L1 fees. Consumer
age, fee/profit, nonce ownership, live parity and single-writer handoff remain required.

## Verification

- Linux optimized full library tests: **25 engine passed; 73 node passed, 1 existing manual stress
  test ignored**, zero failures. Exact command:
  `cargo test --locked --offline --release -j 2 -p arb-reth-engine -p arb-reth-node --lib`.
- Separate frontier filter: engine 6/6, node 5/5, including actual Arb EVM checks and entry failure.
- Touched-file rustfmt and `git diff --check` pass. Untouched workspace rustfmt differences remain.
- Full receipt, toolchain/lock/test-binary hashes and identical local/remote source hashes:
  `docs/frontier-v3-verification-2026-09-08.md`.
- CI separately runs full-workspace check/clippy/tests on Rust 1.97.1. Local tests used the existing
  Linux host's Rust 1.98.1 in an isolated source/cache copy, no external RPC or services changed.
  Library tests compiled the node library; this is not a new deployable node CLI binary receipt.
- Upstream CI currently reports **`action_required` with no jobs run** for this fork PR:
  https://github.com/nuntax/arbitrum-reth/actions/runs/34228024438. Maintainer action is needed;
  this is not a CI pass. GitGuardian Security Checks passed.
